### PR TITLE
AMQP-190 Memory Leak With Tx and RabbitTemplate

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2010 the original author or authors.
- * 
+ * Copyright 2002-2012 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -26,13 +26,14 @@ import com.rabbitmq.client.Channel;
 /**
  * Helper class for managing a Spring based Rabbit {@link org.springframework.amqp.rabbit.connection.ConnectionFactory},
  * in particular for obtaining transactional Rabbit resources for a given ConnectionFactory.
- * 
+ *
  * <p>
  * Mainly for internal use within the framework. Used by {@link org.springframework.amqp.rabbit.core.RabbitTemplate} as
  * well as {@link org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer}.
- * 
+ *
  * @author Mark Fisher
  * @author Dave Syer
+ * @author Gary Russell
  */
 public class ConnectionFactoryUtils {
 
@@ -161,7 +162,7 @@ public class ConnectionFactoryUtils {
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	public static void registerDeliveryTag(ConnectionFactory connectionFactory, Channel channel, Long tag)
 			throws IOException {
@@ -237,10 +238,12 @@ public class ConnectionFactoryUtils {
 			this.transacted = transacted;
 		}
 
+		@Override
 		protected boolean shouldReleaseBeforeCompletion() {
 			return !this.transacted;
 		}
 
+		@Override
 		protected void processResourceAfterCommit(RabbitResourceHolder resourceHolder) {
 			resourceHolder.commitAll();
 		}
@@ -250,10 +253,13 @@ public class ConnectionFactoryUtils {
 			if (status != TransactionSynchronization.STATUS_COMMITTED) {
 				resourceHolder.rollbackAll();
 			}
-			// resourceHolder.setSynchronizedWithTransaction(false);
+			if (resourceHolder.isReleaseAfterCompletion()) {
+				resourceHolder.setSynchronizedWithTransaction(false);
+			}
 			super.afterCompletion(status);
 		}
 
+		@Override
 		protected void releaseResource(RabbitResourceHolder resourceHolder, Object resourceKey) {
 			ConnectionFactoryUtils.releaseResources(resourceHolder);
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitResourceHolder.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitResourceHolder.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2010 the original author or authors.
- * 
+ * Copyright 2002-2012 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -35,13 +35,14 @@ import com.rabbitmq.client.Channel;
 /**
  * Rabbit resource holder, wrapping a RabbitMQ Connection and Channel. RabbitTransactionManager binds instances of this
  * class to the thread, for a given Rabbit ConnectionFactory.
- * 
+ *
  * <p>
  * Note: This is an SPI class, not intended to be used by applications.
- * 
+ *
  * @author Mark Fisher
  * @author Dave Syer
- * 
+ * @author Gary Russell
+ *
  * @see RabbitTransactionManager
  * @see RabbitTemplate
  */
@@ -61,6 +62,8 @@ public class RabbitResourceHolder extends ResourceHolderSupport {
 
 	private boolean transactional;
 
+	private boolean releaseAfterCompletion = true;
+
 	/**
 	 * Create a new RabbitResourceHolder that is open for resources to be added.
 	 */
@@ -70,13 +73,23 @@ public class RabbitResourceHolder extends ResourceHolderSupport {
 	/**
 	 * @param channel a channel to add
 	 */
-	public RabbitResourceHolder(Channel channel) {
+	public RabbitResourceHolder(Channel channel, boolean releaseAfterCompletion) {
 		this();
 		addChannel(channel);
+		this.releaseAfterCompletion = releaseAfterCompletion;
 	}
 
 	public final boolean isFrozen() {
 		return this.frozen;
+	}
+
+	/**
+	 * Whether the resources should be released after transaction completion.
+	 * Default true. Listener containers set to false because the listener continues
+	 * to use the channel.
+	 */
+	public boolean isReleaseAfterCompletion() {
+		return releaseAfterCompletion;
 	}
 
 	public final void addConnection(Connection connection) {


### PR DESCRIPTION
When the RabbitTemplate is invoked with an existing transaction,
the channel is bound to the thread, and

  ConnectionFactoryUtils.releaseResources(resourceHolder);

is called after processing. There was a commented-out line
in ConnectionFactoryUtils.RabbitResourceSynchronization.afterCompletion()
that would have reset the synchronized state so that
releaseResouces() would "close" the chanel/connection (return
them to the caching factory).

Being commented out, the channel was never removed, and each
transactional template call grabbed a new channel.

However, uncommenting causes issues with the listener container
because it continues to use the channel, so it must not
be closed (made available for reuse).

Added code to reset synch, by default, but not for the listener.

The listener sets a boolean releaseAfterCompletion in the
ResourceHolder to false so that the channel remains and
is not closed (logically or otherwise).
