### PR TITLE
Spring-Remoting via AMQP

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/client/AmqpClientInterceptor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/client/AmqpClientInterceptor.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.amqp.remoting.client;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.remoting.common.Constants;
+import org.springframework.amqp.remoting.common.MethodHeaderNamingStrategy;
+import org.springframework.amqp.remoting.common.SimpleHeaderNamingStrategy;
+import org.springframework.amqp.remoting.service.AmqpServiceMessageListener;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.remoting.support.RemoteAccessor;
+
+
+/**
+ * {@link org.aopalliance.intercept.MethodInterceptor} for accessing RMI-style AMQP services.
+ * 
+ * @author David Bilge
+ * @since 13.04.2013
+ * @see AmqpServiceMessageListener
+ * @see AmqpProxyFactoryBean
+ * @see org.springframework.remoting.RemoteAccessException
+ */
+public class AmqpClientInterceptor extends RemoteAccessor implements MethodInterceptor {
+
+	private AmqpTemplate amqpTemplate;
+
+	private MethodHeaderNamingStrategy methodHeaderNamingStrategy = new SimpleHeaderNamingStrategy();
+
+	private MessageConverter messageConverter = new SimpleMessageConverter();
+
+	private String routingKey = null;
+
+	@Override
+	public Object invoke(MethodInvocation invocation) throws Throwable {
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setHeader(Constants.INVOKED_METHOD_HEADER_NAME,
+				methodHeaderNamingStrategy.generateMethodName(invocation.getMethod()));
+
+		Message m = getMessageConverter().toMessage(invocation.getArguments(), messageProperties);
+
+		Message resultMessage;
+		if (getRoutingKey() == null) {
+			// Use the template's default routing key
+			resultMessage = amqpTemplate.sendAndReceive(m);
+		} else {
+			resultMessage = amqpTemplate.sendAndReceive(getRoutingKey(), m);
+		}
+
+		Object result = getMessageConverter().fromMessage(resultMessage);
+
+		if (invocation.getMethod().getReturnType().getCanonicalName().equals(Void.class.getCanonicalName())) {
+			return null;
+		} else if (result instanceof Throwable
+				&& !invocation.getMethod().getReturnType().isAssignableFrom(result.getClass())) {
+			// TODO handle for case where exceptions that are not known to the
+			// caller are being thrown (might be nested unchecked exceptions)
+			throw (Throwable) result;
+		} else {
+			return result;
+		}
+	}
+
+	public AmqpTemplate getAmqpTemplate() {
+		return amqpTemplate;
+	}
+
+	/**
+	 * The AMQP template to be used for sending messages and receiving results. This class is using "Request/Reply" for
+	 * sending messages as described <a href=
+	 * "http://static.springsource.org/spring-amqp/reference/html/amqp.html#request-reply" >in the Spring-AMQP
+	 * documentation</a>.
+	 */
+	public void setAmqpTemplate(AmqpTemplate amqpTemplate) {
+		this.amqpTemplate = amqpTemplate;
+	}
+
+	public MessageConverter getMessageConverter() {
+		return messageConverter;
+	}
+
+	/**
+	 * Set the message converter for this remote service. Used to serialize arguments to called methods and to
+	 * deserialize their return values.
+	 * <p>
+	 * The default converter is a SimpleMessageConverter, which is able to handle byte arrays, Strings, and Serializable
+	 * Objects depending on the message content type header.
+	 * 
+	 * @see org.springframework.amqp.support.converter.SimpleMessageConverter
+	 */
+	public void setMessageConverter(MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
+	}
+
+	public MethodHeaderNamingStrategy getMethodHeaderNamingStrategy() {
+		return methodHeaderNamingStrategy;
+	}
+
+	/**
+	 * A strategy to name methods in the message header for lookup in the service. Make sure to use the same strategy on
+	 * the service side.
+	 */
+	public void setMethodHeaderNamingStrategy(MethodHeaderNamingStrategy methodHeaderNamingStrategy) {
+		this.methodHeaderNamingStrategy = methodHeaderNamingStrategy;
+	}
+
+	public String getRoutingKey() {
+		return routingKey;
+	}
+
+	/**
+	 * The routing key to send calls to the service with. Use this to route the messages to a specific queue on the
+	 * broker. If not set, the {@link AmqpTemplate}'s default routing key will be used.
+	 * <p>
+	 * This property is useful if you want to use the same AmqpTemplate to talk to multiple services.
+	 */
+	public void setRoutingKey(String routingKey) {
+		this.routingKey = routingKey;
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/client/AmqpProxyFactoryBean.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/client/AmqpProxyFactoryBean.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.amqp.remoting.client;
+
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.remoting.service.AmqpServiceMessageListener;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.remoting.rmi.RmiServiceExporter;
+
+/**
+ * {@link FactoryBean} for AMQP proxies. Exposes the proxied service for use as a bean reference, using the specified
+ * service interface. Proxies will throw Spring's unchecked RemoteAccessException on remote invocation failure.
+ * 
+ * <p>
+ * This is intended for an "RMI-style" (i.e. synchroneous) usage of the AMQP protocol. Obviously, AMQP allows for a much
+ * broader scope of execution styles, which are not the scope of the mechanism at hand.
+ * <p>
+ * Calling a method on the proxy will cause an AMQP message being sent according to the configured {@link AmqpTemplate}.
+ * This can be received and answered by an {@link AmqpServiceMessageListener}.
+ * 
+ * @author David Bilge
+ * @since 13.04.2013
+ * @see #setServiceInterface
+ * @see AmqpClientInterceptor
+ * @see RmiServiceExporter
+ * @see org.springframework.remoting.RemoteAccessException
+ */
+public class AmqpProxyFactoryBean extends AmqpClientInterceptor implements FactoryBean<Object>, BeanClassLoaderAware,
+		InitializingBean {
+
+	private Object serviceProxy;
+
+	private AmqpAdmin amqpAdmin;
+
+	@Override
+	public void afterPropertiesSet() {
+		if (getServiceInterface() == null) {
+			throw new IllegalArgumentException("Property 'serviceInterface' is required");
+		}
+		this.serviceProxy = new ProxyFactory(getServiceInterface(), this).getProxy(getBeanClassLoader());
+	}
+
+	@Override
+	public Object getObject() throws Exception {
+		return this.serviceProxy;
+	}
+
+	@Override
+	public Class<?> getObjectType() {
+		return getServiceInterface();
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return true;
+	}
+
+	public AmqpAdmin getAmqpAdmin() {
+		return amqpAdmin;
+	}
+
+	/**
+	 * The AmqpAdmin that is used for creating the service queue on the message broker
+	 */
+	public void setAmqpAdmin(AmqpAdmin amqpAdmin) {
+		this.amqpAdmin = amqpAdmin;
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/common/Constants.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/common/Constants.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.remoting.common;
+
+public interface Constants {
+	static final String INVOKED_METHOD_HEADER_NAME = "InvokedMethod";
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/common/MethodHeaderNamingStrategy.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/common/MethodHeaderNamingStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.amqp.remoting.common;
+
+import java.lang.reflect.Method;
+
+import org.springframework.amqp.remoting.client.AmqpClientInterceptor;
+import org.springframework.amqp.remoting.service.AmqpServiceMessageListener;
+
+
+/**
+ * A strategy to create a unique method identifier by which client and service can determine which method is to be
+ * called. Used in both the {@link AmqpClientInterceptor} and the {@link AmqpServiceMessageListener} and has to match in a pair
+ * of those.
+ * 
+ * <p>
+ * The method identifier is put in the message header and passed along with the serialized arguments.
+ * 
+ * @author David Bilge
+ * @since 13.04.2013
+ * 
+ */
+public interface MethodHeaderNamingStrategy {
+	String generateMethodName(Method method);
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/common/SimpleHeaderNamingStrategy.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/common/SimpleHeaderNamingStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.remoting.common;
+
+import java.lang.reflect.Method;
+
+/**
+ * Uses the parameters suggested in the {@link Method#equals(Object)} method
+ * with the omission of the declaring class: That should be unnecessary in the
+ * given context.
+ * 
+ * <p>
+ * Will create a String of the form
+ * <code>returnType + " " + name + "(" + parameterTypes + ")"</code> which has
+ * the side-effect of being human-readable.
+ * 
+ * @author David
+ * 
+ */
+public class SimpleHeaderNamingStrategy implements MethodHeaderNamingStrategy {
+
+	@Override
+	public String generateMethodName(Method method) {
+		String name = method.getName();
+		String parameterTypes = serializeParameterTypes(method.getParameterTypes());
+		String returnType = method.getReturnType().getCanonicalName();
+
+		return returnType + " " + name + "(" + parameterTypes + ")";
+	}
+
+	private String serializeParameterTypes(Class<?>[] parameterTypes) {
+		StringBuilder sb = new StringBuilder();
+
+		for (Class<?> parameterType : parameterTypes) {
+			sb.append(parameterType.getCanonicalName() + ",");
+		}
+
+		return sb.toString();
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/service/AmqpServiceMessageListener.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/service/AmqpServiceMessageListener.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.amqp.remoting.service;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.amqp.core.Address;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.remoting.client.AmqpProxyFactoryBean;
+import org.springframework.amqp.remoting.common.Constants;
+import org.springframework.amqp.remoting.common.MethodHeaderNamingStrategy;
+import org.springframework.amqp.remoting.common.SimpleHeaderNamingStrategy;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.remoting.support.RemoteExporter;
+
+/**
+ * This message listener exposes a plain java service via AMQP. Such services can be accessed via plain AMQP or via
+ * {@link AmqpProxyFactoryBean}.
+ * 
+ * To configure this message listener so that it actually receives method calls via AMQP, it needs to be put into a
+ * listener container. That could be spring-rabbit's {@link SimpleMessageConverter}, for example (see below for an
+ * example configuration).
+ * 
+ * <p>
+ * When receiving a message, a service method is called - which is determined by the
+ * {@link Constants#INVOKED_METHOD_HEADER_NAME} header. An exception thrown by the invoked method is serialized and
+ * returned to the client as is a regular method return value.
+ * 
+ * <p>
+ * This listener responds to "Request/Reply"-style messages as described <a href=
+ * "http://static.springsource.org/spring-amqp/reference/html/amqp.html#request-reply" >here</a>.
+ * 
+ * <p>
+ * You could use an (xml) configuration like this:
+ * 
+ * <pre>
+ * &lt;bean id="amqpMessageListener" class="org.springframework.amqp.remoting.service.AmqpServiceMessageListener"&gt;
+ *    &lt;property name="amqpTemplate" ref="amqpTemplate" /&gt;
+ *    &lt;property name="service" ref="xyzService" /&gt;
+ *    &lt;property name="serviceInterface" value="x.y.z.ServiceInterface" /&gt;
+ * &lt;/bean&gt;
+ * &lt;rabbit:queue name="ServiceQueue" /&gt;
+ * &lt;rabbit:listener-container&gt;
+ *   &lt;rabbit:listener ref="amqpMessageListener" queues="ServiceQueue" /&gt;
+ * &lt;/rabbit:listener-container&gt;
+ * </pre>
+ * 
+ * @author David Bilge
+ * @since 13.04.2013
+ */
+public class AmqpServiceMessageListener extends RemoteExporter implements MessageListener, InitializingBean {
+
+	private AmqpTemplate amqpTemplate;
+
+	private MethodHeaderNamingStrategy methodHeaderNamingStrategy = new SimpleHeaderNamingStrategy();
+
+	private Map<String, Method> methodCache = new HashMap<String, Method>();
+
+	private MessageConverter messageConverter = new SimpleMessageConverter();
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Method[] methods = getService().getClass().getMethods();
+		for (Method method : methods) {
+			methodCache.put(getMethodHeaderNamingStrategy().generateMethodName(method), method);
+		}
+	}
+
+	@Override
+	public void onMessage(Message message) {
+		Address replyToAddress = message.getMessageProperties().getReplyToAddress();
+
+		Map<String, Object> headers = message.getMessageProperties().getHeaders();
+		Object invokedMethodRaw = headers.get(Constants.INVOKED_METHOD_HEADER_NAME);
+		if (invokedMethodRaw == null || !(invokedMethodRaw instanceof String)) {
+			send(new RuntimeException("The 'invoked method' header is missing (expected name '"
+					+ Constants.INVOKED_METHOD_HEADER_NAME + "')"), replyToAddress);
+			return;
+		}
+
+		String invokedMethodName = (String) invokedMethodRaw;
+		Method invokedMethod = methodCache.get(invokedMethodName);
+		if (invokedMethod == null) {
+			send(new RuntimeException("The invoked method does not exist on the service (Method: '" + invokedMethodName
+					+ "')"), replyToAddress);
+			return;
+		}
+
+		Object argumentsRaw = messageConverter.fromMessage(message);
+		Object[] arguments;
+		if (argumentsRaw instanceof Object[]) {
+			arguments = (Object[]) argumentsRaw;
+		} else {
+			send(new RuntimeException("The message does not contain an argument array"), replyToAddress);
+			return;
+		}
+
+		Object retVal;
+		try {
+			retVal = invokedMethod.invoke(getService(), arguments);
+		} catch (InvocationTargetException ite) {
+			send(ite.getCause(), replyToAddress);
+			return;
+		} catch (Throwable e) {
+			send(e, replyToAddress);
+			return;
+		}
+
+		send(retVal, replyToAddress);
+	}
+
+	private void send(Object o, Address replyToAddress) {
+		Message m = messageConverter.toMessage(o, new MessageProperties());
+
+		getAmqpTemplate().send(replyToAddress.getExchangeName(), replyToAddress.getRoutingKey(), m);
+	}
+
+	public AmqpTemplate getAmqpTemplate() {
+		return amqpTemplate;
+	}
+
+	/**
+	 * The AMQP template to use for sending the return value.
+	 * 
+	 * <p>
+	 * Note that the exchange and routing key parameters on this template are ignored for these return messages. Instead
+	 * of those the respective parameters from the original message's <code>returnAddress</code> are being used.
+	 */
+	public void setAmqpTemplate(AmqpTemplate amqpTemplate) {
+		this.amqpTemplate = amqpTemplate;
+	}
+
+	public MessageConverter getMessageConverter() {
+		return messageConverter;
+	}
+
+	/**
+	 * Set the message converter for this remote service. Used to deserialize arguments to called methods and to
+	 * serialize their return values.
+	 * <p>
+	 * The default converter is a SimpleMessageConverter, which is able to handle byte arrays, Strings, and Serializable
+	 * Objects depending on the message content type header.
+	 * 
+	 * @see org.springframework.amqp.support.converter.SimpleMessageConverter
+	 */
+	public void setMessageConverter(MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
+	}
+
+	public MethodHeaderNamingStrategy getMethodHeaderNamingStrategy() {
+		return methodHeaderNamingStrategy;
+	}
+
+	/**
+	 * A strategy to name methods in the message header for lookup in the service. Make sure to use the same strategy on
+	 * the client side.
+	 */
+	public void setMethodHeaderNamingStrategy(MethodHeaderNamingStrategy methodHeaderNamingStrategy) {
+		this.methodHeaderNamingStrategy = methodHeaderNamingStrategy;
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SimpleMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SimpleMessageConverter.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2002-2013 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package org.springframework.amqp.support.converter;
@@ -28,15 +25,14 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.utils.SerializationUtils;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.remoting.rmi.CodebaseAwareObjectInputStream;
-import java.rmi.server.RMIClassLoader;
 import org.springframework.util.ClassUtils;
 
 /**
- * Implementation of {@link MessageConverter} that can work with Strings, Serializable instances,
- * or byte arrays. The {@link #toMessage(Object, MessageProperties)} method simply checks the
- * type of the provided instance while the {@link #fromMessage(Message)} method relies upon the
- * {@link MessageProperties#getContentType() content-type} of the provided Message.
- *
+ * Implementation of {@link MessageConverter} that can work with Strings, Serializable instances, or byte arrays. The
+ * {@link #toMessage(Object, MessageProperties)} method simply checks the type of the provided instance while the
+ * {@link #fromMessage(Message)} method relies upon the {@link MessageProperties#getContentType() content-type} of the
+ * provided Message.
+ * 
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  */
@@ -59,7 +55,7 @@ public class SimpleMessageConverter extends AbstractMessageConverter implements 
 	 * spaces.
 	 * <p>
 	 * Follows RMI's codebase conventions for dynamic class download.
-	 *
+	 * 
 	 * @see org.springframework.remoting.rmi.CodebaseAwareObjectInputStream
 	 * @see java.rmi.server.RMIClassLoader
 	 */
@@ -68,8 +64,8 @@ public class SimpleMessageConverter extends AbstractMessageConverter implements 
 	}
 
 	/**
-	 * Specify the default charset to use when converting to or from text-based
-	 * Message body content. If not specified, the charset will be "UTF-8".
+	 * Specify the default charset to use when converting to or from text-based Message body content. If not specified,
+	 * the charset will be "UTF-8".
 	 */
 	public void setDefaultCharset(String defaultCharset) {
 		this.defaultCharset = (defaultCharset != null) ? defaultCharset : DEFAULT_CHARSET;
@@ -90,22 +86,17 @@ public class SimpleMessageConverter extends AbstractMessageConverter implements 
 				}
 				try {
 					content = new String(message.getBody(), encoding);
+				} catch (UnsupportedEncodingException e) {
+					throw new MessageConversionException("failed to convert text-based Message content", e);
 				}
-				catch (UnsupportedEncodingException e) {
-					throw new MessageConversionException(
-							"failed to convert text-based Message content", e);
-				}
-			}
-			else if (contentType != null &&
-					contentType.equals(MessageProperties.CONTENT_TYPE_SERIALIZED_OBJECT)) {
+			} else if (contentType != null && contentType.equals(MessageProperties.CONTENT_TYPE_SERIALIZED_OBJECT)) {
 				try {
-					content = SerializationUtils.deserialize(createObjectInputStream(new ByteArrayInputStream(message.getBody()), this.codebaseUrl));
+					content = SerializationUtils.deserialize(createObjectInputStream(
+							new ByteArrayInputStream(message.getBody()), this.codebaseUrl));
 				} catch (IOException e) {
-					throw new MessageConversionException(
-							"failed to convert serialized Message content", e);
+					throw new MessageConversionException("failed to convert serialized Message content", e);
 				} catch (IllegalArgumentException e) {
-					throw new MessageConversionException(
-							"failed to convert serialized Message content", e);
+					throw new MessageConversionException("failed to convert serialized Message content", e);
 				}
 			}
 		}
@@ -118,29 +109,25 @@ public class SimpleMessageConverter extends AbstractMessageConverter implements 
 	/**
 	 * Creates an AMQP Message from the provided Object.
 	 */
-	protected Message createMessage(Object object, MessageProperties messageProperties) throws MessageConversionException {
+	protected Message createMessage(Object object, MessageProperties messageProperties)
+			throws MessageConversionException {
 		byte[] bytes = null;
 		if (object instanceof byte[]) {
 			bytes = (byte[]) object;
 			messageProperties.setContentType(MessageProperties.CONTENT_TYPE_BYTES);
-		}
-		else if (object instanceof String) {
+		} else if (object instanceof String) {
 			try {
 				bytes = ((String) object).getBytes(this.defaultCharset);
-			}
-			catch (UnsupportedEncodingException e) {
-				throw new MessageConversionException(
-						"failed to convert to Message content", e);
+			} catch (UnsupportedEncodingException e) {
+				throw new MessageConversionException("failed to convert to Message content", e);
 			}
 			messageProperties.setContentType(MessageProperties.CONTENT_TYPE_TEXT_PLAIN);
 			messageProperties.setContentEncoding(this.defaultCharset);
-		}
-		else if (object instanceof Serializable) {
+		} else if (object instanceof Serializable) {
 			try {
 				bytes = SerializationUtils.serialize(object);
 			} catch (IllegalArgumentException e) {
-				throw new MessageConversionException(
-						"failed to convert to serialized Message content", e);
+				throw new MessageConversionException("failed to convert to serialized Message content", e);
 			}
 			messageProperties.setContentType(MessageProperties.CONTENT_TYPE_SERIALIZED_OBJECT);
 		}
@@ -153,6 +140,7 @@ public class SimpleMessageConverter extends AbstractMessageConverter implements 
 	/**
 	 * Create an ObjectInputStream for the given InputStream and codebase. The default implementation creates a
 	 * CodebaseAwareObjectInputStream.
+	 * 
 	 * @param is the InputStream to read from
 	 * @param codebaseUrl the codebase URL to load classes from if not found locally (can be <code>null</code>)
 	 * @return the new ObjectInputStream instance to use


### PR DESCRIPTION
Added a means to expose and use a plain java service via amqp. This is accomplished by a MessageListener implementation on the service side that receives calls and forwards them to a service bean and a ProxyFactoryBean on the service side that allows for easy creation of those method-calling messages by simply calling a method on a proxy.
