### PR TITLE
AMQP-62 Configure requestedHeartBeat Property

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2012 the original author or authors.
+ * Copyright 2010-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,11 +13,12 @@
 
 package org.springframework.amqp.rabbit.config;
 
+import org.w3c.dom.Element;
+
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.w3c.dom.Element;
 
 /**
  * @author Dave Syer
@@ -46,6 +47,8 @@ class ConnectionFactoryParser extends AbstractSingleBeanDefinitionParser {
 	private static final String PUBLISHER_CONFIRMS = "publisher-confirms";
 
 	private static final String PUBLISHER_RETURNS = "publisher-returns";
+
+	private static final String REQUESTED_HEARTBEAT = "requested-heartbeat";
 
 	@Override
 	protected Class<?> getBeanClass(Element element) {
@@ -80,6 +83,7 @@ class ConnectionFactoryParser extends AbstractSingleBeanDefinitionParser {
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, ADDRESSES);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, PUBLISHER_CONFIRMS);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, PUBLISHER_RETURNS);
+		NamespaceUtils.setValueIfAttributeDefined(builder, element, REQUESTED_HEARTBEAT, "requestedHeartBeat");
 
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -82,6 +83,10 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	public void setPort(int port) {
 		this.rabbitConnectionFactory.setPort(port);
+	}
+
+	public void setRequestedHeartBeat(int requestedHeartBeat) {
+		this.rabbitConnectionFactory.setRequestedHeartbeat(requestedHeartBeat);
 	}
 
 	public int getPort() {

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.2.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.2.xsd
@@ -1021,7 +1021,7 @@
 			<xsd:attribute name="connection-factory" type="xsd:string" use="optional">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	Reference to native rabbit connection factory, where you can specify native features like heartbeat.  The other properties (host, port) etc. on this element
+	Reference to native rabbit connection factory, where you can specify native features like client properties.  The other properties (host, port) etc. on this element
 	override the ones on the native connection factory (which is used as a parent bean definition).
 					]]></xsd:documentation>
 					<xsd:appinfo>
@@ -1056,6 +1056,13 @@
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 	When true, channels on connections created by this factory support publisher returns.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="requested-heartbeat" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Sets the requested heardbeat interval on the underlying Rabbit connection factory.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -57,6 +58,9 @@ public final class ConnectionFactoryParserTests {
 		assertNull(dfa.getPropertyValue("executorService"));
 		assertEquals(Boolean.TRUE, dfa.getPropertyValue("publisherConfirms"));
 		assertEquals(Boolean.TRUE, dfa.getPropertyValue("publisherReturns"));
+		assertEquals(123,
+				((com.rabbitmq.client.ConnectionFactory) dfa.getPropertyValue("rabbitConnectionFactory"))
+						.getRequestedHeartbeat());
 	}
 
 	@Test

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
@@ -12,7 +12,8 @@
 
 	<rabbit:connection-factory id="kitchenSink" host="foo" virtual-host="/bar"
 		channel-cache-size="10" port="6888" username="user" password="password"
-		publisher-confirms="true" publisher-returns="true"/>
+		publisher-confirms="true" publisher-returns="true"
+		requested-heartbeat="123"/>
 
 	<rabbit:connection-factory id="native" connection-factory="connectionFactory" channel-cache-size="10" />
 

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -318,6 +318,22 @@ Connection connection = connectionFactory.createConnection();]]></programlisting
     id="connectionFactory" addresses="host1:5672,host2:5672"/>]]></programlisting>
 
     <sect2>
+      <title>Configuring the Underlying Client Connection Factory</title>
+      <para>
+        The <classname>CachingConnectionFactory</classname> uses an instance of the Rabbit
+        client <classname>ConnectionFactory</classname>; a number of configuration properties
+        are passed through (<code>host, port, userName, password, requestedHeartBeat</code> for
+        example) when setting the equivalent property on the <classname>CachingConnectionFactory
+        </classname>. To set other properties (<code>clientProperties</code> for example),
+        define an instance of the rabbit factory and provide a reference to it using
+        the appropriate constructor of the <classname>CachingConnectionFactory</classname>.
+        When using the namespace as described above, provide a reference to the configured
+        factory in the <code>connection-factory</code> attribute.
+      </para>
+      <programlisting language="xml"><![CDATA[<rabbit:connection-factory
+      id="connectionFactory" connection-factory="rabbitConnectionFactory"/>]]></programlisting>
+    </sect2>
+    <sect2>
       <title>Publisher Confirms and Returns</title>
       <para>
         Confirmed and returned messages are supported by setting the

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -8,9 +8,9 @@
 		<section>
 			<title>RabbitMQ Version</title>
 			<para>
-				Spring AMQP now using RabbitMQ 3.0.x by default (but retains
+				Spring AMQP now using RabbitMQ 3.1.x by default (but retains
 				compatibility with earlier versions). Certain deprecations have
-				been added for features no longer supported by RabbitMQ 3.0.x -
+				been added for features no longer supported by RabbitMQ 3.1.x -
 				federated exchanges and the <code>immediate</code> property on
 				the <classname>RabbitTemplate</classname>.
 			</para>
@@ -62,6 +62,15 @@
 			<para>
 				Facilities are now provided for using Spring Remoting techniques, using AMQP
 				as the transport for the RPC calls. For more information see <xref linkend="remoting"/>
+			</para>
+		</section>
+		<section>
+			<title>Requested Heart Beats</title>
+			<para>
+				Several users have asked for the underlying client connection factory's <code>requestedHeartBeats</code>
+				property to be exposed on the Spring AMQP <classname>CachingConnectionFactory</classname>. This is
+				now available; previously, it was necessary to configure the AMQP client factory as
+				a separate bean and provide a reference to it in the <classname>CachingConnectionFactory</classname>.
 			</para>
 		</section>
 	</section>


### PR DESCRIPTION
Allow this property to be set on the CachingConnectionFactory, either
directly, or using the namespace.
