### PR TITLE
When java.lang.Error(e.g.OutOfMemory) occurs, threads do not abort.

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -567,6 +567,9 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				logger.error("Consumer received fatal exception during processing", ex);
 				// Fatal, but no point re-throwing, so just abort.
 				aborted = true;
+			} catch (Error e) {
+				logger.error("Consumer thread error, processing aborted.", e);
+				aborted = true;
 			} catch (Throwable t) {
 				if (logger.isDebugEnabled() || !(t instanceof AmqpConnectException)) {
 					logger.warn(


### PR DESCRIPTION
When an OutOfMemory occurs, threads do not abort.

But, it is expected that threads will be abort in this situation.

So, I just fixed this bug.
