### PR TITLE
AMQP-283/284 Upgrade to RabbitMQ 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ subprojects { subproject ->
 		junitVersion = '4.8.2'
 		log4jVersion = '1.2.15'
 		mockitoVersion = '1.8.4'
-		rabbitmqVersion = '2.8.4'
+		rabbitmqVersion = '3.0.0'
 
 		springVersion = '3.0.7.RELEASE'
 	}

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeTypes.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeTypes.java
@@ -34,6 +34,10 @@ public abstract class ExchangeTypes {
 
 	public static final String SYSTEM = "system";
 
+	/**
+	 * @deprecated
+	 */
+	@Deprecated
 	public static final String FEDERATED = "x-federation";
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/FederatedExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/FederatedExchange.java
@@ -21,9 +21,11 @@ import java.util.Map;
 /**
  *
  * @see AmqpAdmin
+ * @deprecated RabbitMQ no longer supports 'x-federation' exchanges.
  *
  * @author Gary Russell
  */
+@Deprecated
 public class FederatedExchange extends AbstractExchange {
 
 	public static final FederatedExchange DEFAULT = new FederatedExchange("");

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/FederatedExchangeParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/FederatedExchangeParser.java
@@ -26,6 +26,7 @@ import org.w3c.dom.Element;
  * @author Gary Russell
  *
  */
+@SuppressWarnings("deprecation")
 public class FederatedExchangeParser extends AbstractExchangeParser {
 
 	private final static String BACKING_TYPE_ATTRIBUTE = "backing-type";

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -278,8 +278,16 @@ public class RabbitTemplate extends RabbitAccessor implements RabbitOperations, 
 		this.mandatory = mandatory;
 	}
 
+	/**
+	 * @deprecated - RabbitMQ no longer supports this option
+	 * when publishing messages.
+	 */
+	@Deprecated
 	public void setImmediate(boolean immediate) {
 		this.immediate = immediate;
+		if (logger.isWarnEnabled()) {
+			logger.warn("RabbitMQ 3.0.0 and above no longer supports 'immediate'.");
+		}
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -174,6 +174,12 @@ public class PublisherCallbackChannelImpl implements PublisherCallbackChannel, C
 				props, body);
 	}
 
+	public void basicPublish(String exchange, String routingKey,
+			boolean mandatory, BasicProperties props, byte[] body)
+			throws IOException {
+		this.delegate.basicPublish(exchange, routingKey, mandatory, props, body);
+	}
+
 	public DeclareOk exchangeDeclare(String exchange, String type)
 			throws IOException {
 		return this.delegate.exchangeDeclare(exchange, type);

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.2.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.2.xsd
@@ -1,0 +1,1041 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/rabbit" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:beans="http://www.springframework.org/schema/beans" targetNamespace="http://www.springframework.org/schema/rabbit"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+
+	<xsd:element name="queue">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Creates a queue for consumers to retrieve messages.  Uses an existing queue
+				with the same name if it exists on the broker, or else declares a
+				new one.  If you want to send a message use an exchange.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="queue-arguments" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						The id of the queue in case it is different than the name.  Clients can receive or listen for messages by referring to the
+						queue itself, or to its name.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="name" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						The name of the queue.  Clients can receive or listen for messages by referring to the
+						queue itself, or to its name.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-delete" use="optional" type="xsd:string" default="false">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Flag indicating that an queue will be deleted when it is no longer in use, i.e. the connection that declared it is closed. Default is false.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="exclusive" use="optional" type="xsd:string" default="false">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					Flag indicating that the queue is exclusive to this connection.  Default is false.
+				]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="durable" use="optional" type="xsd:string" default="true">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					Flag indicating that the queue is durable, meaning that it will survive broker restarts (not that the messages in it will, although they might if they are persistent).  Default is true.
+				]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="queue-arguments" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					A reference to a <queue-arguments/> element.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="java.util.Map" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="queue-arguments" type="mapType">
+		<xsd:annotation>
+			<xsd:documentation source="java:java.util.Map"><![CDATA[
+						A Map to pass to the broker when this component is declared.
+						]]></xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="direct-exchange">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+					Creates a direct exchange for producers to send messages to.  Uses an existing exchange
+					with the same name if it exists on the broker, or declares a
+					new one.  A direct exhange routes messages
+					to queues that are bound to the exchange when the routing key in the message
+					matches that in the binding exactly.  You can set up bindings here too, either with
+					explicit routing keys, or using the queue name implicitly.
+				]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="exchangeType">
+					<xsd:sequence>
+						<xsd:element name="bindings" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Groups bindings of queues to this exchange.
+								]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:choice>
+									<xsd:element name="binding" maxOccurs="unbounded" type="directBindingType">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+											Declares a binding of a queue to this exchange either with
+											an explicit routing key, or using the queue name implicitly.
+										]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:choice>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="topic-exchange">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+					Creates a topic exchange for producers to send messages to.  Uses an existing exchange
+					with the same name if it exists on the broker, or declares a
+					new one.  A topic exhange routes messages
+					to queues that are bound to the exchange when the routing key in the message
+					matches the routing pattern in the binding of the queue.
+					You can set up bindings here too.
+				]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="exchangeType">
+					<xsd:sequence>
+						<xsd:element name="bindings" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Groups bindings of queues to this exchange.
+								]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:choice>
+									<xsd:element name="binding" maxOccurs="unbounded" type="topicBindingType">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+											Declares a binding of a queue to this exchange either with
+											a routing pattern, e.g. "uk.weather.*" or "uk.#".
+										]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:choice>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="fanout-exchange">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+					Creates a fanout exchange for producers to send messages to.  Uses an existing exchange
+					with the same name if it exists on the broker, or declares a
+					new one.  A fanout exhange routes messages
+					to all queues that are bound to the exchange.  You can set up bindings here too.
+				]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="exchangeType">
+					<xsd:sequence>
+						<xsd:element name="bindings" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Groups bindings of queues to this exchange.
+								]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:choice>
+									<xsd:element name="binding" maxOccurs="unbounded" type="bindingType">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+												Binds a queue to this exchange.  All messages sent to this exchange will be
+												placed on this queue by the broker.
+											]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:choice>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="headers-exchange">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+					Creates a headers exchange for producers to send messages to.  Uses an existing exchange
+					with the same name if it exists on the broker, or declares a
+					new one.  A headers exhange routes messages
+					to all queues where a message header matches that specified in the binding of the queue.
+					You can set up bindings here too.
+				]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="exchangeType">
+					<xsd:sequence>
+						<xsd:element name="bindings" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Groups bindings of queues to this exchange.
+								]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:choice>
+									<xsd:element name="binding" maxOccurs="unbounded" type="headersBindingType">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+												Binds a queue to this exchange.  Messages sent to this exchange will be
+												placed on this queue by the broker if they contain a header that matches
+												this binding (key-value pair).
+											]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:choice>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="federated-exchange">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+					DEPRECATED - RabbitMQ no longer supports 'x-federation' exchanges; exhange federation
+					is now dynamic.
+					Creates a federated exchange for producers to send messages to.  Uses an existing exchange
+					with the same name if it exists on the broker, or declares a
+					new one.  A federated exchange uses a backing exchange of type defined by
+					the backing-type attribute. It connects to a set of upstream exchanges as
+					defined by the upstream-set. The bindings elements must match the bindings
+					for the backing exchange.
+				]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="exchangeType">
+					<xsd:sequence>
+						<xsd:choice>
+							<xsd:element name="direct-bindings" minOccurs="0" maxOccurs="1">
+								<xsd:annotation>
+									<xsd:documentation><![CDATA[
+										Groups bindings of queues to this exchange.
+									]]></xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:choice>
+										<xsd:element name="binding" maxOccurs="unbounded" type="directBindingType">
+											<xsd:annotation>
+												<xsd:documentation><![CDATA[
+												Declares a binding of a queue to this exchange either with
+												an explicit routing key, or using the queue name implicitly.
+											]]></xsd:documentation>
+											</xsd:annotation>
+										</xsd:element>
+									</xsd:choice>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="topic-bindings" minOccurs="0" maxOccurs="1">
+								<xsd:annotation>
+									<xsd:documentation><![CDATA[
+										Groups bindings of queues to this exchange.
+									]]></xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:choice>
+										<xsd:element name="binding" maxOccurs="unbounded" type="topicBindingType">
+											<xsd:annotation>
+												<xsd:documentation><![CDATA[
+												Declares a binding of a queue to this exchange either with
+												a routing pattern, e.g. "uk.weather.*" or "uk.#".
+											]]></xsd:documentation>
+											</xsd:annotation>
+										</xsd:element>
+									</xsd:choice>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="fanout-bindings" minOccurs="0" maxOccurs="1">
+								<xsd:annotation>
+									<xsd:documentation><![CDATA[
+										Groups bindings of queues to this exchange.
+									]]></xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:choice>
+										<xsd:element name="binding" maxOccurs="unbounded" type="bindingType">
+											<xsd:annotation>
+												<xsd:documentation><![CDATA[
+													Binds a queue to this exchange.  All messages sent to this exchange will be
+													placed on this queue by the broker.
+												]]></xsd:documentation>
+											</xsd:annotation>
+										</xsd:element>
+									</xsd:choice>
+								</xsd:complexType>
+							</xsd:element>
+							<xsd:element name="headers-bindings" minOccurs="0" maxOccurs="1">
+								<xsd:annotation>
+									<xsd:documentation><![CDATA[
+										Groups bindings of queues to this exchange.
+									]]></xsd:documentation>
+								</xsd:annotation>
+								<xsd:complexType>
+									<xsd:choice>
+										<xsd:element name="binding" maxOccurs="unbounded" type="headersBindingType">
+											<xsd:annotation>
+												<xsd:documentation><![CDATA[
+													Binds a queue to this exchange.  Messages sent to this exchange will be
+													placed on this queue by the broker if they contain a header that matches
+													this binding (key-value pair).
+												]]></xsd:documentation>
+											</xsd:annotation>
+										</xsd:element>
+									</xsd:choice>
+								</xsd:complexType>
+						</xsd:element>
+						</xsd:choice>
+					</xsd:sequence>
+					<xsd:attribute name="backing-type" use="optional" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								The type of the exchange used as a backing exchange for the
+								federated exhange.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="upstream-set" use="optional" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								The names of the set of upstream exchanges to which this
+								federated exchange connects.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="exchangeType">
+		<xsd:sequence>
+			<xsd:element ref="exchange-arguments" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The id of the exchange bean definition in case it is different than the name.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="name" use="required" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The name of the exchange. Clients can send a message by referring to the
+					exchange itself, or to its name.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-delete" use="optional" type="xsd:string" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Flag indicating that an exchange will be deleted when no longer in use, i.e. the connection that declared it is closed. Default is false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="durable" use="optional" type="xsd:string " default="true">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Flag indicating that the exchange is durable, i.e. will survive broker restart.  Default is true.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="exchange-arguments" type="mapType">
+		<xsd:annotation>
+			<xsd:documentation source="java:java.util.Map"><![CDATA[
+				A Map to pass to the broker when this component is declared.
+			]]></xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="directBindingType">
+		<xsd:complexContent>
+			<xsd:extension base="bindingType">
+				<xsd:attribute name="key" use="optional">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+							An explicit routing key binding the queue to this exchange.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="topicBindingType">
+		<xsd:complexContent>
+			<xsd:extension base="bindingType">
+				<xsd:attribute name="pattern" use="required">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+						An explicit routing pattern binding the queue to this exchange.  In the pattern,
+						the symbol # matches one or more words and the symbol * matches any single word.
+						Typical bindings might be "uk.#" for all items in the uk, "#.weather" for all
+						weather items, or "uk.weather" for all uk weather items.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="headersBindingType">
+		<xsd:complexContent>
+			<xsd:extension base="bindingType">
+				<xsd:attribute name="key" use="required" />
+				<xsd:attribute name="value" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="bindingType">
+		<xsd:sequence>
+			<xsd:element ref="binding-arguments" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="queue" use="optional">
+			<xsd:annotation>
+				<xsd:documentation source="java:org.springframework.amqp.core.Queue"><![CDATA[
+				The bean name of the Queue to bind to this exchange.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.core.Queue" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="exchange" use="optional">
+			<xsd:annotation>
+				<xsd:documentation source="java:org.springframework.amqp.core.Exchange"><![CDATA[
+				The bean name of another exchange to bind to this exchange.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.core.Exchange" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="binding-arguments" type="mapType">
+		<xsd:annotation>
+			<xsd:documentation source="java:java.util.Map"><![CDATA[
+						A Map to pass to the broker when this component is declared.
+						]]></xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="mapType">
+		<xsd:complexContent>
+			<xsd:extension base="beans:mapType">
+				<xsd:attribute name="id" type="xsd:string" />
+				<xsd:attribute name="ref" use="optional">
+					<xsd:annotation>
+						<xsd:documentation source="java:java.util.Map"><![CDATA[
+						The bean name of the Map to pass to the broker when this component is declared.
+						]]></xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="java.util.Map" />
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="listener-container">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Each listener child element will be hosted by a container whose configuration
+	is determined by this parent element. This variant builds RabbitMQ
+	listener containers, operating against a specified ConnectionFactory.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="listenerContainerBaseType">
+					<xsd:sequence>
+						<xsd:element name="listener" type="listenerType" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+					<xsd:attribute name="connection-factory" type="xsd:string" default="rabbitConnectionFactory">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+				A reference to the org.springframework.amqp.rabbit.connection.ConnectionFactory.
+				Default referenced bean name is "rabbitConnectionFactory".
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.amqp.rabbit.connection.ConnectionFactory" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="message-converter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+				A reference to the MessageConverter strategy for converting AMQP Messages to
+				listener method arguments for any referenced 'listener' that is a POJO.
+				Default is a SimpleMessageConverter.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.amqp.support.converter.MessageConverter" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="listenerContainerBaseType">
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Optional bean id for the container.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="task-executor" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to a Spring TaskExecutor (or standard JDK 1.5 Executor) for executing
+	listener invokers. Default is a SimpleAsyncTaskExecutor, using internally managed threads.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.util.concurrent.Executor" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="error-handler" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to an ErrorHandler strategy for handling any uncaught Exceptions
+	that may occur during the execution of the MessageListener.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.util.ErrorHandler" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="acknowledge" default="auto">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The acknowledge mode: "auto", "manual", or "none".
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="auto" />
+					<xsd:enumeration value="manual" />
+					<xsd:enumeration value="none" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="transaction-manager" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to an external PlatformTransactionManager.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.transaction.PlatformTransactionManager" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="channel-transacted" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Flag to indicate that the channel should be used transactionally.
+	Cannot be 'true' if acknowledge is 'none'. Default is false.
+					]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="concurrency" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The number of concurrent consumers to start for each listener.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="prefetch" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Tells the broker how many messages to send to each consumer in a single request. Often this can be set quite high
+	to improve throughput. It should be greater than or equal to the transaction size.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="transaction-size" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Tells the container how many messages to process in a single transaction (if the channel is transactional). For
+	best results it should be less than or equal to the prefetch count.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="requeue-rejected" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Tells the container the default requeue behavior when rejecting messages. Default is 'true' meaning messages
+	will be requeued, unless the listener signals not to by throwing an AmqpRejectAndDontRequeueException. When
+	set to false, messages will never be requeued.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="phase" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The lifecycle phase within which this container should start and stop. The lower
+	the value the earlier this container will start and the later it will stop. The
+	default is Integer.MAX_VALUE meaning the container will start as late as possible
+	and stop as soon as possible.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Flag to indicate that the container should start up automatically when the enclosing context is refreshed.  Default true.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="advice-chain" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Reference to a chain of AOP advice to be applied to the listener.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="listenerType">
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The unique identifier for this listener.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="queue-names" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The queue names for this listener as a comma-separated list. Either this or queues is required.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="queues" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The queues (bean references) for this listener as a comma-separated list. Either this or queue-names is required.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The bean name of the listener object, implementing
+	the MessageListener/ChannelAwareMessageListener interface
+	or defining the specified listener method. Required.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref" />
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="method" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The name of the listener method to invoke. If not specified,
+	the target bean is supposed to implement the MessageListener
+	or ChannelAwareMessageListener interface.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="response-exchange" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The name of the default response Exchange to send response messages to.
+	This will be applied in case of a request message that does not carry
+	a "replyTo" property. Note: This only applies to a listener method with
+	a return value, for which each result object will be converted into a
+	response message.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="response-routing-key" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The routing key to send along with a response message.
+	This will be applied in case of a request message that does not carry
+	a "replyTo" property. Note: This only applies to a listener method with
+	a return value, for which each result object will be converted into a
+	response message.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="admin">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Creates a rabbit admin (org.springframework.amqp.rabbit.core.RabbitAdmin)
+	for customers to manage exchanges, queues and bindings.
+					]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Unique name for this rabbit admin used as a bean definition identifier.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-factory" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to rabbit connection factory. Either 'connection-factory' or
+	'template' attribute can be set.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.rabbit.connection.ConnectionFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:boolean">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Specifies if the queues, exchanges and bindings in the context should be automatically declared (lazily on first connection to the broker). Default value is 'true'.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="template">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Creates a rabbit template (org.springframework.amqp.rabbit.core.RabbitTemplate)
+	for convenient access to the broker.
+					]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="reply-listener" type="listenerContainerBaseType"
+					minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+	A <listener-container/> used to receive asynchronous replies on the reply-channel the
+	<listener/> child element is disallowed because the template itself is the listener.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Unique name for this rabbit template used as a bean definition identifier.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="routing-key" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Default routing key for sending messages.  Default is empty.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="exchange" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Default exchange for sending messages.  Default is empty (the default exchange).
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="queue" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Default queue for receiving messages. Default is empty (non-existent queue).
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-timeout" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Timeout for send and receive in milliseconds.  Default is 5000 (5 seconds).
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel-transacted" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Flag to indicate that the channel should be used transactionally.  Default is false.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="encoding" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Encoding to use for packing and unpacking MessagePoperties of type String.  Default is UTF-8.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="message-converter" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	MessageConverter to convert between raw bytes and Java objects in the *convert* methods.  Defaults to a simple implementation that handles Strings, byte arrays and Serializable.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.support.converter.MessageConverter" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-factory" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to rabbit connection factory.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.rabbit.connection.ConnectionFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-queue" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to a <queue/> for replies; optional; if not supplied, methods expecting replies
+	will use a temporary, exclusive, auto-delete queue.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.core.Queue" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mandatory" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When 'true' sets the mandatory flag on basic.publish; only applies if
+	a 'return-callback' is provided.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="immediate" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	DEPRECATED - RabbitMQ No longer supports the immediate flag when publishing messages.
+	When 'true' sets the immediate flag on basic.publish; only applies if
+	a 'return-callback' is provided.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="return-callback" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to an implementation of RabbitTemplate.ReturnCallback - invoked if
+	a return is received for a message published with mandatory set
+	that couldn't be delivered according to the semantics of that option.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.core.RabbitTemplate.ReturnCallback" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="confirm-callback" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to an implementation of RabbitTemplate.ConfirmCallback - invoked if
+	a confirm (ack or nack) return is received for a published message.
+	Requires a 'connection-factory' that has 'publisher-confirms' set to 'true'.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.core.RabbitTemplate.ConfirmCallback" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="connection-factory">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Creates a rabbit CachingConnectionFactory with sensible defaults.
+					]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Unique name for this rabbit connection factory used as a bean definition identifier.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="host" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Hostname to connect to broker.  Default is "localhost".
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="port" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Port number to connect to broker.  Default is 5672.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="addresses" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	List of addresses; e.g. host1,host2:4567,host3 - overrides host/port if supplied.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="username" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Username to connect to broker.  Default is "guest".
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="password" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Password to connect to broker.  Default is "guest".
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="virtual-host" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Virtual host name to connect to broker.  Default is "/".  Virtual hosts are logical partitions of the broker with separate queues, excchanges, users, etc.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel-cache-size" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Cache size for channels.  More channels can be used by clients, but in excess of this number they will not be cached.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-factory" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to native rabbit connection factory, where you can specify native features like heartbeat.  The other properties (host, port) etc. on this element
+	override the ones on the native connection factory (which is used as a parent bean definition).
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="com.rabbitmq.client.ConnectionFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="executor" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to an ExecutorService, or ThreadPoolTaskExecutor (as defined by a <task:executor/>
+	element). Passed to the Rabbit library when creating the connection. When not supplied, the
+	Rabbit library currently uses a fixed thread pool ExecutorService with 5 threads.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="java.util.concurrent.Executor" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="publisher-confirms" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When true, channels on connections created by this factory support publisher confirms.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="publisher-returns" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When true, channels on connections created by this factory support publisher confirms.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ExchangeParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ExchangeParserTests.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.FanoutExchange;
-import org.springframework.amqp.core.FederatedExchange;
 import org.springframework.amqp.core.HeadersExchange;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.beans.factory.xml.XmlBeanFactory;
