### PR TITLE
AMQP-274 Local Transaction Issues

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -71,6 +71,14 @@ public class ConnectionFactoryUtils {
 	}
 
 	/**
+	 * See registerConsumerChannel. This method is called to retrieve the
+	 * channel for this consumer.
+	 */
+	public static Channel getConsumerChannel() {
+		return consumerChannel.get();
+	}
+
+	/**
 	 * Determine whether the given RabbitMQ Channel is transactional, that is, bound to the current thread by Spring's
 	 * transaction facilities.
 	 * @param channel the RabbitMQ Channel to check

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitResourceHolder.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitResourceHolder.java
@@ -154,7 +154,14 @@ public class RabbitResourceHolder extends ResourceHolderSupport {
 	public void closeAll() {
 		for (Channel channel : this.channels) {
 			try {
-				channel.close();
+				if (channel != ConnectionFactoryUtils.getConsumerChannel()) {
+					channel.close();
+				}
+				else {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Skipping close of consumer channel:" + channel.toString());
+					}
+				}
 			} catch (Throwable ex) {
 				logger.debug("Could not close synchronized Rabbit Channel after transaction", ex);
 			}


### PR DESCRIPTION
When running a listener container with local transactions
(channelTransacted, and no external transaction manager), the
consumer's channel is bound to the thread for use by downstream
RabbitTemplates.

However, the syncronizedWithTransaction boolean was not set so
the RabbitTemplate closed the channel after its operation.

We should never close the consumer's channel.

The solution is to set the boolean when binding the resource.

In addition, when using a RabbitTransactionManager, the
RabbitResourceHolder.closeAll() method would close the consumer's
channel.

Previously, the consumer's channel was registered with a
ThreadLocal in the ConnectionFactoryUtils. This enabled
the doGetTransactionalResourceHolder method to bind the
consumer's channel.

The RabbitResourceHolder.closeAll() now examines the channels
is it closing and skips the close for the consumer's channel.

Added tests to the Local and External transaction test cases
to ensure the appropriate channel.close() calls are executed,
depending on the scenario. e.g. a local transaction with
exposeListenerChannel=false should close() the exposed channel
but not the consumer's channel.

NEEDS BACKPORT TO 1.1.x
