### PR TITLE
AMQP-363: Fix `ignoresThrowable` for AmqpAppender

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j/AmqpAppender.java
@@ -105,6 +105,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
  *
  * @author Jon Brisbin
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class AmqpAppender extends AppenderSkeleton {
 
@@ -529,7 +530,7 @@ public class AmqpAppender extends AppenderSkeleton {
 						msgBody = new StringBuilder(layout.format(logEvent));
 						routingKey = routingKeyLayout.format(logEvent);
 					}
-					if (null != logEvent.getThrowableInformation()) {
+					if (layout.ignoresThrowable() && null != logEvent.getThrowableInformation()) {
 						ThrowableInformation tinfo = logEvent.getThrowableInformation();
 						for (String line : tinfo.getThrowableStrRep()) {
 							msgBody.append(String.format("%s%n", line));

--- a/spring-rabbit/src/test/resources/log4j-amqp.properties
+++ b/spring-rabbit/src/test/resources/log4j-amqp.properties
@@ -12,7 +12,16 @@ log4j.appender.amqp.layout.ConversionPattern=%d %p %t [%c] - <%m>%n
 log4j.appender.amqp.generateId=true
 log4j.appender.amqp.charset=UTF-8
 
+log4j.appender.amqpXml=org.springframework.amqp.rabbit.log4j.AmqpAppender
+log4j.appender.amqpXml.applicationId=AmqpAppenderTest
+log4j.appender.amqpXml.routingKeyPattern=%X{applicationId}.%c.%p
+log4j.appender.amqpXml.layout=org.apache.log4j.xml.XMLLayout
+log4j.appender.amqpXml.generateId=true
+log4j.appender.amqpXml.charset=UTF-8
+log4j.appender.amqpXml.contentType=text/xml
+
 log4j.category.org.springframework.amqp.rabbit.log4j=DEBUG, amqp
+log4j.category.org.springframework.amqp.rabbit.logging.customLayout=DEBUG, amqpXml
 
 log4j.category.org.springframework.amqp.rabbit=DEBUG
 log4j.category.org.springframework.beans.factory=INFO


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/AMQP-363

Previously the `AmqpAppender` didn't check `layout.ignoresThrowable`
and added `ThrowableInformation` to the end of log message.
- Add check `layout.ignoresThrowable()` and now it allow to use custom `Layout`, e.g. JSON or XML
- Add test for `org.apache.log4j.xml.XMLLayout`
