### PR TITLE
AMQP-385 ErrorHandler and AmqpRejectAndDontRequeue

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -559,6 +559,13 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					} catch (ListenerExecutionFailedException ex) {
 						// Continue to process, otherwise re-throw
 					}
+					catch (AmqpRejectAndDontRequeueException rejectEx) {
+						/*
+						 *  These will normally be wrapped by an LEFE if thrown by the
+						 *  listener, but we will also honor it if thrown by an
+						 *  error handler.
+						 */
+					}
 				}
 
 			} catch (InterruptedException e) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -15,11 +15,16 @@ package org.springframework.amqp.rabbit.listener;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.contains;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -29,6 +34,8 @@ import org.apache.log4j.Level;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
@@ -40,6 +47,8 @@ import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.test.BrokerRunning;
 import org.springframework.amqp.rabbit.test.BrokerTestUtils;
 import org.springframework.amqp.rabbit.test.Log4jLevelAdjuster;
+import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.util.ErrorHandler;
 
@@ -71,6 +80,54 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 	@Before
 	public void setUp() {
 		reset(errorHandler);
+	}
+
+	@Test // AMQP-385
+	public void testErrorHandlerThrowsARADRE() throws Exception {
+		RabbitTemplate template = this.createTemplate(1);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(template.getConnectionFactory());
+		container.setQueues(queue);
+		final CountDownLatch messageReceived = new CountDownLatch(1);
+		final CountDownLatch spiedQLogger = new CountDownLatch(1);
+		final CountDownLatch errorHandled = new CountDownLatch(1);
+		container.setErrorHandler(new ErrorHandler() {
+
+			@Override
+			public void handleError(Throwable t) {
+				errorHandled.countDown();
+				throw new AmqpRejectAndDontRequeueException("foo", t);
+			}
+		});
+		container.setMessageListener(new MessageListener() {
+
+			@Override
+			public void onMessage(Message message) {
+				try {
+					messageReceived.countDown();
+					spiedQLogger.await(10, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				throw new RuntimeException("bar");
+			}
+		});
+		container.start();
+		Log logger = spy(TestUtils.getPropertyValue(container, "logger", Log.class));
+		new DirectFieldAccessor(container).setPropertyValue("logger", logger);
+		when(logger.isWarnEnabled()).thenReturn(true);
+		template.convertAndSend(queue.getName(), "baz");
+		assertTrue(messageReceived.await(10, TimeUnit.SECONDS));
+		Object consumer = TestUtils.getPropertyValue(container, "consumers", Set.class)
+				.iterator().next();
+		Log qLogger = spy(TestUtils.getPropertyValue(consumer, "logger", Log.class));
+		new DirectFieldAccessor(consumer).setPropertyValue("logger", qLogger);
+		when(qLogger.isDebugEnabled()).thenReturn(true);
+		spiedQLogger.countDown();
+		assertTrue(errorHandled.await(10, TimeUnit.SECONDS));
+		container.stop();
+		verify(logger, never()).warn(contains("Consumer raised exception"), any(Throwable.class));
+		verify(qLogger).debug(contains("Rejecting messages (requeue=false)"));
 	}
 
 	@Test
@@ -218,6 +275,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 			this.exception = exception;
 		}
 
+		@Override
 		public void onMessage(Message message) {
 			try {
 				String value = new String(message.getBody());
@@ -243,6 +301,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 			this.exception = exception;
 		}
 
+		@Override
 		public void onMessage(Message message, Channel channel) throws Exception {
 			try {
 				String value = new String(message.getBody());

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -1396,9 +1396,11 @@ public Binding binding() {
     <classname>SimpleMessageListenerContainer</classname> you will also be
     able to inject a Spring <classname>ErrorHandler</classname> instance that
     can be used to react to an exception in the listener. The
-    <classname>ErrorHandler</classname> cannot prevent the exception from
-    eventually propagating, but it can be used to log or alert another
-    component that there is a problem.</para>
+    <classname>ErrorHandler</classname> can influence whether or not
+    the errant message is requeued by throwing a
+    <classname>AmqpRejectAndDontRequeueException</classname>. See
+    <xref linkend="async-listeners" /> for more information about this
+    exception.</para>
   </section>
 
   <section>
@@ -1866,7 +1868,7 @@ public RabbitTransactionManager rabbitTransactionManager() {
 
       <para>Or, you can throw a <classname>AmqpRejectAndDontRequeueException</classname>;
       this prevents message requeuing, regardless of the setting of the
-      rejectRequeued property.</para>
+      <code>defaultRequeueRejected</code> property.</para>
 
       <para>Often, a combination of both techniques will be used. Use a
       <classname>StatefulRetryOperationsInterceptor</classname> in the


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-385

Previously, if an ErrorHandler threw an AmqpRejectAndDontRequeueException,
the message was properly rejected but it caused the consumer to be aborted.

This caused problems when listening on auto-delete queues that are not
auto-declared by a RabbitAdmin.

Treat these exceptions as non-fatal for the consumer.

Conflicts:

```
spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
```

Resolved.