@@ -108,9 +107,11 @@ public final class ExchangeParserTests {
 		assertEquals("bar", exchange.getArguments().get("foo"));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testFederatedDirectExchange() throws Exception {
-		FederatedExchange exchange = beanFactory.getBean("fedDirect", FederatedExchange.class);
+		org.springframework.amqp.core.FederatedExchange exchange =
+			beanFactory.getBean("fedDirect", org.springframework.amqp.core.FederatedExchange.class);
 		assertNotNull(exchange);
 		assertEquals("fedDirect", exchange.getName());
 		assertTrue(exchange.isDurable());
@@ -119,9 +120,11 @@ public final class ExchangeParserTests {
 		assertEquals("upstream-set1", exchange.getArguments().get("upstream-set"));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testFederatedTopicExchange() throws Exception {
-		FederatedExchange exchange = beanFactory.getBean("fedTopic", FederatedExchange.class);
+		org.springframework.amqp.core.FederatedExchange exchange =
+			beanFactory.getBean("fedTopic", org.springframework.amqp.core.FederatedExchange.class);
 		assertNotNull(exchange);
 		assertEquals("fedTopic", exchange.getName());
 		assertTrue(exchange.isDurable());
@@ -130,9 +133,11 @@ public final class ExchangeParserTests {
 		assertEquals("upstream-set2", exchange.getArguments().get("upstream-set"));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testFederatedFanoutExchange() throws Exception {
-		FederatedExchange exchange = beanFactory.getBean("fedFanout", FederatedExchange.class);
+		org.springframework.amqp.core.FederatedExchange exchange =
+			beanFactory.getBean("fedFanout", org.springframework.amqp.core.FederatedExchange.class);
 		assertNotNull(exchange);
 		assertEquals("fedFanout", exchange.getName());
 		assertTrue(exchange.isDurable());
@@ -141,9 +146,11 @@ public final class ExchangeParserTests {
 		assertEquals("upstream-set3", exchange.getArguments().get("upstream-set"));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testFederatedHeadersExchange() throws Exception {
-		FederatedExchange exchange = beanFactory.getBean("fedHeaders", FederatedExchange.class);
+		org.springframework.amqp.core.FederatedExchange exchange =
+			beanFactory.getBean("fedHeaders", org.springframework.amqp.core.FederatedExchange.class);
 		assertNotNull(exchange);
 		assertEquals("fedHeaders", exchange.getName());
 		assertTrue(exchange.isDurable());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
@@ -184,7 +184,6 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 			}
 		});
 		templateWithReturnsEnabled.setMandatory(true);
-		templateWithReturnsEnabled.setImmediate(true);
 		templateWithReturnsEnabled.convertAndSend(ROUTE + "junk", (Object) "message", new CorrelationData("abc"));
 		assertTrue(latch.await(1000, TimeUnit.MILLISECONDS));
 		assertEquals(1, returns.size());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/BrokerFederated.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/BrokerFederated.java
@@ -22,7 +22,6 @@ import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.TestWatchman;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
-import org.springframework.amqp.core.FederatedExchange;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.util.StringUtils;
@@ -102,6 +101,7 @@ public class BrokerFederated extends TestWatchman {
 		this.hostName = hostName;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public Statement apply(Statement base, FrameworkMethod method, Object target) {
 
@@ -121,7 +121,7 @@ public class BrokerFederated extends TestWatchman {
 				connectionFactory.setHost(hostName);
 			}
 			RabbitAdmin admin = new RabbitAdmin(connectionFactory);
-			FederatedExchange exchange = new FederatedExchange("fedDirectRuleTest");
+			org.springframework.amqp.core.FederatedExchange exchange = new org.springframework.amqp.core.FederatedExchange("fedDirectRuleTest");
 			exchange.setBackingType("direct");
 			exchange.setUpstreamSet("upstream-set");
 			admin.declareExchange(exchange);


### PR DESCRIPTION
AMQP-283 Upgrade Rabbit Client to 3.0.0.

AMQP-284 Deprecate immediate (publish) flag, Deprecate
Federated Exchanges.

Exchange Federation is no longer configured using
exchange declaration.

Federation: Pre 3.0
Configuration lives in the configuration file.
You must ensure all nodes in a cluster have the same configuration.
The broker must be restarted for changes to take effect.
Federated exchanges are of a special type, and must be declared as such by AMQP clients.

Federation: 3.0
Configuration is stored in the broker database, manipulated with rabbitmqctl or the management plugin.
All nodes in a cluster automatically have the same configuration.
Changes to federation take effect immediately.
Federated exchanges are transparent to clients; exchanges can become federated at any time.
