### PR TITLE
AMQP-340 Consider RabbitMQ authentication failure as FatalListenerStartupException

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/RabbitExceptionTranslator.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/RabbitExceptionTranslator.java
@@ -24,8 +24,10 @@ import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpIOException;
 import org.springframework.amqp.AmqpUnsupportedEncodingException;
 import org.springframework.amqp.UncategorizedAmqpException;
+import org.springframework.amqp.rabbit.listener.FatalListenerStartupException;
 import org.springframework.util.Assert;
 
+import com.rabbitmq.client.PossibleAuthenticationFailureException;
 import com.rabbitmq.client.ShutdownSignalException;
 
 /**
@@ -50,11 +52,14 @@ public class RabbitExceptionTranslator {
 		if (ex instanceof ConnectException) {
 			return new AmqpConnectException((ConnectException) ex);
 		}
-		if (ex instanceof IOException) {
-			return new AmqpIOException((IOException) ex);
+		if (ex instanceof PossibleAuthenticationFailureException) {
+			return new FatalListenerStartupException("Authentication failure", ex);
 		}
 		if (ex instanceof UnsupportedEncodingException) {
 			return new AmqpUnsupportedEncodingException(ex);
+		}
+		if (ex instanceof IOException) {
+			return new AmqpIOException((IOException) ex);
 		}
 		// fallback
 		return new UncategorizedAmqpException(ex);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/transaction/RabbitExceptionTranslatorTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/transaction/RabbitExceptionTranslatorTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.transaction;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.ConnectException;
+
+import org.junit.Test;
+import org.springframework.amqp.AmqpConnectException;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.AmqpIOException;
+import org.springframework.amqp.AmqpUnsupportedEncodingException;
+import org.springframework.amqp.UncategorizedAmqpException;
+import org.springframework.amqp.rabbit.listener.FatalListenerStartupException;
+import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
+
+import com.rabbitmq.client.PossibleAuthenticationFailureException;
+import com.rabbitmq.client.ShutdownSignalException;
+
+/**
+ * @author Sergey Shcherbakov
+ */
+public class RabbitExceptionTranslatorTests {
+
+	@Test
+	public void testConvertRabbitAccessException() {
+		
+		assertThat(RabbitExceptionTranslator.convertRabbitAccessException(new PossibleAuthenticationFailureException(null)), 
+				instanceOf(FatalListenerStartupException.class));
+
+		assertThat(RabbitExceptionTranslator.convertRabbitAccessException(new AmqpException("")), 
+				instanceOf(AmqpException.class));
+
+		assertThat(RabbitExceptionTranslator.convertRabbitAccessException(new ShutdownSignalException(false, false, null, null)), 
+				instanceOf(AmqpConnectException.class));
+
+		assertThat(RabbitExceptionTranslator.convertRabbitAccessException(new ConnectException()), 
+				instanceOf(AmqpConnectException.class));
+
+		assertThat(RabbitExceptionTranslator.convertRabbitAccessException(new IOException()), 
+				instanceOf(AmqpIOException.class));
+
+		assertThat(RabbitExceptionTranslator.convertRabbitAccessException(new UnsupportedEncodingException()), 
+				instanceOf(AmqpUnsupportedEncodingException.class));
+
+		assertThat(RabbitExceptionTranslator.convertRabbitAccessException(new Exception() {
+			private static final long serialVersionUID = 1L;}), 
+				instanceOf(UncategorizedAmqpException.class));
+
+	}
+
+}


### PR DESCRIPTION
SimpleMessageListenerContainer restart gets aborted if the reason of a failed connection is the wrong RabbitMQ credentials.
