### PR TITLE
AMQP-295 Fix Version in QuickStart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 		maven { url 'http://repo.springsource.org/plugins-release' }
 	}
 	dependencies {
-		classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.1.5'
+		classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.6'
 	}
 }
 
@@ -19,6 +19,10 @@ allprojects {
 	repositories {
 		maven { url 'http://repo.springsource.org/libs-release' }
 	}
+}
+
+ext {
+	expandPlaceholders='**/quick-tour.xml'
 }
 
 subprojects { subproject ->

--- a/src/reference/docbook/quick-tour.xml
+++ b/src/reference/docbook/quick-tour.xml
@@ -17,7 +17,7 @@
     <programlisting><![CDATA[<dependency>
   <groupId>org.springframework.amqp</groupId>
   <artifactId>spring-rabbit</artifactId>
-  <version>1.0.0.RELEASE</version>
+  <version>${version}</version>
 </dependency>]]></programlisting>
 
     <section>


### PR DESCRIPTION
The `<version/>` element in the maven dependency
stanza in the quick start was obsolete.

Use newer version of gradle docbook plugin that
now supports replacing the ${version} placeholder
in files other than index.xml.

Update build.gradle to add the quick start chapter
to the 'expandPlaceholders' property.

Change quick start chapter to use the ${version}
placeholder.

Replaces #77
