### PR TITLE
Remove overlapping test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,9 @@ subprojects { subproject ->
 	// dependencies that are common across all java projects
 	dependencies {
 		testCompile "cglib:cglib-nodep:$cglibVersion"
-		testCompile "junit:junit-dep:$junitVersion"
+		testCompile ("junit:junit:$junitVersion") {
+			exclude group: 'org.hamcrest'
+		}
 		testCompile ("log4j:log4j:$log4jVersion") {
 			exclude group: 'javax.jms', module: 'jms'
 			exclude group: 'com.sun.jdmk', module: 'jmxtools'
@@ -96,7 +98,9 @@ subprojects { subproject ->
 		}
 
 		testCompile "org.hamcrest:hamcrest-all:$hamcrestVersion"
-		testCompile "org.mockito:mockito-all:$mockitoVersion"
+		testCompile ("org.mockito:mockito-core:$mockitoVersion") {
+			exclude group: 'org.hamcrest'
+		}
 		testCompile "org.springframework:spring-test:$springVersion"
 
 		jacoco group: "org.jacoco", name: "org.jacoco.agent", version: "0.5.6.201201232323", classifier: "runtime"


### PR DESCRIPTION
Previously, the test classpath of each project contained multiple copies of a number of Hamcrest classes. This PR adds some exclusions to remove the overlapping dependencies so that the test classpath contains a single source for each Hamcrest class.
