### PR TITLE
AMQP-385 ErrorHandler and AmqpRejectAndDontRequeue

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1007,6 +1007,13 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					catch (ListenerExecutionFailedException ex) {
 						// Continue to process, otherwise re-throw
 					}
+					catch (AmqpRejectAndDontRequeueException rejectEx) {
+						/*
+						 *  These will normally be wrapped by an LEFE if thrown by the
+						 *  listener, but we will also honor it if thrown by an
+						 *  error handler.
+						 */
+					}
 				}
 
 			}

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -1769,9 +1769,11 @@ public Binding binding() {
     <classname>SimpleMessageListenerContainer</classname> you will also be
     able to inject a Spring <classname>ErrorHandler</classname> instance that
     can be used to react to an exception in the listener. The
-    <classname>ErrorHandler</classname> cannot prevent the exception from
-    eventually propagating, but it can be used to log or alert another
-    component that there is a problem.</para>
+    <classname>ErrorHandler</classname> can influence whether or not
+    the errant message is requeued by throwing a
+    <classname>AmqpRejectAndDontRequeueException</classname>. See
+    <xref linkend="async-listeners" /> for more information about this
+    exception.</para>
   </section>
 
   <section>
@@ -2473,7 +2475,7 @@ public StatefulRetryOperationsInterceptor interceptor() {
 
       <para>Or, you can throw a <classname>AmqpRejectAndDontRequeueException</classname>;
       this prevents message requeuing, regardless of the setting of the
-      rejectRequeued property.</para>
+      <code>defaultRequeueRejected</code> property.</para>
 
       <para>Often, a combination of both techniques will be used. Use a
       <classname>StatefulRetryOperationsInterceptor</classname> in the


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-385

Previously, if an ErrorHandler threw an AmqpRejectAndDontRequeueException,
the message was properly rejected but it caused the consumer to be aborted.

This caused problems when listening on auto-delete queues that are not
auto-declared by a RabbitAdmin.

Treat these exceptions as non-fatal for the consumer.
