### PR TITLE
AMQP-373 Support Listen on auto-delete Queues

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -15,7 +15,9 @@ package org.springframework.amqp.rabbit.listener;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.springframework.amqp.core.AcknowledgeMode;
@@ -28,6 +30,8 @@ import org.springframework.amqp.rabbit.connection.RabbitAccessor;
 import org.springframework.amqp.rabbit.connection.RabbitResourceHolder;
 import org.springframework.amqp.rabbit.connection.RabbitUtils;
 import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.SmartLifecycle;
@@ -44,8 +48,8 @@ import com.rabbitmq.client.Channel;
  * @author James Carr
  * @author Gary Russell
  */
-public abstract class AbstractMessageListenerContainer extends RabbitAccessor implements BeanNameAware, DisposableBean,
-		SmartLifecycle {
+public abstract class AbstractMessageListenerContainer extends RabbitAccessor
+		implements BeanFactoryAware, BeanNameAware, DisposableBean, SmartLifecycle {
 
 	private volatile String beanName;
 
@@ -70,6 +74,8 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor im
 	private volatile AcknowledgeMode acknowledgeMode = AcknowledgeMode.AUTO;
 
 	private boolean initialized;
+
+	private volatile BeanFactory beanFactory;
 
 	/**
 	 * <p>
@@ -137,6 +143,10 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor im
 	protected String[] getRequiredQueueNames() {
 		Assert.state(this.queueNames.size() > 0, "Queue names must not be empty.");
 		return this.getQueueNames();
+	}
+
+	protected Set<String> getQueueNamesAsSet() {
+		return new HashSet<String>(this.queueNames);
 	}
 
 	/**
@@ -292,6 +302,15 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor im
 	 */
 	protected final String getBeanName() {
 		return this.beanName;
+	}
+
+	protected final BeanFactory getBeanFactory() {
+		return beanFactory;
+	}
+
+	@Override
+	public final void setBeanFactory(BeanFactory beanFactory) {
+		this.beanFactory = beanFactory;
 	}
 
 	/**


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/AMQP-373

Previously, listening on auto-delete queues was impractical
if the container is stopped/started. Stopping the container
causes the consumer to be cancelled, deleting the queue.

The RabbitAdmin only redeclares beans in the context when
the connection is lost. When stopping the container, the
connection is not closed.

Add code to the listener consumer startup to check if any
of it's queue names are declared in the context as
auto-delete queues and check that the queue exists.

If not, declare such queues with a RabbitAdmin.
