### PR TITLE
Added Route class for preparing 

### DIFF
--- a/spring-amqp-core/src/main/java/org/springframework/amqp/core/Binding.java
+++ b/spring-amqp-core/src/main/java/org/springframework/amqp/core/Binding.java
@@ -27,53 +27,43 @@ import java.util.Map;
  * @author Mark Fisher
  * @see AmqpAdmin
  */
-public class Binding {
+public class Binding extends Route {
 
-	private String queue;
+	private Queue queue;
 
-	private String exchange;
-
-	private String routingKey;
 
 	private Map<String, Object> arguments;
-
-
 	public Binding(Queue queue, FanoutExchange exchange) {
-		this.queue = queue.getName();
-		this.exchange = exchange.getName();
-		this.routingKey = "";
+		this(queue, (Exchange) exchange, "");
 	}
-
 	public Binding(Queue queue, HeadersExchange exchange, Map<String, Object> arguments) {
-		this.queue = queue.getName();
-		this.exchange = exchange.getName();
-		this.routingKey = "";
+		this(queue, (Exchange) exchange, "");
 		this.arguments = arguments;
 	}
 
+	public Binding(Queue queue, Exchange exchange, String routingKey) {
+		super(exchange, routingKey);
+		this.queue = queue;	
+	}
+
+	public Binding(Queue queue, Route route) {
+		super(route);	
+		this.queue = queue;
+	}
 	public Binding(Queue queue, DirectExchange exchange, String routingKey) {
-		this.queue = queue.getName();
-		this.exchange = exchange.getName();
-		this.routingKey = routingKey;
+		this(queue, (Exchange) exchange, routingKey);
 	}
 
 	public Binding(Queue queue, TopicExchange exchange, String routingKey) {
-		this.queue = queue.getName();
-		this.exchange = exchange.getName();
-		this.routingKey = routingKey;
+		this(queue, (Exchange) exchange, routingKey);
 	}
 
-
-	public String getQueue() {
+	public Queue getQueue() {
 		return this.queue;
 	}
 
-	public String getExchange() {
-		return this.exchange;
-	}
-
-	public String getRoutingKey() {
-		return this.routingKey;
+	public Route getRoute() {
+		return (Route) this;
 	}
 
 	public Map<String, Object> getArguments() {

--- a/spring-amqp-core/src/main/java/org/springframework/amqp/core/Route.java
+++ b/spring-amqp-core/src/main/java/org/springframework/amqp/core/Route.java
@@ -1,0 +1,44 @@
+package org.springframework.amqp.core;
+
+import org.springframework.amqp.core.Exchange;
+
+/**
+ * User: Benjamin Bennett benjamin.j.bennett@boeing.com
+ * Date: Nov 21, 2010
+ * Time: 8:35:07 PM
+ */
+public class Route {
+
+	private Exchange exchange;
+
+	private String routingKey;
+
+	public Route(Route route){
+		this.exchange = route.getExchange();
+		this.routingKey = route.getRoutingKey();
+	}
+	public Route(Exchange exchange, String routingKey) {
+		this.exchange = exchange;
+		this.routingKey = routingKey;
+	}
+
+	public Exchange getExchange() {
+		return exchange;
+	}
+
+	public void setExchange(Exchange exchange) {
+		this.exchange = exchange;
+	}
+
+	public String getExchangeName() {
+		return this.getExchange().getName();
+	}
+
+	public String getRoutingKey() {
+		return routingKey;
+	}
+
+	public void setRoutingKey(String routingKey) {
+		this.routingKey = routingKey;
+	}
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -259,10 +259,10 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, SmartLif
 	private void declareBindings(final Channel channel, final Binding... bindings) throws IOException {
 		for (Binding binding : bindings) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("Binding queue [" + binding.getQueue() + "] to exchange [" +
+				logger.debug("Binding queue [" + binding.getQueue().getName() + "] to exchange [" +
 						binding.getExchange() + "] with routing key [" + binding.getRoutingKey() + "]");
 			}
-			channel.queueBind(binding.getQueue(), binding.getExchange(),
+			channel.queueBind(binding.getQueue().getName(), binding.getExchange().getName(),
 					binding.getRoutingKey(), binding.getArguments());
 		}
 	}


### PR DESCRIPTION
Just added route class, to reduce duplication of code and prepare spring-integration-amqp . Also inspired by the rabbitmq describing routes as entity. 
Basically I added route and binding elements to the spring-integration-amqp schema. 
A route is a generic class to allow reuse in other binding elements and outbound channel adapters. 
So it becomes 

<amqp:route exchange="si.test.exchange" id="my.route.id" routing-key="inbound.from.si"/>

It can be referenced in both a  <amqp:binding > element or amqp:outbound-channel-adapter 
Examples:
    <amqp:binding queue="inbound.from.si.queue" route="my.route.id"/>
And also 
    <amqp:outbound-channel-adapter  route-ref="my.route.id" channel="toRabbit"  amqp-template="amqpTemplate"/>

I also made changes to spring-integration-amqp that it so you can reference queue, exchanges  , route and binding elements from the outbound-channel-adapter and inbound-channel adapter. 
