### PR TITLE
AMQP-342: Fix Listener Integration Tests

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -342,10 +342,9 @@ public class BlockingQueueConsumer {
 				logger.debug("Storing delivery for " + BlockingQueueConsumer.this);
 			}
 			try {
-				// N.B. we can't use a bounded queue and offer() here with a timeout
-				// in case the connection thread gets blocked
 				queue.put(new Delivery(envelope, properties, body));
-			} catch (InterruptedException e) {
+			}
+			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 			}
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -365,6 +365,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 * @param txSize the transaction size
 	 */
 	public void setTxSize(int txSize) {
+		Assert.isTrue(txSize > 0, "'txSize' must be > 0");
 		this.txSize = txSize;
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerLifecycleIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerLifecycleIntegrationTests.java
@@ -60,9 +60,9 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 	private static Queue queue = new Queue("test.queue");
 
 	private enum TransactionMode {
-		ON, OFF, PREFETCH;
+		ON, OFF, PREFETCH, PREFETCH_NO_TX;
 		public boolean isTransactional() {
-			return this != OFF;
+			return this != OFF && this != PREFETCH_NO_TX;
 		}
 
 		public AcknowledgeMode getAcknowledgeMode() {
@@ -70,11 +70,11 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 		}
 
 		public int getPrefetch() {
-			return this == PREFETCH ? 10 : -1;
+			return this == PREFETCH || this == PREFETCH_NO_TX ? 10 : -1;
 		}
 
 		public int getTxSize() {
-			return this == PREFETCH ? 5 : -1;
+			return this == PREFETCH || this == PREFETCH_NO_TX ? 5 : -1;
 		}
 	}
 
@@ -155,6 +155,16 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 	}
 
 	@Test
+	public void testNonTransactionalLowLevelWithPrefetch() throws Exception {
+		doTest(MessageCount.MEDIUM, Concurrency.LOW, TransactionMode.PREFETCH_NO_TX);
+	}
+
+	@Test
+	public void testNonTransactionalHighLevelWithPrefetch() throws Exception {
+		doTest(MessageCount.HIGH, Concurrency.HIGH, TransactionMode.PREFETCH_NO_TX);
+	}
+
+	@Test
 	public void testBadCredentials() throws Exception {
 		RabbitTemplate template = createTemplate(1);
 		com.rabbitmq.client.ConnectionFactory cf = new com.rabbitmq.client.ConnectionFactory();
@@ -177,6 +187,10 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 		this.doTest(level, concurrency, transactionMode, template, template.getConnectionFactory());
 	}
 
+	/**
+	 * If transactionMode is OFF, the undelivered messages will be lost (ack=NONE). If it is
+	 * ON, PREFETCH, or PREFETCH_NO_TX, ack=AUTO, so we should not lose any messages.
+	 */
 	private void doTest(MessageCount level, Concurrency concurrency, TransactionMode transactionMode,
 			RabbitTemplate template, ConnectionFactory connectionFactory) throws Exception {
 
@@ -224,9 +238,9 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 				int messagesReceivedAfterStop = listener.getCount();
 				waited = latch.await(500, TimeUnit.MILLISECONDS);
 				// AMQP-338
-				logger.info("All messages received after stop: " + waited);
+				logger.info("All messages received after stop: " + waited + " (" + messagesReceivedAfterStop + ")");
 
-				assertFalse("Isn't expected to receive all messages after stop", waited);
+				assertFalse("Didn't expect to receive all messages after stop", waited);
 
 				assertEquals("Unexpected additional messages received after stop", messagesReceivedAfterStop,
 						listener.getCount());
@@ -234,7 +248,10 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 				for (int i = 0; i < messageCount; i++) {
 					template.convertAndSend(queue.getName(), i + "bar");
 				}
-				latch = new CountDownLatch(messageCount);
+				// Even though not transactional, we shouldn't lose messages for PREFETCH_NO_TX
+				int expectedAfterRestart = transactionMode == TransactionMode.PREFETCH_NO_TX ?
+						messageCount * 2 - messagesReceivedAfterStop : messageCount;
+				latch = new CountDownLatch(expectedAfterRestart);
 				listener.reset(latch);
 
 			}
@@ -249,7 +266,8 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 			assertEquals(concurrentConsumers, container.getActiveConsumerCount());
 			if (transactional) {
 				assertTrue("Timed out waiting for message", waited);
-			} else {
+			}
+			else {
 				int count = listener.getCount();
 				assertTrue("Expected additional messages received after start: " + messagesReceivedBeforeStart + ">="
 						+ count, messagesReceivedBeforeStart < count);
@@ -258,7 +276,8 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 
 			assertEquals(concurrentConsumers, container.getActiveConsumerCount());
 
-		} finally {
+		}
+		finally {
 			// Wait for broker communication to finish before trying to stop
 			// container
 			Thread.sleep(500L);


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/AMQP-342

Previously, the `MessageListenerContainerLifecycleIntegrationTests` relied
on Consumers' logic, when they can emit messages even after stop() of container.

Since AMQP-338 fix Consumers consumers are marker to stop on container stop().
So, now non-transactional consumers work as transactional and there is no received
new messages from message broker after stop().
