### PR TITLE
AMQP-262 ConcurrentExecutionException

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -541,7 +541,9 @@ public class PublisherCallbackChannelImpl implements PublisherCallbackChannel, C
 	public void addPendingConfirm(Listener listener, long seq, PendingConfirm pendingConfirm) {
 		SortedMap<Long, PendingConfirm> pendingConfirmsForListener = this.pendingConfirms.get(listener);
 		Assert.notNull(pendingConfirmsForListener, "Listener not registered");
-		pendingConfirmsForListener.put(seq, pendingConfirm);
+		synchronized (this.pendingConfirms) {
+			pendingConfirmsForListener.put(seq, pendingConfirm);
+		}
 		this.listenerForSeq.put(seq, listener);
 	}
 


### PR DESCRIPTION
Pls cherry-pick to 1.1.x after merge.

When a 'multiple' ack is received, we iterate over pending acks for
each listener in order to generate a discrete ack for each.

While this is synchronized on the entire pending acks map, addition
of a new pending ack can cause a ConcurrentModificationException.

sychnronize the put(); add a test to reproduce the issue and to
show the correction fixes the problem.
