### PR TITLE
AMQP-366 StackTrace for ConsumerCancelledException

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -906,7 +906,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		}
 
 		private void logConsumerException(Throwable t) {
-			if (logger.isDebugEnabled() || !(t instanceof AmqpConnectException)) {
+			if (logger.isDebugEnabled()
+					|| !(t instanceof AmqpConnectException  || t instanceof ConsumerCancelledException)) {
 				logger.warn(
 						"Consumer raised exception, processing can restart if the connection factory supports it",
 						t);


### PR DESCRIPTION
Do not emit a stack trace for this exception (which can
result, for example, when the consumer's queue is deleted).

It is only thrown from one place.

JIRA: https://jira.springsource.org/browse/AMQP-366
