### PR TITLE
AMQP-378 Support Bulk Queue Changes

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -150,36 +150,52 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	}
 
 	/**
-	 * Add a queue to this container's list of queues.
-	 * @param queueName The queue to add.
+	 * Add queue(s) to this container's list of queues.
+	 * @param queueNames The queue(s) to add.
 	 */
-	public void addQueueName(String queueName) {
-		this.queueNames.add(queueName);
+	public void addQueueNames(String... queueNames) {
+		Assert.notNull(queueNames, "'queueNames' cannot be null");
+		Assert.noNullElements(queueNames, "'queueNames' cannot contain null elements");
+		this.queueNames.addAll(Arrays.asList(queueNames));
 	}
 
 	/**
-	 * Add a queue to this container's list of queues.
-	 * @param queue The queue to add.
+	 * Add queue(s) to this container's list of queues.
+	 * @param queues The queue(s) to add.
 	 */
-	public void addQueue(Queue queue) {
-		this.addQueueName(queue.getName());
+	public void addQueues(Queue... queues) {
+		Assert.notNull(queues, "'queues' cannot be null");
+		Assert.noNullElements(queues, "'queues' cannot contain null elements");
+		String[] queueNames = new String[queues.length];
+		for (int i = 0; i< queues.length; i++) {
+			queueNames[i] = queues[i].getName();
+		}
+		this.addQueueNames(queueNames);
 	}
 
 	/**
-	 * Remove a queue from this container's list of queues.
-	 * @param queueName The queue to remove.
+	 * Remove queue(s) from this container's list of queues.
+	 * @param queueNames The queue(s) to remove.
 	 */
-	public boolean removeQueueName(String queueName) {
-		Assert.isTrue(this.queueNames.size() > 1, "Cannot remove the last queue");
-		return this.queueNames.remove(queueName);
+	public boolean removeQueueNames(String... queueNames) {
+		Assert.notNull(queueNames, "'queueNames' cannot be null");
+		Assert.noNullElements(queueNames, "'queueNames' cannot contain null elements");
+		Assert.isTrue(this.queueNames.size() - queueNames.length > 0, "Cannot remove the last queue");
+		return this.queueNames.removeAll(Arrays.asList(queueNames));
 	}
 
 	/**
-	 * Remove a queue from this container's list of queues.
-	 * @param queue The queue to remove.
+	 * Remove queue(s) from this container's list of queues.
+	 * @param queues The queue(s) to remove.
 	 */
-	public boolean removeQueue(Queue queue) {
-		return this.removeQueueName(queue.getName());
+	public boolean removeQueues(Queue... queues) {
+		Assert.notNull(queues, "'queues' cannot be null");
+		Assert.noNullElements(queues, "'queues' cannot contain null elements");
+		String[] queueNames = new String[queues.length];
+		for (int i = 0; i< queues.length; i++) {
+			queueNames[i] = queues[i].getName();
+		}
+		return this.removeQueueNames(queueNames);
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -456,40 +456,40 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
-	 * Add a queue to this container's list of queues. The existing consumers
+	 * Add queue(s) to this container's list of queues. The existing consumers
 	 * will be cancelled after they have processed any pre-fetched messages and
 	 * new consumers will be created. The queue must exist to avoid problems when
 	 * restarting the consumers.
 	 * @param queueName The queue to add.
 	 */
 	@Override
-	public void addQueueName(String queueName) {
-		super.addQueueName(queueName);
+	public void addQueueNames(String... queueName) {
+		super.addQueueNames(queueName);
 		this.queuesChanged();
 	}
 
 	/**
-	 * Add a queue to this container's list of queues. The existing consumers
+	 * Add queue(s) to this container's list of queues. The existing consumers
 	 * will be cancelled after they have processed any pre-fetched messages and
 	 * new consumers will be created. The queue must exist to avoid problems when
 	 * restarting the consumers.
 	 * @param queue The queue to add.
 	 */
 	@Override
-	public void addQueue(Queue queue) {
-		super.addQueue(queue);
+	public void addQueues(Queue... queue) {
+		super.addQueues(queue);
 		this.queuesChanged();
 	}
 
 	/**
-	 * Remove a queue from this container's list of queues. The existing consumers
+	 * Remove queues from this container's list of queues. The existing consumers
 	 * will be cancelled after they have processed any pre-fetched messages and
 	 * new consumers will be created. At least one queue must remain.
 	 * @param queueName The queue to remove.
 	 */
 	@Override
-	public boolean removeQueueName(String queueName) {
-		if (super.removeQueueName(queueName)) {
+	public boolean removeQueueNames(String... queueName) {
+		if (super.removeQueueNames(queueName)) {
 			this.queuesChanged();
 			return true;
 		}
@@ -499,14 +499,14 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
-	 * Remove a queue from this container's list of queues. The existing consumers
+	 * Remove queue(s) from this container's list of queues. The existing consumers
 	 * will be cancelled after they have processed any pre-fetched messages and
 	 * new consumers will be created. At least one queue must remain.
 	 * @param queue The queue to remove.
 	 */
 	@Override
-	public boolean removeQueue(Queue queue) {
-		if (super.removeQueue(queue)) {
+	public boolean removeQueues(Queue... queue) {
+		if (super.removeQueues(queue)) {
 			this.queuesChanged();
 			return true;
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -101,7 +101,7 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 			template.convertAndSend(queue.getName(), i + "foo");
 			template.convertAndSend(queue1.getName(), i + "foo");
 		}
-		container.addQueueName(queue1.getName());
+		container.addQueueNames(queue1.getName());
 		Thread.sleep(1100); // allow current consumer to time out and terminate
 		for (int i = 0; i < 10; i++) {
 			template.convertAndSend(queue.getName(), i + "foo");

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerLongTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerLongTests.java
@@ -95,7 +95,7 @@ public class SimpleMessageListenerContainerLongTests {
 		for (int i = 0; i < 20; i++) {
 			AnonymousQueue anonymousQueue = new AnonymousQueue();
 			admin.declareQueue(anonymousQueue);
-			container.addQueueName(anonymousQueue.getName());
+			container.addQueueNames(anonymousQueue.getName());
 			if (!container.isRunning()) {
 				container.start();
 			}

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -2209,9 +2209,9 @@ public RabbitTransactionManager rabbitTransactionManager() {
       was the case previously too, but now
       queues can be added and removed at runtime.
       The container will recycle (cancel and re-create) the consumers when any
-      pre-fetched messages have been processed. See methods <code>addQueue</code>,
-      <code>addQueueName</code>, <code>removeQueue</code> and
-      <code>removeQueueName</code>. When removing queues,
+      pre-fetched messages have been processed. See methods <code>addQueues</code>,
+      <code>addQueueNames</code>, <code>removeQueues</code> and
+      <code>removeQueueNames</code>. When removing queues,
       at least one queue must remain.
     </para>
     <para>


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/AMQP-378

Consumers are restarted when queue changes are made.

Currently only one queue can be added/removed at a time.

Change the method args to varargs and make the method names
plural.

Deprecate the singular methods - we have at least one user
using this feature from the snapshot. The deprecated methods
can be removed in 1.3 GA.
