### PR TITLE
AMQP-316 Support Exclusive Consumer

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerParser.java
@@ -60,6 +60,8 @@ class ListenerContainerParser implements BeanDefinitionParser {
 
 	private static final String RESPONSE_ROUTING_KEY_ATTRIBUTE = "response-routing-key";
 
+	private static final String EXCLUSIVE = "exclusive";
+
 	private final Set<String> listenerIds = new HashSet<String>();
 
 	private static final AtomicInteger instance = new AtomicInteger();
@@ -132,6 +134,11 @@ class ListenerContainerParser implements BeanDefinitionParser {
 
 		listenerDef.setBeanClass(MessageListenerAdapter.class);
 		containerDef.getPropertyValues().add("messageListener", listenerDef);
+
+		String exclusive = listenerEle.getAttribute(EXCLUSIVE);
+		if (StringUtils.hasText(exclusive)) {
+			containerDef.getPropertyValues().add("exclusive", exclusive);
+		}
 
 		String parentElementId = containerEle.getAttribute(ID_ATTRIBUTE);
 		// If no bean id is given auto generate one using the ReaderContext's BeanNameGenerator

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,9 @@ public class RabbitNamespaceUtils {
 	private static final String ADVICE_CHAIN_ATTRIBUTE = "advice-chain";
 
 	private static final String REQUEUE_REJECTED_ATTRIBUTE = "requeue-rejected";
+
+	private static final String RECOVERY_INTERVAL = "recovery-interval";
+
 
 	public static BeanDefinition parseContainer(Element containerEle, ParserContext parserContext) {
 		RootBeanDefinition containerDef = new RootBeanDefinition(SimpleMessageListenerContainer.class);
@@ -188,6 +191,11 @@ public class RabbitNamespaceUtils {
 		String adviceChain = containerEle.getAttribute(ADVICE_CHAIN_ATTRIBUTE);
 		if (StringUtils.hasText(adviceChain)) {
 			containerDef.getPropertyValues().add("adviceChain", new RuntimeBeanReference(adviceChain));
+		}
+
+		String recoveryInterval = containerEle.getAttribute(RECOVERY_INTERVAL);
+		if (StringUtils.hasText(recoveryInterval)) {
+			containerDef.getPropertyValues().add("recoveryInterval", new TypedStringValue(recoveryInterval));
 		}
 
 		return containerDef;

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.3.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.3.xsd
@@ -625,6 +625,13 @@
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="recovery-interval" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The time in milliseconds between attempts to start a consumer if it fails to start with a non-fatal error. Default 5000.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="listenerType">
@@ -646,6 +653,14 @@
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 	The queues (bean references) for this listener as a comma-separated list. Either this or queue-names is required.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="exclusive" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	When true, a single consumer in the container will have exlusive use of the queue(s), preventing other consumers from
+	receiving messages from the queue(s). When true, requires a concurrency of 1. Default false.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
@@ -89,6 +89,8 @@ public class ListenerContainerParserTests {
 		Object xPriority = consumerArgs.get("x-priority");
 		assertNotNull(xPriority);
 		assertEquals(10, xPriority);
+		assertEquals(Long.valueOf(5555), TestUtils.getPropertyValue(container, "recoveryInterval", Long.class));
+		assertFalse(TestUtils.getPropertyValue(container, "exclusive", Boolean.class));
 	}
 
 	@Test
@@ -104,6 +106,7 @@ public class ListenerContainerParserTests {
 		Object adviceChain = ReflectionTestUtils.getField(container, "adviceChain");
 		assertNotNull(adviceChain);
 		assertEquals(3, ((Advice[]) adviceChain).length);
+		assertTrue(TestUtils.getPropertyValue(container, "exclusive", Boolean.class));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -18,6 +18,10 @@ package org.springframework.amqp.rabbit.listener;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -33,6 +37,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
@@ -64,6 +69,7 @@ public class ExternalTxManagerTests {
 	 * Verifies that an up-stack RabbitTemplate uses the listener's
 	 * channel (MessageListener).
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testMessageListener() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
@@ -99,11 +105,11 @@ public class ExternalTxManagerTests {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				return null;
 			}
 		}).when(onlyChannel)
-			.basicConsume(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(Consumer.class));
+			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
 		doAnswer(new Answer<String>() {
@@ -118,6 +124,7 @@ public class ExternalTxManagerTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(cachingConnectionFactory);
 		container.setMessageListener(new MessageListener() {
+			@Override
 			public void onMessage(Message message) {
 				RabbitTemplate rabbitTemplate = new RabbitTemplate(cachingConnectionFactory);
 				rabbitTemplate.setChannelTransacted(true);
@@ -161,6 +168,7 @@ public class ExternalTxManagerTests {
 	 * Verifies that an up-stack RabbitTemplate does not use the listener's
 	 * channel when it has its own connection factory.
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testMessageListenerTemplateUsesDifferentConnectionFactory() throws Exception {
 		ConnectionFactory listenerConnectionFactory = mock(ConnectionFactory.class);
@@ -204,11 +212,11 @@ public class ExternalTxManagerTests {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				return null;
 			}
 		}).when(listenerChannel)
-			.basicConsume(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(Consumer.class));
+			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(2);
 		doAnswer(new Answer<String>() {
@@ -231,6 +239,7 @@ public class ExternalTxManagerTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(cachingConnectionFactory);
 		container.setMessageListener(new MessageListener() {
+			@Override
 			public void onMessage(Message message) {
 				RabbitTemplate rabbitTemplate = new RabbitTemplate(cachingTemplateConnectionFactory);
 				rabbitTemplate.setChannelTransacted(true);
@@ -276,6 +285,7 @@ public class ExternalTxManagerTests {
 	 * Verifies that an up-stack RabbitTemplate uses the listener's
 	 * channel (ChannelAwareMessageListener).
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testChannelAwareMessageListener() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
@@ -311,11 +321,11 @@ public class ExternalTxManagerTests {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				return null;
 			}
 		}).when(onlyChannel)
-			.basicConsume(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(Consumer.class));
+			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
 		doAnswer(new Answer<String>() {
@@ -331,6 +341,7 @@ public class ExternalTxManagerTests {
 		final AtomicReference<Channel> exposed = new AtomicReference<Channel>();
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(singleConnectionFactory);
 		container.setMessageListener(new ChannelAwareMessageListener() {
+			@Override
 			public void onMessage(Message message, Channel channel) {
 				exposed.set(channel);
 				RabbitTemplate rabbitTemplate = new RabbitTemplate(singleConnectionFactory);
@@ -376,6 +387,7 @@ public class ExternalTxManagerTests {
 	 * channel (ChannelAwareMessageListener). exposeListenerChannel=false
 	 * is ignored (ChannelAwareMessageListener).
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testChannelAwareMessageListenerDontExpose() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
@@ -411,11 +423,11 @@ public class ExternalTxManagerTests {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				return null;
 			}
 		}).when(onlyChannel)
-			.basicConsume(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(Consumer.class));
+			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
 		doAnswer(new Answer<String>() {
@@ -431,6 +443,7 @@ public class ExternalTxManagerTests {
 		final AtomicReference<Channel> exposed = new AtomicReference<Channel>();
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(singleConnectionFactory);
 		container.setMessageListener(new ChannelAwareMessageListener() {
+			@Override
 			public void onMessage(Message message, Channel channel) {
 				exposed.set(channel);
 				RabbitTemplate rabbitTemplate = new RabbitTemplate(singleConnectionFactory);
@@ -477,6 +490,7 @@ public class ExternalTxManagerTests {
 	 * Previously, the wrong channel was bound. See AMQP-260.
 	 * @throws Exception
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testMessageListenerWithRabbitTxManager() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
@@ -512,11 +526,11 @@ public class ExternalTxManagerTests {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				return null;
 			}
 		}).when(onlyChannel)
-			.basicConsume(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(Consumer.class));
+			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
 		doAnswer(new Answer<String>() {
@@ -531,6 +545,7 @@ public class ExternalTxManagerTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(cachingConnectionFactory);
 		container.setMessageListener(new MessageListener() {
+			@Override
 			public void onMessage(Message message) {
 				RabbitTemplate rabbitTemplate = new RabbitTemplate(cachingConnectionFactory);
 				rabbitTemplate.setChannelTransacted(true);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
@@ -18,6 +18,10 @@ package org.springframework.amqp.rabbit.listener;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -33,6 +37,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
@@ -59,6 +64,7 @@ public class LocallyTransactedTests {
 	 * Verifies that an up-stack RabbitTemplate uses the listener's
 	 * channel (MessageListener).
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testMessageListener() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
@@ -94,11 +100,11 @@ public class LocallyTransactedTests {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				return null;
 			}
 		}).when(onlyChannel)
-			.basicConsume(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(Consumer.class));
+			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
 		doAnswer(new Answer<String>() {
@@ -113,6 +119,7 @@ public class LocallyTransactedTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(cachingConnectionFactory);
 		container.setMessageListener(new MessageListener() {
+			@Override
 			public void onMessage(Message message) {
 				RabbitTemplate rabbitTemplate = new RabbitTemplate(cachingConnectionFactory);
 				rabbitTemplate.setChannelTransacted(true);
@@ -155,6 +162,7 @@ public class LocallyTransactedTests {
 	 * Verifies that an up-stack RabbitTemplate uses the listener's
 	 * channel (ChannelAwareMessageListener).
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testChannelAwareMessageListener() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
@@ -190,11 +198,11 @@ public class LocallyTransactedTests {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				return null;
 			}
 		}).when(onlyChannel)
-			.basicConsume(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(Consumer.class));
+			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
 		doAnswer(new Answer<String>() {
@@ -210,6 +218,7 @@ public class LocallyTransactedTests {
 		final AtomicReference<Channel> exposed = new AtomicReference<Channel>();
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(singleConnectionFactory);
 		container.setMessageListener(new ChannelAwareMessageListener() {
+			@Override
 			public void onMessage(Message message, Channel channel) {
 				exposed.set(channel);
 				RabbitTemplate rabbitTemplate = new RabbitTemplate(singleConnectionFactory);
@@ -254,6 +263,7 @@ public class LocallyTransactedTests {
 	 * up-stack RabbitTemplate uses the additional channel.
 	 * created when exposeListenerChannel is false (ChannelAwareMessageListener).
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testChannelAwareMessageListenerDontExpose() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
@@ -288,11 +298,11 @@ public class LocallyTransactedTests {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				return null;
 			}
 		}).when(firstChannel)
-			.basicConsume(Mockito.anyString(), Mockito.anyBoolean(), Mockito.any(Consumer.class));
+			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
 		doAnswer(new Answer<String>() {
@@ -308,6 +318,7 @@ public class LocallyTransactedTests {
 		final AtomicReference<Channel> exposed = new AtomicReference<Channel>();
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(singleConnectionFactory);
 		container.setMessageListener(new ChannelAwareMessageListener() {
+			@Override
 			public void onMessage(Message message, Channel channel) {
 				exposed.set(channel);
 				RabbitTemplate rabbitTemplate = new RabbitTemplate(singleConnectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -139,6 +140,7 @@ public class SimpleMessageListenerContainerTests {
 	/*
 	 * txSize = 2; 4 messages; should get 2 acks (#2 and #4)
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testTxSizeAcks() throws Exception {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
@@ -151,11 +153,11 @@ public class SimpleMessageListenerContainerTests {
 
 			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				consumer.get().handleConsumeOk("1");
 				return null;
 			}
-		}).when(channel).basicConsume(anyString(), anyBoolean(), any(Consumer.class));
+		}).when(channel).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 		final CountDownLatch latch = new CountDownLatch(2);
 		doAnswer(new Answer<Object>() {
 
@@ -208,6 +210,7 @@ public class SimpleMessageListenerContainerTests {
 	 * txSize = 2; 3 messages; should get 2 acks (#2 and #3)
 	 * after timeout.
 	 */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testTxSizeAcksWIthShortSet() throws Exception {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
@@ -220,11 +223,11 @@ public class SimpleMessageListenerContainerTests {
 
 			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				consumer.get().handleConsumeOk("1");
 				return null;
 			}
-		}).when(channel).basicConsume(anyString(), anyBoolean(), any(Consumer.class));
+		}).when(channel).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 		final CountDownLatch latch = new CountDownLatch(2);
 		doAnswer(new Answer<Object>() {
 
@@ -349,19 +352,20 @@ public class SimpleMessageListenerContainerTests {
 		verify(channel2).basicCancel("2");
 	}
 
+	@SuppressWarnings("unchecked")
 	protected void setupMockConsume(Channel channel, final List<Consumer> consumers, final AtomicInteger consumerTag,
 			final CountDownLatch latch) throws IOException {
 		doAnswer(new Answer<Object>() {
 
 			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
-				Consumer cons = (Consumer) invocation.getArguments()[2];
+				Consumer cons = (Consumer) invocation.getArguments()[6];
 				consumers.add(cons);
 				cons.handleConsumeOk(String.valueOf(consumerTag.getAndIncrement()));
 				latch.countDown();
 				return null;
 			}
-		}).when(channel).basicConsume(anyString(), anyBoolean(), any(Consumer.class));
+		}).when(channel).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 	}
 
 	protected void setUpMockCancel(Channel channel, final List<Consumer> consumers) throws IOException {
@@ -383,6 +387,7 @@ public class SimpleMessageListenerContainerTests {
 		}).when(channel).basicCancel(anyString());
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testWithConnectionPerListenerThread() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
@@ -413,9 +418,9 @@ public class SimpleMessageListenerContainerTests {
 		CountDownLatch latch1 = new CountDownLatch(2);
 		CountDownLatch latch2 = new CountDownLatch(2);
 		doAnswer(messageToConsumer(mockChannel1, container, false, latch1))
-		.when(mockChannel1).basicConsume(anyString(), anyBoolean(), any(Consumer.class));
+		.when(mockChannel1).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 		doAnswer(messageToConsumer(mockChannel2, container, false, latch1))
-			.when(mockChannel2).basicConsume(anyString(), anyBoolean(), any(Consumer.class));
+			.when(mockChannel2).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 		doAnswer(messageToConsumer(mockChannel1, container, true, latch2)).when(mockChannel1).basicCancel(anyString());
 		doAnswer(messageToConsumer(mockChannel2, container, true, latch2)).when(mockChannel2).basicCancel(anyString());
 
@@ -430,6 +435,7 @@ public class SimpleMessageListenerContainerTests {
 		assertEquals(1, openConnections.size());
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testConsumerCancel() throws Exception {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
@@ -442,11 +448,11 @@ public class SimpleMessageListenerContainerTests {
 
 			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[2]);
+				consumer.set((Consumer) invocation.getArguments()[6]);
 				consumer.get().handleConsumeOk("foo");
 				return null;
 			}
-		}).when(channel).basicConsume(anyString(), anyBoolean(), any(Consumer.class));
+		}).when(channel).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		container.setQueueNames("foo");
@@ -458,7 +464,7 @@ public class SimpleMessageListenerContainerTests {
 		});
 		container.afterPropertiesSet();
 		container.start();
-		verify(channel).basicConsume(anyString(), anyBoolean(), any(Consumer.class));
+		verify(channel).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 		Log logger = spy(TestUtils.getPropertyValue(container, "logger", Log.class));
 		final CountDownLatch latch = new CountDownLatch(1);
 		doAnswer(new Answer<Object>() {

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -12,7 +12,7 @@
 	<rabbit:queue id="bar" />
 
 	<rabbit:listener-container id="container1" connection-factory="connectionFactory" acknowledge="manual" concurrency="5"
-			max-concurrency="6" receive-timeout="9876"
+			max-concurrency="6" receive-timeout="9876" recovery-interval="5555"
 			min-start-interval="1234" min-stop-interval="2345" min-consecutive-active="12" min-consecutive-idle="34">
 		<rabbit:listener queue-names="foo, #{bar.name}" ref="testBean" method="handle" priority="10" />
 	</rabbit:listener-container>
@@ -22,7 +22,7 @@
 	</rabbit:listener-container>
 
 	<rabbit:listener-container id="container3" connection-factory="connectionFactory" advice-chain="adviceChain">
-		<rabbit:listener queues="foo" ref="testBean" method="handle"/>
+		<rabbit:listener queues="foo" exclusive="true" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 
 	<rabbit:listener-container id="container4" connection-factory="connectionFactory">

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -2092,6 +2092,27 @@ public RabbitTransactionManager rabbitTransactionManager() {
               rejected because the listener
               threw an exception should be requeued or not. Default 'true'.</entry>
             </row>
+
+            <row>
+              <entry><literallayout>recoveryInterval
+(recovery-interval)</literallayout></entry>
+
+              <entry>Determines the time in milliseconds between attempts to start a consumer
+              if it fails to start for non-fatal reasons. Default '5000'.</entry>
+            </row>
+
+            <row>
+              <entry><literallayout>exclusive
+(exclusive)</literallayout></entry>
+
+              <entry>Determines whether the single consumer in this container has
+              exclusive access to the queue(s). The concurrency of the container
+              must be 1 when this is true. If another consumer has exclusive access,
+              the container will attempt to recover the consumer, according to the
+              <code>recovery-interval</code>. When using the namespace, this attribute
+              appears on the &lt;rabbit:listener/&gt; element along with the queue names.
+              Default 'false'.</entry>
+            </row>
           </tbody>
         </tgroup>
       </table></para>
@@ -2154,6 +2175,24 @@ public RabbitTransactionManager rabbitTransactionManager() {
       some time. This is because the broker will share its work across all the active
       consumers.
     </note>
+    <para>
+      Exclusive consumers must have a concurrency of 1.
+    </para>
+  </section>
+
+  <section id="exclusive-consumer">
+    <title>Exclusive Consumer</title>
+    <para>
+       Also starting with <emphasis>version 1.3</emphasis>, the listener container can
+       be configured with a single exclusive consumer; this prevents other containers
+       from consuming from the queue(s) until the current consumer is cancelled. The
+       concurrency of such a container must be 1.
+    </para>
+    <para>
+       When using exclusive consumers, other containers will attempt to consume from
+       the queue(s) according to the <code>recoveryInterval</code> property, and log
+       a WARNing if the attempt fails.
+    </para>
   </section>
 
   <section id="listener-queues">

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -30,6 +30,14 @@
 			</para>
 		</section>
 		<section>
+			<title>Exclusive Consumer</title>
+			<para>
+				The <classname>SimpleMessageListenerContainer</classname> can now be configured
+				with a single <code>exclusive</code> consumer, preventing other consumers from
+				listening to the queue. See <xref linkend="exclusive-consumer" />.
+			</para>
+		</section>
+		<section>
 			<title>Rabbit Admin</title>
 			<para>
 				It is now possible to have the Broker generate the queue name, regardless


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/AMQP-316

Allow the `SimpleMessageListenerContainer` to be configured
with an exlusive consumer; preventing other consumers from
accessing the queue(s).
