### PR TITLE
AMQP-364 Revert Long MesageProperties to long

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageBuilderSupport.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageBuilderSupport.java
@@ -239,7 +239,7 @@ abstract class MessageBuilderSupport<T> {
 	}
 
 	public MessageBuilderSupport<T> setContentLengthIfAbsent(long contentLength) {
-		if (this.properties.getContentLength() == null) {
+		if (!this.properties.isContentLengthSet()) {
 			this.properties.setContentLength(contentLength);
 		}
 		return this;
@@ -290,7 +290,7 @@ abstract class MessageBuilderSupport<T> {
 	}
 
 	public MessageBuilderSupport<T> setDeliveryTagIfAbsent(Long deliveryTag) {
-		if (this.properties.getDeliveryTag() == null) {
+		if (!this.properties.isDeliveryTagSet()) {
 			this.properties.setDeliveryTag(deliveryTag);
 		}
 		return this;

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -70,7 +70,9 @@ public class MessageProperties implements Serializable {
 
 	private volatile String contentEncoding;
 
-	private volatile Long contentLength;
+	private volatile long contentLength;
+
+	private volatile boolean contentLengthSet;
 
 	private volatile MessageDeliveryMode deliveryMode = DEFAULT_DELIVERY_MODE;
 
@@ -84,7 +86,9 @@ public class MessageProperties implements Serializable {
 
 	private volatile String receivedRoutingKey;
 
-	private volatile Long deliveryTag;
+	private volatile long deliveryTag;
+
+	private volatile boolean deliveryTagSet;
 
 	private volatile Integer messageCount;
 
@@ -196,12 +200,17 @@ public class MessageProperties implements Serializable {
 		return this.contentEncoding;
 	}
 
-	public void setContentLength(Long contentLength) {
+	public void setContentLength(long contentLength) {
 		this.contentLength = contentLength;
+		this.contentLengthSet = true;
 	}
 
-	public Long getContentLength() {
+	public long getContentLength() {
 		return this.contentLength;
+	}
+
+	protected final boolean isContentLengthSet() {
+		return contentLengthSet;
 	}
 
 	public void setDeliveryMode(MessageDeliveryMode deliveryMode) {
@@ -262,12 +271,17 @@ public class MessageProperties implements Serializable {
 		return this.redelivered;
 	}
 
-	public void setDeliveryTag(Long deliveryTag) {
+	public void setDeliveryTag(long deliveryTag) {
 		this.deliveryTag = deliveryTag;
+		this.deliveryTagSet = true;
 	}
 
-	public Long getDeliveryTag() {
+	public long getDeliveryTag() {
 		return this.deliveryTag;
+	}
+
+	protected final boolean isDeliveryTagSet() {
+		return deliveryTagSet;
 	}
 
 	public void setMessageCount(Integer messageCount) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
@@ -146,7 +146,7 @@ public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter {
 		messageProperties.setContentType(MessageProperties.CONTENT_TYPE_JSON);
 		messageProperties.setContentEncoding(getDefaultCharset());
 		if (bytes != null) {
-			messageProperties.setContentLength((long) bytes.length);
+			messageProperties.setContentLength(bytes.length);
 		}
 
 		if (getClassMapper() == null) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/JsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/JsonMessageConverter.java
@@ -150,7 +150,7 @@ public class JsonMessageConverter extends AbstractJsonMessageConverter {
 		messageProperties.setContentType(MessageProperties.CONTENT_TYPE_JSON);
 		messageProperties.setContentEncoding(getDefaultCharset());
 		if (bytes != null) {
-			messageProperties.setContentLength((long) bytes.length);
+			messageProperties.setContentLength(bytes.length);
 		}
 
 		if (getClassMapper() == null) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SerializerMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SerializerMessageConverter.java
@@ -145,7 +145,7 @@ public class SerializerMessageConverter extends AbstractMessageConverter {
 			messageProperties.setContentType(MessageProperties.CONTENT_TYPE_SERIALIZED_OBJECT);
 		}
 		if (bytes != null) {
-			messageProperties.setContentLength((long) bytes.length);
+			messageProperties.setContentLength(bytes.length);
 		}
 		return new Message(bytes, messageProperties);
 	}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SimpleMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SimpleMessageConverter.java
@@ -151,7 +151,7 @@ public class SimpleMessageConverter extends AbstractMessageConverter implements 
 			messageProperties.setContentType(MessageProperties.CONTENT_TYPE_SERIALIZED_OBJECT);
 		}
 		if (bytes != null) {
-			messageProperties.setContentLength((long) bytes.length);
+			messageProperties.setContentLength(bytes.length);
 		}
 		return new Message(bytes, messageProperties);
 	}

--- a/spring-amqp/src/test/java/org/springframework/amqp/core/MessageBuilderTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/core/MessageBuilderTests.java
@@ -309,10 +309,10 @@ public class MessageBuilderTests {
 		assertEquals("clusterId", properties.getClusterId());
 		assertEquals("contentEncoding", properties.getContentEncoding());
 		assertEquals(MessageProperties.CONTENT_TYPE_TEXT_PLAIN, properties.getContentType());
-		assertEquals(Long.valueOf(1), properties.getContentLength());
+		assertEquals(1, properties.getContentLength());
 		assertEquals("correlationId", new String(properties.getCorrelationId()));
 		assertEquals(MessageDeliveryMode.NON_PERSISTENT, properties.getDeliveryMode());
-		assertEquals(Long.valueOf(2), properties.getDeliveryTag());
+		assertEquals(2, properties.getDeliveryTag());
 		assertEquals("expiration", properties.getExpiration());
 		assertEquals("bar", properties.getHeaders().get("foo"));
 		assertEquals("fiz", properties.getHeaders().get("qux"));
@@ -333,10 +333,10 @@ public class MessageBuilderTests {
 		assertEquals("CLUSTERID", properties.getClusterId());
 		assertEquals("CONTENTENCODING", properties.getContentEncoding());
 		assertEquals(MessageProperties.CONTENT_TYPE_BYTES, properties.getContentType());
-		assertEquals(Long.valueOf(10), properties.getContentLength());
+		assertEquals(10, properties.getContentLength());
 		assertEquals("CORRELATIONID", new String(properties.getCorrelationId()));
 		assertEquals(MessageDeliveryMode.PERSISTENT, properties.getDeliveryMode());
-		assertEquals(Long.valueOf(20), properties.getDeliveryTag());
+		assertEquals(20, properties.getDeliveryTag());
 		assertEquals("EXPIRATION", properties.getExpiration());
 		assertEquals("BAR", properties.getHeaders().get("foo"));
 		assertEquals("FIZ", properties.getHeaders().get("qux"));


### PR DESCRIPTION
API changes to support the message builder (with setIfAbsent) breaks
existing Apps. Use a boolean instead to determine if the header has been
explicitly set.

JIRA: https://jira.springsource.org/browse/AMQP-364

Cause: 22801e674f0e0c401d055a145381573308785790
