### PR TITLE
AMQP-359: Reset amqp-log4j to default after test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ subprojects { subproject ->
 	test {
 		// suppress all console output during testing unless running `gradle -i`
 		logging.captureStandardOutput(LogLevel.INFO)
-		jvmArgs "-Dlog4j.debug=true -javaagent:${configurations.jacoco.asPath}=destfile=${buildDir}/jacoco.exec,includes=org.springframework.*"
+		jvmArgs "-javaagent:${configurations.jacoco.asPath}=destfile=${buildDir}/jacoco.exec,includes=org.springframework.*"
 	}
 
 	task testAll() {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 by the original author(s).
+ * Copyright (c) 2011-2014 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -29,6 +29,7 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.MDC;
 import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +49,7 @@ import org.springframework.util.Log4jConfigurer;
  * @author Jon Brisbin <jbrisbin@vmware.com>
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Artem Bilan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "org.springframework.amqp.rabbit.log4j" }, loader = AnnotationConfigContextLoader.class)
@@ -74,6 +76,11 @@ public class AmqpAppenderIntegrationTests {
 	@After
 	public void tearDown() {
 		listenerContainer.shutdown();
+	}
+
+	@AfterClass
+	public static void reset() throws Exception {
+		Log4jConfigurer.initLogging("classpath:log4j.properties");
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/AMQP-359

Previously `AmqpAppenderIntegrationTests` configured `LogManager`
to use `log4j-amqp.properties`, who turned on DEBUG for `org.springframework.amqp.rabbit`
and all other tests generated a lot of DEBUG log message for their reports.
It causes a long time for parsing test results on CI.

Revert `LogManager` to use `log4j.properties` after `AmqpAppenderIntegrationTests`

**Cherry-pick to 1.2.x**
