### PR TITLE
AMQP-371 Fix Visibility of MessageBuilderSupport

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageBuilderSupport.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageBuilderSupport.java
@@ -29,7 +29,7 @@ import org.springframework.beans.BeanUtils;
  * @since 1.3
  *
  */
-abstract class MessageBuilderSupport<T> {
+public abstract class MessageBuilderSupport<T> {
 
 	private MessageProperties properties = new MessageProperties();
 
@@ -340,5 +340,5 @@ abstract class MessageBuilderSupport<T> {
 		return this.properties;
 	}
 
-	protected abstract T build();
+	public abstract T build();
 }

--- a/spring-amqp/src/test/java/org/springframework/amqp/core/build/MessageBuilderTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/core/build/MessageBuilderTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.amqp.core;
+package org.springframework.amqp.core.build;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -26,6 +26,13 @@ import java.util.Collections;
 import java.util.Date;
 
 import org.junit.Test;
+
+import org.springframework.amqp.core.Address;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.core.MessagePropertiesBuilder;
 
 /**
  * @author Gary Russell


### PR DESCRIPTION
Package visibility of the support class and protected
visibility of `build()` prevents use of the fluent
API outside of the package.

JIRA: https://jira.springsource.org/browse/AMQP-371
