### PR TITLE
Fixed version of spring-rabbit in quick tour doc and upgraded dependent version of Spring to 3.1.3 to be consistent with Spring Integration dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ subprojects { subproject ->
 		mockitoVersion = '1.8.4'
 		rabbitmqVersion = '2.8.4'
 
-		springVersion = '3.0.7.RELEASE'
+		springVersion = '3.1.3.RELEASE'
 	}
 
 	eclipse {

--- a/src/reference/docbook/quick-tour.xml
+++ b/src/reference/docbook/quick-tour.xml
@@ -17,7 +17,7 @@
     <programlisting><![CDATA[<dependency>
   <groupId>org.springframework.amqp</groupId>
   <artifactId>spring-rabbit</artifactId>
-  <version>1.0.0.RELEASE</version>
+  <version>1.2.0.RELEASE</version>
 </dependency>]]></programlisting>
 
     <section>


### PR DESCRIPTION
Fixed version of spring-rabbit in quick tour doc and upgraded dependent version of Spring to 3.1.3 to be consistent with Spring Integration dependency

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
