### PR TITLE
AMQP-282 Log4j Appender - Configurable Charset

### DIFF
--- a/spring-rabbit/src/test/resources/log4j-amqp.properties
+++ b/spring-rabbit/src/test/resources/log4j-amqp.properties
@@ -10,6 +10,7 @@ log4j.appender.amqp.routingKeyPattern=%X{applicationId}.%c.%p
 log4j.appender.amqp.layout=org.apache.log4j.PatternLayout
 log4j.appender.amqp.layout.ConversionPattern=%d %p %t [%c] - <%m>%n
 log4j.appender.amqp.generateId=true
+log4j.appender.amqp.charset=UTF-8
 
 log4j.category.org.springframework.amqp.rabbit.log4j=DEBUG, amqp
 


### PR DESCRIPTION
A charset is used when converting the message body
String to a byte[] to send to AMQP.

For backwards compatibility, the appender uses the
system charset by default, but now allows the charset
name to be specified in the log4j configuration...

log4j.appender.amqp.charset=UTF-8

**cherry-pick to 1.1.x**
