### PR TITLE
Fix for prefetch count = 0 in BlockingQueueConsumer when consuming after...

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -61,6 +61,7 @@ import com.rabbitmq.utility.Utility;
  * @author Mark Pollack
  * @author Dave Syer
  * @author Gary Russell
+ * @author Casper Mout
  *
  */
 public class BlockingQueueConsumer {


### PR DESCRIPTION
AMQP-396 Prefetch count = 0 after passive declare failure in BlockingQueueConsumer
