### PR TITLE
AMQP-102 Verify Timeout and txSize Work Together

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -13,11 +13,35 @@
 package org.springframework.amqp.rabbit.listener;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
 import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.SingleConnectionFactory;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -26,9 +50,15 @@ import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
+
 /**
  * @author David Syer
  * @author Gunnar Hillert
+ * @author Gary Russell
  *
  */
 public class SimpleMessageListenerContainerTests {
@@ -87,6 +117,133 @@ public class SimpleMessageListenerContainerTests {
 		container.start();
 		assertEquals(1, ReflectionTestUtils.getField(container, "concurrentConsumers"));
 		singleConnectionFactory.destroy();
+	}
+
+	/*
+	 * txSize = 2; 4 messages; should get 2 acks (#2 and #4)
+	 */
+	@Test
+	public void testTxSizeAcks() throws Exception {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		Connection connection = mock(Connection.class);
+		Channel channel = mock(Channel.class);
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		when(connection.createChannel(false)).thenReturn(channel);
+		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
+		doAnswer(new Answer<Object>() {
+
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.get().handleConsumeOk("1");
+				return null;
+			}
+		}).when(channel).basicConsume(anyString(), anyBoolean(), any(Consumer.class));
+
+		final List<Message> messages = new ArrayList<Message>();
+		final CountDownLatch latch = new CountDownLatch(4);
+		final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setQueueNames("foo");
+		container.setTxSize(2);
+		container.setMessageListener(new MessageListener() {
+
+			@Override
+			public void onMessage(Message message) {
+				messages.add(message);
+				latch.countDown();
+			}
+		});
+		container.start();
+		BasicProperties props = new BasicProperties();
+		byte[] payload = "baz".getBytes();
+		Envelope envelope = new Envelope(1L, false, "foo", "bar");
+		consumer.get().handleDelivery("1", envelope, props, payload);
+		envelope = new Envelope(2L, false, "foo", "bar");
+		consumer.get().handleDelivery("1", envelope, props, payload);
+		envelope = new Envelope(3L, false, "foo", "bar");
+		consumer.get().handleDelivery("1", envelope, props, payload);
+		envelope = new Envelope(4L, false, "foo", "bar");
+		consumer.get().handleDelivery("1", envelope, props, payload);
+		assertTrue(latch.await(5, TimeUnit.SECONDS));
+		assertEquals(4, messages.size());
+		Executors.newSingleThreadExecutor().execute(new Runnable() {
+
+			@Override
+			public void run() {
+				container.stop();
+			}
+		});
+		consumer.get().handleCancelOk("1");
+		verify(channel, times(2)).basicAck(anyLong(), anyBoolean());
+		verify(channel).basicAck(2, true);
+		verify(channel).basicAck(4, true);
+	}
+
+	/*
+	 * txSize = 2; 3 messages; should get 2 acks (#2 and #3)
+	 * after timeout.
+	 */
+	@Test
+	public void testTxSizeAcksWIthShortSet() throws Exception {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		Connection connection = mock(Connection.class);
+		Channel channel = mock(Channel.class);
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		when(connection.createChannel(false)).thenReturn(channel);
+		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
+		doAnswer(new Answer<Object>() {
+
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.get().handleConsumeOk("1");
+				return null;
+			}
+		}).when(channel).basicConsume(anyString(), anyBoolean(), any(Consumer.class));
+		final CountDownLatch latch = new CountDownLatch(2);
+		doAnswer(new Answer<Object>() {
+
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				latch.countDown();
+				return null;
+			}
+		}).when(channel).basicAck(anyLong(), anyBoolean());
+
+		final List<Message> messages = new ArrayList<Message>();
+		final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setQueueNames("foo");
+		container.setTxSize(2);
+		container.setMessageListener(new MessageListener() {
+
+			@Override
+			public void onMessage(Message message) {
+				messages.add(message);
+			}
+		});
+		container.start();
+		BasicProperties props = new BasicProperties();
+		byte[] payload = "baz".getBytes();
+		Envelope envelope = new Envelope(1L, false, "foo", "bar");
+		consumer.get().handleDelivery("1", envelope, props, payload);
+		envelope = new Envelope(2L, false, "foo", "bar");
+		consumer.get().handleDelivery("1", envelope, props, payload);
+		envelope = new Envelope(3L, false, "foo", "bar");
+		consumer.get().handleDelivery("1", envelope, props, payload);
+		assertTrue(latch.await(5, TimeUnit.SECONDS));
+		assertEquals(3, messages.size());
+		Executors.newSingleThreadExecutor().execute(new Runnable() {
+
+			@Override
+			public void run() {
+				container.stop();
+			}
+		});
+		consumer.get().handleCancelOk("1");
+		verify(channel, times(2)).basicAck(anyLong(), anyBoolean());
+		verify(channel).basicAck(2, true);
+		// second set was short
+		verify(channel).basicAck(3, true);
 	}
 
 	@SuppressWarnings("serial")


### PR DESCRIPTION
Add test case to verify acks are correctly sent
according to txSize.

Add test case that the same applies if we time
out having received a partial txSize set.
