### PR TITLE
Add explict spring-context dependency to spring-rabbit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,7 @@ project('spring-rabbit') {
 		compile "com.rabbitmq:amqp-client:$rabbitmqVersion"
 
 		compile ("org.springframework:spring-aop:$springVersion", optional)
+		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
 
 		compile ("org.springframework.retry:spring-retry:1.0.3.RELEASE", optional)


### PR DESCRIPTION
spring-rabbit includes a number of classes with compile dependencies
upon spring-context, for example RabbitAdmin. It's currently only
getting spring-context transitively via its optional dependency on
spring-retry.

This causes a problem when spring-rabbit is depended upon as it can
lead to spring-retry's version of spring-context being used. This is
3.0.5.RELEASE which does not match the versions of the other spring
modules that spring-rabbit directly depends upon.

This commit adds a direct compile dependency upon spring-context
which better expresses the project's dependencies and ensures that a
matching and up-to-date version of spring-context is used.
