### PR TITLE
AMQP-332 Fix Multiple Listeners with Id

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.aopalliance.aop.Advice;
 import org.junit.Before;
@@ -54,6 +55,9 @@ public class ListenerContainerParserTests {
 
 	@Before
 	public void setUp() throws Exception {
+		ListenerContainerParser parser = new ListenerContainerParser();
+		AtomicInteger instance = (AtomicInteger) ReflectionTestUtils.getField(parser, "instance");
+		instance.set(0);
 		beanFactory = new DefaultListableBeanFactory();
 		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(beanFactory);
 		reader.loadBeanDefinitions(new ClassPathResource(getClass().getSimpleName() + "-context.xml", getClass()));
@@ -135,6 +139,19 @@ public class ListenerContainerParserTests {
 				SimpleMessageListenerContainer.class);
 		assertEquals("ex2", ReflectionTestUtils.getField(ReflectionTestUtils.getField(container, "messageListener"),
 				"responseExchange"));
+	}
+
+	@Test
+	public void testAnonParent() throws Exception {
+		beanFactory.getBean(
+				"org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#1$anonParentL1",
+				SimpleMessageListenerContainer.class);
+		beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#1$anonParentL2",
+				SimpleMessageListenerContainer.class);
+		beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#2$anonParentL1",
+				SimpleMessageListenerContainer.class);
+		beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#2$anonParentL2",
+				SimpleMessageListenerContainer.class);
 	}
 
 	@Test

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -62,6 +62,16 @@
 		<rabbit:listener queues="bar" ref="testBean" method="handle" response-exchange="ex2" />
 	</rabbit:listener-container>
 
+	<rabbit:listener-container connection-factory="connectionFactory">
+		<rabbit:listener id="anonParentL1" queues="foo" ref="testBean" method="handle" />
+		<rabbit:listener id="anonParentL2" queues="bar" ref="testBean" method="handle" />
+	</rabbit:listener-container>
+
+	<rabbit:listener-container connection-factory="connectionFactory">
+		<rabbit:listener id="anonParentL1" queues="foo" ref="testBean" method="handle" />
+		<rabbit:listener id="anonParentL2" queues="bar" ref="testBean" method="handle" />
+	</rabbit:listener-container>
+
 	<util:list id="adviceChain">
 		<bean class="org.springframework.amqp.rabbit.config.ListenerContainerParserTests$TestAdvice"/>
 		<bean class="org.springframework.amqp.rabbit.config.ListenerContainerParserTests$TestAdvice"/>


### PR DESCRIPTION
Previously, if the parent `<listener-container/>` element
was given an Id, and multiple `<listener/>` elements existed
only one listener container bean was defined - the parent
element Id was used for the bean name.
- Use the child element id if present
- Disallow multiple child elements with the same id
- If a single child element has no id, use the parent
- If multiple elements with the same id exist, use the parent id + '#n'.
