### PR TITLE
Add constructor call to support delegate and method name

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
@@ -189,6 +189,17 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 	}
 
 	/**
+	 * Create a new {@link MessageListenerAdapter} for the given delegate while also
+	 * declaring its POJO method.
+	 * @param delegate the delegate object
+	 * @param defaultListenerMethod name of the POJO method to call upon message receipt
+	 */
+	public MessageListenerAdapter(Object delegate, String defaultListenerMethod) {
+		this(delegate);
+		setDefaultListenerMethod(defaultListenerMethod);
+	}
+
+	/**
 	 * Set a target object to delegate message listening to. Specified listener methods have to be present on this
 	 * target object.
 	 * <p>

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
@@ -47,7 +47,7 @@ public class MessageListenerAdapterTests {
 		};
 		adapter.setMessageConverter(new SimpleMessageConverter());
 	}
-
+	
 	@Test
 	public void testDefaultListenerMethod() throws Exception {
 		final AtomicBoolean called = new AtomicBoolean(false);
@@ -59,6 +59,21 @@ public class MessageListenerAdapterTests {
 			}
 		}
 		adapter.setDelegate(new Delegate());
+		adapter.onMessage(new Message("foo".getBytes(), messageProperties));
+		assertTrue(called.get());
+	}
+
+	@Test
+	public void testAlternateConstructor() throws Exception {
+		final AtomicBoolean called = new AtomicBoolean(false);
+		class Delegate {
+			@SuppressWarnings("unused")
+			public String myPojoMessageMethod(String input) {
+				called.set(true);
+				return "processed" + input;
+			}
+		}
+		adapter = new MessageListenerAdapter(new Delegate(), "myPojoMessageMethod");
 		adapter.onMessage(new Message("foo".getBytes(), messageProperties));
 		assertTrue(called.get());
 	}


### PR DESCRIPTION
When configuring Spring Rabbit with pure Java config, it's easier with
a constructor call that lets you specify the delegate and the POJO method
name at once.

``` java
    public MessageListenerAdapter(Object delegate, String defaultListenerMethod) {
        this(delegate);
        setDefaultListenerMethod(defaultListenerMethod);
    }
```

This constructor lets me setup java config like this:

``` java
    @Bean
    MessageListenerAdapter listenerAdapter() {
        return new MessageListenerAdapter(new Receiver(), "receiveMessage");
    }
```

P.S. This patch includes automated unit tests to verify the new constructor
method signature.
