### PR TITLE
AMQP-250 Template reply-queue Could Not be Anon. Backport

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2010-2012 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -24,8 +24,6 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * @author Dave Syer
@@ -143,7 +141,7 @@ class TemplateParser extends AbstractSingleBeanDefinitionParser {
 					"connectionFactory",
 					new RuntimeBeanReference(element.getAttribute(CONNECTION_FACTORY_ATTRIBUTE)));
 		}
-		replyContainer.getPropertyValues().add("queues", element.getAttribute(REPLY_QUEUE_ATTRIBUTE));
+		replyContainer.getPropertyValues().add("queues", new RuntimeBeanReference(element.getAttribute(REPLY_QUEUE_ATTRIBUTE)));
 		return replyContainer;
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2010-2011 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -31,10 +31,10 @@ import org.springframework.beans.factory.xml.XmlBeanFactory;
 import org.springframework.core.io.ClassPathResource;
 
 /**
- * 
+ *
  * @author Dave Syer
  * @author Gary Russell
- * 
+ *
  */
 public final class TemplateParserTests {
 
@@ -65,14 +65,14 @@ public final class TemplateParserTests {
 		assertEquals(Boolean.TRUE, dfa.getPropertyValue("immediate"));
 		assertNotNull(dfa.getPropertyValue("returnCallback"));
 		assertNotNull(dfa.getPropertyValue("confirmCallback"));
-	}	
-	
+	}
+
 	@Test
 	public void testKitchenSink() throws Exception {
 		RabbitTemplate template = beanFactory.getBean("kitchenSink", RabbitTemplate.class);
 		assertNotNull(template);
 		assertTrue(template.getMessageConverter() instanceof SerializerMessageConverter);
-	}	
+	}
 
 	@Test
 	public void testWithReplyQ() throws Exception {
@@ -87,6 +87,10 @@ public final class TemplateParserTests {
 		assertNotNull(container);
 		dfa = new DirectFieldAccessor(container);
 		assertSame(template, dfa.getPropertyValue("messageListener"));
+		SimpleMessageListenerContainer messageListenerContainer = beanFactory.getBean(SimpleMessageListenerContainer.class);
+		dfa = new DirectFieldAccessor(messageListenerContainer);
+		String[] queueNames = (String[]) dfa.getPropertyValue("queueNames");
+		assertEquals(queueBean.getName(), queueNames[0]);
 	}
 
 }

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
@@ -13,11 +13,11 @@
 
 	<bean id="converter" class="org.springframework.amqp.support.converter.SerializerMessageConverter"/>
 
-	<rabbit:template id="withReplyQ" connection-factory="connectionFactory" reply-queue="reply.queue">
+	<rabbit:template id="withReplyQ" connection-factory="connectionFactory" reply-queue="replyQId">
 		<rabbit:reply-listener />
 	</rabbit:template>
 
-	<rabbit:queue name="reply.queue" queue-arguments="args" />
+	<rabbit:queue id="replyQId" name="reply.queue" queue-arguments="args" />
 
 	<rabbit:queue-arguments id="args">
 		<entry key="foo" value="bar" />


### PR DESCRIPTION
Backport to 1.1.x

If the reply queue was defined with an id (rather than name)
attribute, the template's reply container listened on
the wrong queue name.

The template parser set the container's queues attribute
to the reply-queue attribute value, instead of a
RuntimeBeanReference to a bean of that name.

When a <queue name="foo"/> was used, it worked because
the Queue that Spring created during property assignment
had the same name and all was fine (the container uses
the queue name).

Changed the parser to correctly use a bean reference instead.
