### PR TITLE
AMQP-384 Fix Test

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/utils/test/TestUtils.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/utils/test/TestUtils.java
@@ -57,7 +57,9 @@ public class TestUtils {
 	@SuppressWarnings("unchecked")
 	public static <T> T getPropertyValue(Object root, String propertyPath, Class<T> type) {
 		Object value = getPropertyValue(root, propertyPath);
-		Assert.isAssignable(type, value.getClass());
+		if (value != null) {
+			Assert.isAssignable(type, value.getClass());
+		}
 		return (T) value;
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -534,7 +534,7 @@ public class SimpleMessageListenerContainerTests {
 				Set<?> consumers = TestUtils.getPropertyValue(container, "consumers", Map.class).keySet();
 				for (Object consumer : consumers) {
 					ChannelProxy channel = TestUtils.getPropertyValue(consumer, "channel", ChannelProxy.class);
-					if (channel.getTargetChannel() == mockChannel) {
+					if (channel != null && channel.getTargetChannel() == mockChannel) {
 						Consumer rabbitConsumer = TestUtils.getPropertyValue(consumer, "consumer", Consumer.class);
 						if (cancel) {
 							rabbitConsumer.handleCancelOk((String) invocation.getArguments()[0]);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-384
- `TestUtils.getPropertyValue()` (with type) NPE if the
  field is null
- When iterating over consumers to answer the consumeOk
  ignore consumers that don't have a channel yet
