### PR TITLE
AMQP-207

### DIFF
--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.0.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.0.xsd
@@ -403,7 +403,6 @@
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 							An explicit routing key binding the queue to this exchange.  
-							If not provided defaults to the queue name.
 						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>


### PR DESCRIPTION
removed explicit mentioning of default exchange if key is not provided.
However, considering that no-key is still a valid optioin and would result in binding to the default exchange
we may want to consider making 'key' a required field on the directExchange binding while also stating that
if you want the default binding than you shoudl not have <binding> defined in the first place.
