### PR TITLE
AMQP-377: SMLC: Fix consumers Map race condition

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -758,8 +758,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					}
 					consumer.getKey().setQuiesce(this.shutdownTimeout);
 					consumer.setValue(false);
-					this.addAndStartConsumers(1);
 				}
+				this.addAndStartConsumers(this.consumers.size());
 			}
 		}
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -352,6 +352,33 @@ public class SimpleMessageListenerContainerTests {
 		verify(channel2).basicCancel("2");
 	}
 
+	@Test
+	public void testAddQueuesAndStartInCycle() throws Exception {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		Connection connection = mock(Connection.class);
+		Channel channel1 = mock(Channel.class);
+		when(channel1.isOpen()).thenReturn(true);
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		when(connection.createChannel(false)).thenReturn(channel1);
+
+		final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setMessageListener(new MessageListener() {
+
+			@Override
+			public void onMessage(Message message) {
+			}
+		});
+		container.afterPropertiesSet();
+
+		for (int i = 0; i < 10; i++) {
+			System.out.println(i);
+			container.addQueueName("foo" + i);
+			if (!container.isRunning()) {
+				container.start();
+			}
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	protected void setupMockConsume(Channel channel, final List<Consumer> consumers, final AtomicInteger consumerTag,
 			final CountDownLatch latch) throws IOException {


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/AMQP-377

There is a case when container is empty (without queues)
and adding new queues and attempt to start container from cycle causes
the `ConcurrentModificationException` on `consumers` `Map` iteration,
when `queuesChanged` and `doStart` modify the Map.

Move `addAndStartConsumers` operation in the `queuesChanged()` outside from cycle to avoid the concurrent modification race condition
