### PR TITLE
AMQP-198 Document Mixed Queue Arg Types

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/QueueParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/QueueParserTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2008 the original author or authors.
- * 
+ * Copyright 2002-2012 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -91,6 +91,8 @@ public class QueueParserTests {
 		Queue queue = beanFactory.getBean("arguments", Queue.class);
 		assertNotNull(queue);
 		assertEquals("bar", queue.getArguments().get("foo"));
+		assertEquals(100L, queue.getArguments().get("x-message-ttl"));
+		assertEquals("all", queue.getArguments().get("x-ha-policy"));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserPlaceholderTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserPlaceholderTests-context.xml
@@ -10,6 +10,8 @@
 				<prop key="foo">foo</prop>
 				<prop key="true">true</prop>
 				<prop key="bar">bar</prop>
+				<prop key="ttl">100</prop>
+				<prop key="ha">all</prop>
 			</props>
 		</property>
 	</bean>
@@ -27,6 +29,10 @@
 	<rabbit:queue name="arguments">
 		<rabbit:queue-arguments>
 			<beans:entry key="foo" value="${bar}" />
+			<beans:entry key="x-message-ttl">
+				<beans:value type="java.lang.Long">${ttl}</beans:value>
+			</beans:entry>
+			<beans:entry key="x-ha-policy" value="${ha}" />
 		</rabbit:queue-arguments>
 	</rabbit:queue>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserTests-context.xml
@@ -17,6 +17,10 @@
 	<rabbit:queue name="arguments">
 		<rabbit:queue-arguments>
 			<beans:entry key="foo" value="bar" />
+			<beans:entry key="x-message-ttl">
+				<beans:value type="java.lang.Long">100</beans:value>
+			</beans:entry>
+			<beans:entry key="x-ha-policy" value="all" />
 		</rabbit:queue-arguments>
 	</rabbit:queue>
 

--- a/src/docbkx/amqp.xml
+++ b/src/docbkx/amqp.xml
@@ -157,6 +157,10 @@
       or other <emphasis>temporary</emphasis> situations. For that reason, the
       'exclusive' and 'autoDelete' properties of an auto-generated Queue would
       both be set to 'true'.</para>
+
+      <note>See the section on queues in <xref linkend="broker-configuration" />
+      for information about declaring queues using namespace support, including
+      queue arguments.</note>
     </sect2>
 
     <sect2>
@@ -799,6 +803,50 @@ Object receiveAndConvert(String queueName) throws AmqpException;]]></programlist
     context. E.g.</para>
 
     <programlisting><![CDATA[<rabbit:queue name="stocks.trade.queue"/>]]></programlisting>
+
+	<para>Queues can be configured with additional arguments, for example,
+	'x-message-ttl' or 'x-ha-policy'. Using the namespace support, they are provided in the form of
+	a Map of argument name/argument value pairs, using the
+	&lt;rabbit:queue-arguments&gt; element.</para>
+
+    <programlisting><![CDATA[<rabbit:queue name="withArguments">
+	<rabbit:queue-arguments>
+		<entry key="x-ha-policy" value="all" />
+	</rabbit:queue-arguments>
+</rabbit:queue>
+]]></programlisting>
+
+	<para>By default, the arguments are assumed to be strings. For arguments
+	of other types, the type needs to be provided.</para>
+
+	<programlisting><![CDATA[<rabbit:queue name="withArguments">
+	<rabbit:queue-arguments value-type="java.lang.Long">
+		<entry key="x-message-ttl" value="100" />
+	</rabbit:queue-arguments>
+</rabbit:queue>
+]]></programlisting>
+
+	<para>When providing arguments of mixed types, the type is provided for each entry element:</para>
+
+	<programlisting><![CDATA[<rabbit:queue name="withArguments">
+	<rabbit:queue-arguments>
+		<entry key="x-message-ttl">
+			<value type="java.lang.Long">100</value>
+		</entry>
+		<entry key="x-ha-policy" value="all" />
+	</rabbit:queue-arguments>
+</rabbit:queue>
+]]></programlisting>
+
+	<para>With Spring Framework 3.2 and later, this can be declared a little more succinctly:</para>
+
+	<programlisting><![CDATA[<rabbit:queue name="withArguments">
+	<rabbit:queue-arguments>
+		<entry key="x-message-ttl" value="100" value-type="java.lang.Long" />
+		<entry key="x-ha-policy" value="all" />
+	</rabbit:queue-arguments>
+</rabbit:queue>
+]]></programlisting>
 
     <para>To see how to use Java to configure the AMQP infrastructure, look at
     the Stock sample application, where there is the <code>@Configuration</code>


### PR DESCRIPTION
Need to declare the type when setting non-string arguments,
such as x-message-ttl.

Add test showing how to configure a map of mixed types.
