### PR TITLE
Allow capability to set content type on message being marshalled

### DIFF
--- a/spring-amqp-core/src/main/java/org/springframework/amqp/support/converter/MarshallingMessageConverter.java
+++ b/spring-amqp-core/src/main/java/org/springframework/amqp/support/converter/MarshallingMessageConverter.java
@@ -38,14 +38,16 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Arjen Poutsma
  * @author Juergen Hoeller
+ * @author James Carr
  * @see org.springframework.amqp.rabbit.core.RabbitTemplate#convertAndSend
  * @see org.springframework.amqp.rabbit.core.RabbitTemplate#receiveAndConvert
  */
 public class MarshallingMessageConverter extends AbstractMessageConverter implements InitializingBean {
-
 	private Marshaller marshaller;
 
 	private Unmarshaller unmarshaller;
+  
+  private String contentType;
 
 
 	/**
@@ -95,6 +97,13 @@ public class MarshallingMessageConverter extends AbstractMessageConverter implem
 
 
 	/**
+	 * Set the contentType to be used by this message converter.
+	 */
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	/**
 	 * Set the {@link Marshaller} to be used by this message converter.
 	 */
 	public void setMarshaller(Marshaller marshaller) {
@@ -119,6 +128,9 @@ public class MarshallingMessageConverter extends AbstractMessageConverter implem
 	 */
 	protected Message createMessage(Object object, MessageProperties messageProperties) throws MessageConversionException {
 		try {
+      if(contentType != null){
+        messageProperties.setContentType(contentType);
+      }
 			ByteArrayOutputStream bos = new ByteArrayOutputStream();
 			StreamResult streamResult = new StreamResult(bos);
 			marshaller.marshal(object, streamResult);

--- a/spring-amqp-core/src/test/java/org/springframework/amqp/support/converter/MarshallingMessageConverterTests.java
+++ b/spring-amqp-core/src/test/java/org/springframework/amqp/support/converter/MarshallingMessageConverterTests.java
@@ -35,9 +35,9 @@ import org.springframework.oxm.XmlMappingException;
 
 /**
  * @author Mark Fisher
+ * @author James Carr
  */
 public class MarshallingMessageConverterTests {
-
 	@Test
 	public void marshal() throws Exception {
 		TestMarshaller marshaller = new TestMarshaller();
@@ -48,6 +48,29 @@ public class MarshallingMessageConverterTests {
 		assertEquals("MARSHAL TEST", response);
 	}
 
+	@Test
+	public void marshalIncludesContentType() throws Exception {
+		TestMarshaller marshaller = new TestMarshaller();
+		MarshallingMessageConverter converter = new MarshallingMessageConverter(marshaller);
+		converter.setContentType("application/xml");
+    converter.afterPropertiesSet();
+
+		Message message = converter.toMessage("marshal test", new MessageProperties());
+		
+	  assertEquals("application/xml", message.getMessageProperties().getContentType());
+  }
+
+	@Test
+	public void dontSetNullContentType() throws Exception {
+		TestMarshaller marshaller = new TestMarshaller();
+		MarshallingMessageConverter converter = new MarshallingMessageConverter(marshaller);
+    converter.afterPropertiesSet();
+    final String defaultContentType = new MessageProperties().getContentType();
+
+		Message message = converter.toMessage("marshal test", new MessageProperties());
+		
+	  assertEquals(defaultContentType, message.getMessageProperties().getContentType());
+  }
 	@Test
 	public void unmarshal() {
 		TestMarshaller marshaller = new TestMarshaller();


### PR DESCRIPTION
Commits speak for themselves. We were having some [issues](https://jira.springsource.org/browse/AMQP-222) while using oxm to produce XML messages that are eventually routed to an old JMS queue with a consumer that handles messages based on contentType. This converter was basically using application/octet-stream which was causing problems in the legacy system. This change solved our problem while allowing a degree of flexibility. 
