### PR TITLE
AMQP-195 Update AMQP Client to 2.7.1

### DIFF
--- a/spring-amqp-parent/pom.xml
+++ b/spring-amqp-parent/pom.xml
@@ -20,7 +20,7 @@
 		<org.mockito.version>1.8.4</org.mockito.version>
 		<org.codehaus.jackson.version>1.4.3</org.codehaus.jackson.version>
 		<org.erlang.otp.version>1.5.3</org.erlang.otp.version>
-		<com.rabbitmq.version>2.5.0</com.rabbitmq.version>
+		<com.rabbitmq.version>2.7.1</com.rabbitmq.version>
 		<org.springframework.version>3.0.5.RELEASE</org.springframework.version>
 	</properties>
 	<licenses>

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
@@ -29,7 +29,7 @@ import org.springframework.util.CollectionUtils;
 
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Envelope;
-import com.rabbitmq.client.impl.LongString;
+import com.rabbitmq.client.LongString;
 
 /**
  * Default implementation of the {@link MessagePropertiesConverter} strategy.

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/MulticastMain.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/MulticastMain.java
@@ -136,7 +136,7 @@ public class MulticastMain {
 				channel.exchangeDeclare(exchangeName, exchangeType);
 				final Producer p = new Producer(channel, exchangeName, id, flags, producerTxSize,
 						1000L * samplingInterval, rateLimit, minMsgSize, timeLimit, messageCount);
-				channel.setReturnListener(p);
+				channel.addReturnListener(p);
 				Thread t = new Thread(p);
 				producerThreads[i] = t;
 				t.start();


### PR DESCRIPTION
LongString moved from client.impl to client

Channel.setReturnListener changed to Channel.addReturnListener

Tested with spring-integration-amqp and amqp sample; spring-integration-amqp (tests) needs a patch to a stub channel used by a stub connection factory to use this version.

https://github.com/garyrussell/spring-integration/commit/45ac2dad5c24390390aa2fbfdf9ed5f2e710ee11
