### PR TITLE
AMQP-395 Restore Exception Logging

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
@@ -62,6 +62,9 @@ public final class ConditionalRejectingErrorHandler implements ErrorHandler {
 
 	@Override
 	public void handleError(Throwable t) {
+		if (logger.isWarnEnabled()) {
+			logger.warn("Execution of Rabbit message listener failed.", t);
+		}
 		if (!this.causeChainContainsARADRE(t) && this.exceptionStrategy.isFatal(t)) {
 			throw new AmqpRejectAndDontRequeueException("Error Handler converted exception to fatal", t);
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-395

Adding a default error handler (to allow conversion
to a reject and don't requeue exception when there
is a conversion error) suppressed the WARN log
when the listener threw an exception.

Restore the log by logging in the default error handler.
