### PR TITLE
AMQP-330: fix JavaTypeMapper JsonArray conversion

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJavaTypeMapper.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.codehaus.jackson.type.JavaType;
+
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.util.ClassUtils;
 
@@ -23,6 +24,7 @@ import org.springframework.util.ClassUtils;
  * @author Mark Pollack
  * @author Sam Nelson
  * @author Andreas Asplund
+ * @author Artem Bilan
  */
 public class DefaultJavaTypeMapper extends AbstractJavaTypeMapper implements JavaTypeMapper, ClassMapper {
 
@@ -30,7 +32,7 @@ public class DefaultJavaTypeMapper extends AbstractJavaTypeMapper implements Jav
 	public JavaType toJavaType(MessageProperties properties) {
 		JavaType classType = getClassIdType(retrieveHeader(properties,
 				getClassIdFieldName()));
-		if (!classType.isContainerType()) {
+		if (!classType.isContainerType() || classType.isArrayType()) {
 			return classType;
 		}
 
@@ -44,10 +46,9 @@ public class DefaultJavaTypeMapper extends AbstractJavaTypeMapper implements Jav
 
 		JavaType keyClassType = getClassIdType(retrieveHeader(properties,
 				getKeyClassIdFieldName()));
-		JavaType mapType = mapType(
+		return mapType(
 				(Class<? extends Map>) classType.getRawClass(), keyClassType,
 				contentClassType);
-		return mapType;
 
 	}
 
@@ -76,7 +77,7 @@ public class DefaultJavaTypeMapper extends AbstractJavaTypeMapper implements Jav
 		addHeader(properties, getClassIdFieldName(),
 				javaType.getRawClass());
 
-		if (javaType.isContainerType()) {
+		if (javaType.isContainerType() && !javaType.isArrayType()) {
 			addHeader(properties, getContentClassIdFieldName(), javaType
 					.getContentType().getRawClass());
 		}
@@ -95,4 +96,5 @@ public class DefaultJavaTypeMapper extends AbstractJavaTypeMapper implements Jav
 	public Class<?> toClass(MessageProperties properties) {
 		return toJavaType(properties).getRawClass();
 	}
+
 }

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests.java
@@ -9,6 +9,7 @@
 
 package org.springframework.amqp.support.converter;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -18,14 +19,16 @@ import java.util.Hashtable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
+
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
 
 /**
  * @author Mark Pollack
@@ -33,6 +36,7 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
  * @author Sam Nelson
  * @author Gary Russell
  * @author Andreas Asplund
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -124,7 +128,22 @@ public class Jackson2JsonMessageConverterTests {
       assertEquals(trade, marshalledTrade);
    }
 
-   @Test
+	@Test
+	public void testAmqp330StringArray() {
+		String[] testData = {"test"};
+		Message message = converter.toMessage(testData, new MessageProperties());
+		assertArrayEquals(testData, (Object[]) converter.fromMessage(message));
+	}
+
+	@Test
+	public void testAmqp330ObjectArray() {
+		SimpleTrade[] testData = {trade};
+		Message message = converter.toMessage(testData, new MessageProperties());
+		assertArrayEquals(testData, (Object[]) converter.fromMessage(message));
+	}
+
+
+	@Test
    public void testDefaultType() {
 	   byte[] bytes = "{\"name\" : \"foo\" }".getBytes();
 	   MessageProperties messageProperties = new MessageProperties();

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JsonMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JsonMessageConverterTests.java
@@ -9,17 +9,20 @@
 
 package org.springframework.amqp.support.converter;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.util.Hashtable;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.ser.BeanSerializerFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.ser.BeanSerializerFactory;
+
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +34,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Dave Syer
  * @author Sam Nelson
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -120,6 +124,20 @@ public class JsonMessageConverterTests {
 
       SimpleTrade marshalledTrade = (SimpleTrade) converter.fromMessage(message);
       assertEquals(trade, marshalledTrade);
+   }
+
+   @Test
+   public void testAmqp330StringArray() {
+	   String[] testData = {"test"};
+	   Message message = converter.toMessage(testData, new MessageProperties());
+	   assertArrayEquals(testData, (Object[]) converter.fromMessage(message));
+   }
+
+   @Test
+   public void testAmqp330ObjectArray() {
+	   SimpleTrade[] testData = {trade};
+	   Message message = converter.toMessage(testData, new MessageProperties());
+	   assertArrayEquals(testData, (Object[]) converter.fromMessage(message));
    }
 
    @Test


### PR DESCRIPTION
Since `JsonMessageConverter` (`Jackson2JsonMessageConverter`) uses
`JavaTypeMapper`(`Jackson2JavaTypeMapper`) it should correctly do
a conversion around simple Java types and arrays (`String[]`) too.
Seeing Jackson's `ArrayType` is **ContainerType**, erenow `JavaTypeMapper`
implementation added to `Properties` '**ContentTypeId**' header
on `toMessage` call and tried to create a collection (not array) from that header
on `fromMessage` call.

Add checks that provided **ContainerType** is (not is) **ArrayType**

JIRA: https://jira.springsource.org/browse/AMQP-330
