### PR TITLE
AMQP-383 Fix Auto-Delete Queue Redeclaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ subprojects { subproject ->
 		mockitoVersion = '1.9.5'
 		rabbitmqVersion = '3.2.4'
 
-		springVersion = project.hasProperty('springVersion') ? project.springVersion : '3.2.7.RELEASE'
+		springVersion = project.hasProperty('springVersion') ? project.springVersion : '3.2.8.RELEASE'
 
 		springRetryVersion = '1.0.3.RELEASE'
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -30,10 +30,10 @@ import org.springframework.amqp.rabbit.connection.RabbitAccessor;
 import org.springframework.amqp.rabbit.connection.RabbitResourceHolder;
 import org.springframework.amqp.rabbit.connection.RabbitUtils;
 import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
@@ -49,7 +49,7 @@ import com.rabbitmq.client.Channel;
  * @author Gary Russell
  */
 public abstract class AbstractMessageListenerContainer extends RabbitAccessor
-		implements BeanFactoryAware, BeanNameAware, DisposableBean, SmartLifecycle {
+		implements ApplicationContextAware, BeanNameAware, DisposableBean, SmartLifecycle {
 
 	private volatile String beanName;
 
@@ -75,7 +75,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	private boolean initialized;
 
-	private volatile BeanFactory beanFactory;
+	private volatile ApplicationContext applicationContext;
 
 	/**
 	 * <p>
@@ -322,13 +322,13 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 		return this.beanName;
 	}
 
-	protected final BeanFactory getBeanFactory() {
-		return beanFactory;
+	protected final ApplicationContext getApplicationContext() {
+		return applicationContext;
 	}
 
 	@Override
-	public final void setBeanFactory(BeanFactory beanFactory) {
-		this.beanFactory = beanFactory;
+	public final void setApplicationContext(ApplicationContext applicationContext) {
+		this.applicationContext = applicationContext;
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.listener;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.test.BrokerRunning;
+import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * @author Gary Russell
+ * @since 1.3
+ *
+ */
+public class ListenFromAutoDeleteQueueTests {
+
+	@Rule
+	public BrokerRunning brokerIsRunning = BrokerRunning.isRunning();
+
+	private SimpleMessageListenerContainer listenerContainer;
+
+	private ConfigurableApplicationContext context;
+
+	private static BlockingQueue<Message> queue = new LinkedBlockingQueue<Message>();
+
+	@Before
+	public void setup() {
+		this.context = new ClassPathXmlApplicationContext(this.getClass().getSimpleName() + "-context.xml",
+				this.getClass());
+		this.listenerContainer = context.getBean(SimpleMessageListenerContainer.class);
+	}
+
+	@After
+	public void tearDown() {
+		if (this.context != null) {
+			this.context.close();
+		}
+	}
+
+	@Test
+	public void testStopStart() throws Exception {
+		RabbitTemplate template = context.getBean(RabbitTemplate.class);
+		template.convertAndSend("testContainerWithAutoDeleteQueues", "anon", "foo");
+		assertNotNull(queue.poll(10, TimeUnit.SECONDS));
+		this.listenerContainer.stop();
+		RabbitAdmin admin = spy(TestUtils.getPropertyValue(this.listenerContainer, "rabbitAdmin", RabbitAdmin.class));
+		new DirectFieldAccessor(this.listenerContainer).setPropertyValue("rabbitAdmin", admin);
+		this.listenerContainer.start();
+		template.convertAndSend("testContainerWithAutoDeleteQueues", "anon", "foo");
+		assertNotNull(queue.poll(10, TimeUnit.SECONDS));
+		verify(admin, times(1)).initialize(); // should only be called by one of the consumers
+	}
+
+	public static class Listener implements MessageListener {
+
+		@Override
+		public void onMessage(Message message) {
+			queue.add(message);
+		}
+
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -41,7 +41,7 @@ import org.springframework.amqp.rabbit.test.LongRunningIntegrationTest;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.DisposableBean;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.support.GenericApplicationContext;
 
 /**
  * @author Dave Syer
@@ -175,9 +175,10 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		container.setMessageListener(new MessageListenerAdapter(new PojoListener(latch)));
 		container.setQueueNames(queue.getName());
 		container.setConcurrentConsumers(2);
-		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
-		beanFactory.registerSingleton("foo", queue);
-		container.setBeanFactory(beanFactory);
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.getBeanFactory().registerSingleton("foo", queue);
+		context.refresh();
+		container.setApplicationContext(context);
 		container.afterPropertiesSet();
 		container.start();
 		for (int i = 0; i < 10; i++) {
@@ -200,9 +201,10 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		SimpleMessageListenerContainer container1 = new SimpleMessageListenerContainer(template.getConnectionFactory());
 		container1.setMessageListener(new MessageListenerAdapter(new PojoListener(latch1)));
 		container1.setQueueNames(queue.getName());
-		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
-		beanFactory.registerSingleton("foo", queue);
-		container1.setBeanFactory(beanFactory);
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.getBeanFactory().registerSingleton("foo", queue);
+		context.refresh();
+		container1.setApplicationContext(context);
 		container1.setExclusive(true);
 		container1.afterPropertiesSet();
 		container1.start();
@@ -215,7 +217,7 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		SimpleMessageListenerContainer container2 = new SimpleMessageListenerContainer(template.getConnectionFactory());
 		container2.setMessageListener(new MessageListenerAdapter(new PojoListener(latch2)));
 		container2.setQueueNames(queue.getName());
-		container2.setBeanFactory(beanFactory);
+		container2.setApplicationContext(context);
 		container2.setRecoveryInterval(500);
 		container2.setExclusive(true); // not really necessary, but likely people will make all consumers exlusive.
 		container2.afterPropertiesSet();

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+
+	<rabbit:connection-factory id="rabbitConnectionFactory" />
+
+	<rabbit:queue id="anon" />
+
+	<rabbit:direct-exchange name="testContainerWithAutoDeleteQueues" auto-delete="true">
+		<rabbit:bindings>
+			<rabbit:binding queue="anon" key="anon" />
+		</rabbit:bindings>
+	</rabbit:direct-exchange>
+
+	<rabbit:listener-container concurrency="2">
+		<rabbit:listener ref="foo" queues="anon" />
+	</rabbit:listener-container>
+
+	<rabbit:admin connection-factory="rabbitConnectionFactory" />
+
+	<bean id="foo" class="org.springframework.amqp.rabbit.listener.ListenFromAutoDeleteQueueTests$Listener" />
+
+	<rabbit:template id="template" connection-factory="rabbitConnectionFactory"/>
+
+</beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-383

When an auto-delete queue is removed by the broker, its
bindings are removed too. If the binding is the last one
for an auto-delete exchange, the exchange is deleted too.
If that exchange is bound to another exchange, its binding
is removed, etc, etc.

AMQP-373 only redeclares the queue and any upstream infrastructure
was not redeclared.

Added an integration test with an auto-delete exchange and queue.

Now, during container start, if an auto-delete queue is detected to
be missing, the entire `RabbitAdmin.initialize()` is invoked to
redeclare all context elements.
