### PR TITLE
AMQP-397 Explicit 'localhost' For All Tests

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MismatchedQueueDeclarationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MismatchedQueueDeclarationTests.java
@@ -54,6 +54,7 @@ public class MismatchedQueueDeclarationTests {
 	@Before
 	public void setup() throws Exception {
 		connectionFactory = new SingleConnectionFactory();
+		connectionFactory.setHost("localhost");
 		this.admin = new RabbitAdmin(this.connectionFactory);
 		deleteQueues();
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/QueueParserIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/QueueParserIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -56,6 +57,7 @@ public final class QueueParserIntegrationTests {
 		Queue queue = beanFactory.getBean("arguments", Queue.class);
 		assertNotNull(queue);
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory(BrokerTestUtils.getPort());
+		connectionFactory.setHost("localhost");
 		RabbitTemplate template = new RabbitTemplate(connectionFactory);
 		RabbitAdmin rabbitAdmin = new RabbitAdmin(template.getConnectionFactory());
 		rabbitAdmin.deleteQueue(queue.getName());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
@@ -60,6 +60,7 @@ import com.rabbitmq.client.ShutdownSignalException;
 /**
  * @author Dave Syer
  * @author Gunnar Hillert
+ * @author Gary Russell
  * @since 1.0
  *
  */
@@ -78,6 +79,7 @@ public class CachingConnectionFactoryIntegrationTests {
 	@Before
 	public void open() {
 		connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -63,6 +63,7 @@ public class RabbitAdminIntegrationTests {
 
 	@Before
 	public void init() {
+		connectionFactory.setHost("localhost");
 		context = new GenericApplicationContext();
 		context.refresh();
 		rabbitAdmin = new RabbitAdmin(connectionFactory);
@@ -96,8 +97,10 @@ public class RabbitAdminIntegrationTests {
 	public void testDoubleDeclarationOfExclusiveQueue() throws Exception {
 		// Expect exception because the queue is locked when it is declared a second time.
 		CachingConnectionFactory connectionFactory1 = new CachingConnectionFactory();
+		connectionFactory1.setHost("localhost");
 		connectionFactory1.setPort(BrokerTestUtils.getPort());
 		CachingConnectionFactory connectionFactory2 = new CachingConnectionFactory();
+		connectionFactory2.setHost("localhost");
 		connectionFactory2.setPort(BrokerTestUtils.getPort());
 		Queue queue = new Queue("test.queue", false, true, true);
 		rabbitAdmin.deleteQueue(queue.getName());
@@ -116,8 +119,10 @@ public class RabbitAdminIntegrationTests {
 		// No error expected here: the queue is autodeleted when the last consumer is cancelled, but this one never has
 		// any consumers.
 		CachingConnectionFactory connectionFactory1 = new CachingConnectionFactory();
+		connectionFactory1.setHost("localhost");
 		connectionFactory1.setPort(BrokerTestUtils.getPort());
 		CachingConnectionFactory connectionFactory2 = new CachingConnectionFactory();
+		connectionFactory2.setHost("localhost");
 		connectionFactory2.setPort(BrokerTestUtils.getPort());
 		Queue queue = new Queue("test.queue", false, false, true);
 		new RabbitAdmin(connectionFactory1).declareQueue(queue);
@@ -328,6 +333,7 @@ public class RabbitAdminIntegrationTests {
 	 */
 	private boolean queueExists(final Queue queue) throws Exception {
 		ConnectionFactory connectionFactory = new ConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		Connection connection = connectionFactory.newConnection();
 		Channel channel = connection.createChannel();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
@@ -83,6 +83,7 @@ public class RabbitAdminTests {
 	@Test
 	public void testProperties() throws Exception {
 		SingleConnectionFactory connectionFactory = new SingleConnectionFactory();
+		connectionFactory.setHost("localhost");
 		RabbitAdmin rabbitAdmin = new RabbitAdmin(connectionFactory);
 		String queueName = "test.properties." + System.currentTimeMillis();
 		try {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitBindingIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitBindingIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -56,6 +56,7 @@ public class RabbitBindingIntegrationTests {
 	@Before
 	public void setup() {
 		connectionFactory = new CachingConnectionFactory(BrokerTestUtils.getPort());
+		connectionFactory.setHost("localhost");
 		template = new RabbitTemplate(connectionFactory);
 	}
 
@@ -77,6 +78,7 @@ public class RabbitBindingIntegrationTests {
 		admin.declareBinding(BindingBuilder.bind(queue).to(exchange).with("*.end"));
 
 		template.execute(new ChannelCallback<Void>() {
+			@Override
 			public Void doInRabbit(Channel channel) throws Exception {
 
 				BlockingQueueConsumer consumer = createConsumer(template);
@@ -116,6 +118,7 @@ public class RabbitBindingIntegrationTests {
 		admin.declareBinding(BindingBuilder.bind(queue).to(exchange).with("*.end"));
 
 		template.execute(new ChannelCallback<Void>() {
+			@Override
 			public Void doInRabbit(Channel channel) throws Exception {
 
 				BlockingQueueConsumer consumer = createConsumer(template);
@@ -156,10 +159,12 @@ public class RabbitBindingIntegrationTests {
 		admin.declareBinding(BindingBuilder.bind(queue).to(exchange).with("*.end"));
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory();
+		cachingConnectionFactory.setHost("localhost");
 		final RabbitTemplate template = new RabbitTemplate(cachingConnectionFactory);
 		template.setExchange(exchange.getName());
 
 		BlockingQueueConsumer consumer = template.execute(new ChannelCallback<BlockingQueueConsumer>() {
+			@Override
 			public BlockingQueueConsumer doInRabbit(Channel channel) throws Exception {
 
 				BlockingQueueConsumer consumer = createConsumer(template);
@@ -195,6 +200,7 @@ public class RabbitBindingIntegrationTests {
 		admin.declareBinding(BindingBuilder.bind(queue).to(exchange).with("*.end"));
 
 		template.execute(new ChannelCallback<Void>() {
+			@Override
 			public Void doInRabbit(Channel channel) throws Exception {
 
 				BlockingQueueConsumer consumer = createConsumer(template);
@@ -215,6 +221,7 @@ public class RabbitBindingIntegrationTests {
 		});
 
 		template.execute(new ChannelCallback<Void>() {
+			@Override
 			public Void doInRabbit(Channel channel) throws Exception {
 
 				BlockingQueueConsumer consumer = createConsumer(template);
@@ -247,6 +254,7 @@ public class RabbitBindingIntegrationTests {
 		admin.declareBinding(BindingBuilder.bind(queue).to(exchange));
 
 		template.execute(new ChannelCallback<Void>() {
+			@Override
 			public Void doInRabbit(Channel channel) throws Exception {
 
 				BlockingQueueConsumer consumer = createConsumer(template);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -99,6 +99,7 @@ public class RabbitTemplateIntegrationTests {
 	@Before
 	public void create() {
 		final CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template = new RabbitTemplate(connectionFactory);
 	}
@@ -166,7 +167,7 @@ public class RabbitTemplateIntegrationTests {
 
 	@Test
 	public void testSendAndReceiveTransactedWithUncachedConnection() throws Exception {
-		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory();
+		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory("localhost");
 		RabbitTemplate template = new RabbitTemplate(singleConnectionFactory);
 		template.setChannelTransacted(true);
 		template.convertAndSend(ROUTE, "message");
@@ -345,6 +346,7 @@ public class RabbitTemplateIntegrationTests {
 	@Test
 	public void testAtomicSendAndReceive() throws Exception {
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory();
+		cachingConnectionFactory.setHost("localhost");
 		final RabbitTemplate template = new RabbitTemplate(cachingConnectionFactory);
 		template.setRoutingKey(ROUTE);
 		template.setQueue(ROUTE);
@@ -382,6 +384,7 @@ public class RabbitTemplateIntegrationTests {
 	@Test
 	public void testAtomicSendAndReceiveExternalExecutor() throws Exception {
 		final CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
 		final String execName = "make-sure-exec-passed-in";
 		exec.setBeanName(execName);
@@ -457,6 +460,7 @@ public class RabbitTemplateIntegrationTests {
 	@Test
 	public void testAtomicSendAndReceiveWithRoutingKey() throws Exception {
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory();
+		cachingConnectionFactory.setHost("localhost");
 		final RabbitTemplate template = new RabbitTemplate(cachingConnectionFactory);
 		ExecutorService executor = Executors.newFixedThreadPool(1);
 		// Set up a consumer to respond to our producer
@@ -492,6 +496,7 @@ public class RabbitTemplateIntegrationTests {
 	@Test
 	public void testAtomicSendAndReceiveWithExchangeAndRoutingKey() throws Exception {
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory();
+		cachingConnectionFactory.setHost("localhost");
 		final RabbitTemplate template = new RabbitTemplate(cachingConnectionFactory);
 		ExecutorService executor = Executors.newFixedThreadPool(1);
 		// Set up a consumer to respond to our producer
@@ -527,6 +532,7 @@ public class RabbitTemplateIntegrationTests {
 	@Test
 	public void testAtomicSendAndReceiveWithConversion() throws Exception {
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory();
+		cachingConnectionFactory.setHost("localhost");
 		final RabbitTemplate template = new RabbitTemplate(cachingConnectionFactory);
 		template.setRoutingKey(ROUTE);
 		template.setQueue(ROUTE);
@@ -622,6 +628,7 @@ public class RabbitTemplateIntegrationTests {
 	@Test
 	public void testAtomicSendAndReceiveWithConversionAndMessagePostProcessor() throws Exception {
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory();
+		cachingConnectionFactory.setHost("localhost");
 		final RabbitTemplate template = new RabbitTemplate(cachingConnectionFactory);
 		template.setRoutingKey(ROUTE);
 		template.setQueue(ROUTE);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePerformanceIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePerformanceIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 the original author or authors.
+ * Copyright 2010-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -71,6 +71,7 @@ public class RabbitTemplatePerformanceIntegrationTests {
 			return;
 		}
 		connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(repeat.getConcurrency());
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);
@@ -116,6 +117,7 @@ public class RabbitTemplatePerformanceIntegrationTests {
 	public void testSendAndReceiveExternalTransacted() throws Exception {
 		template.setChannelTransacted(true);
 		new TransactionTemplate(new TestTransactionManager()).execute(new TransactionCallback<Void>() {
+			@Override
 			public Void doInTransaction(TransactionStatus status) {
 				template.convertAndSend(ROUTE, "message");
 				return null;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
@@ -87,9 +87,11 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 	@Before
 	public void create() {
 		connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(1);
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		connectionFactoryWithConfirmsEnabled = new CachingConnectionFactory();
+		connectionFactoryWithConfirmsEnabled.setHost("localhost");
 		// When using publisher confirms, the cache size needs to be large enough
 		// otherwise channels can be closed before confirms are received.
 		connectionFactoryWithConfirmsEnabled.setChannelCacheSize(10);
@@ -97,6 +99,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		connectionFactoryWithConfirmsEnabled.setPublisherConfirms(true);
 		templateWithConfirmsEnabled = new RabbitTemplate(connectionFactoryWithConfirmsEnabled);
 		connectionFactoryWithReturnsEnabled = new CachingConnectionFactory();
+		connectionFactoryWithReturnsEnabled.setHost("localhost");
 		connectionFactoryWithReturnsEnabled.setChannelCacheSize(1);
 		connectionFactoryWithReturnsEnabled.setPort(BrokerTestUtils.getPort());
 		connectionFactoryWithReturnsEnabled.setPublisherReturns(true);
@@ -126,6 +129,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		templateWithConfirmsEnabled.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				latch.countDown();
 			}
@@ -140,6 +144,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final CountDownLatch latch = new CountDownLatch(2);
 		templateWithConfirmsEnabled.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				latch.countDown();
 			}
@@ -150,8 +155,10 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		//Thread 1
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 
+			@Override
 			public void run() {
 				templateWithConfirmsEnabled.execute(new ChannelCallback<Object>() {
+					@Override
 					public Object doInRabbit(Channel channel) throws Exception {
 						try {
 							threadLatch.await(10, TimeUnit.SECONDS);
@@ -180,6 +187,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final CountDownLatch latch2 = new CountDownLatch(1);
 		templateWithConfirmsEnabled.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				latch1.countDown();
 			}
@@ -188,6 +196,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		RabbitTemplate secondTemplate = new RabbitTemplate(connectionFactoryWithConfirmsEnabled);
 		secondTemplate.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				latch2.countDown();
 			}
@@ -204,6 +213,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final List<Message> returns = new ArrayList<Message>();
 		templateWithReturnsEnabled.setReturnCallback(new ReturnCallback() {
+			@Override
 			public void returnedMessage(Message message, int replyCode,
 					String replyText, String exchange, String routingKey) {
 				returns.add(message);
@@ -233,6 +243,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final AtomicBoolean confirmed = new AtomicBoolean();
 		template.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				confirmed.set(true);
 			}
@@ -262,6 +273,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final AtomicBoolean confirmed = new AtomicBoolean();
 		template.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				confirmed.set(true);
 			}
@@ -273,8 +285,10 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		//Thread 1
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 
+			@Override
 			public void run() {
 				template.execute(new ChannelCallback<Object>() {
+					@Override
 					public Object doInRabbit(Channel channel) throws Exception {
 						try {
 							threadLatch.await(10, TimeUnit.SECONDS);
@@ -326,6 +340,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 
 		final AtomicInteger count = new AtomicInteger();
 		doAnswer(new Answer<Object>(){
+			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return count.incrementAndGet();
 			}}).when(mockChannel).getNextPublishSeqNo();
@@ -335,6 +350,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final AtomicBoolean confirmed = new AtomicBoolean();
 		template.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				confirmed.set(true);
 			}
@@ -366,6 +382,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 
 		final AtomicInteger count = new AtomicInteger();
 		doAnswer(new Answer<Object>(){
+			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return count.incrementAndGet();
 			}}).when(mockChannel).getNextPublishSeqNo();
@@ -376,6 +393,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final CountDownLatch latch = new CountDownLatch(2);
 		template.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				if (ack) {
 					confirms.add(correlationData.getId());
@@ -409,6 +427,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 
 		final AtomicInteger count = new AtomicInteger();
 		doAnswer(new Answer<Object>(){
+			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return count.incrementAndGet();
 			}}).when(mockChannel).getNextPublishSeqNo();
@@ -419,6 +438,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final CountDownLatch latch1 = new CountDownLatch(1);
 		template1.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				if (ack) {
 					confirms.add(correlationData.getId() + "1");
@@ -431,6 +451,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final CountDownLatch latch2 = new CountDownLatch(1);
 		template2.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				if (ack) {
 					confirms.add(correlationData.getId() + "2");
@@ -483,6 +504,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final AtomicInteger acks = new AtomicInteger();
 		template.setConfirmCallback(new ConfirmCallback() {
 
+			@Override
 			public void confirm(CorrelationData correlationData, boolean ack) {
 				try {
 					startedProcessingMultiAcksLatch.countDown();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 the original author or authors.
+ * Copyright 2010-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNull;
 import org.apache.log4j.Level;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
@@ -49,6 +50,7 @@ public class BlockingQueueConsumerIntegrationTests {
 
 		RabbitTemplate template = new RabbitTemplate();
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/JavaConfigFixedReplyQueueTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/JavaConfigFixedReplyQueueTests.java
@@ -74,7 +74,9 @@ public class JavaConfigFixedReplyQueueTests {
 
 		@Bean
 		public ConnectionFactory rabbitConnectionFactory() {
-			return new CachingConnectionFactory();
+			CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+			connectionFactory.setHost("localhost");
+			return connectionFactory;
 		}
 
 		/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerBrokerInterruptionIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerBrokerInterruptionIntegrationTests.java
@@ -105,6 +105,7 @@ public class MessageListenerBrokerInterruptionIntegrationTests {
 	public void createConnectionFactory() {
 		if (environment.isActive()) {
 			CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+			connectionFactory.setHost("localhost");
 			connectionFactory.setChannelCacheSize(concurrentConsumers);
 			connectionFactory.setPort(BrokerTestUtils.getAdminPort());
 			this.connectionFactory = connectionFactory;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -321,6 +321,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		RabbitTemplate template = new RabbitTemplate();
 		// SingleConnectionFactory connectionFactory = new SingleConnectionFactory();
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(concurrentConsumers);
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerLifecycleIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerLifecycleIntegrationTests.java
@@ -125,6 +125,7 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 	private RabbitTemplate createTemplate(int concurrentConsumers) {
 		RabbitTemplate template = new RabbitTemplate();
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(concurrentConsumers);
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);
@@ -383,6 +384,7 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 	@Test
 	public void testSimpleMessageListenerContainerStoppedWithoutWarn() throws Exception {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerMultipleQueueIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerMultipleQueueIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Level;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -42,6 +41,7 @@ import org.springframework.amqp.support.converter.SimpleMessageConverter;
 /**
  * @author Mark Fisher
  * @author Gunnar Hillert
+ * @author Gary Russell
  */
 public class MessageListenerContainerMultipleQueueIntegrationTests {
 
@@ -68,6 +68,7 @@ public class MessageListenerContainerMultipleQueueIntegrationTests {
 	@Test
 	public void testMultipleQueues() {
 		doTest(1, new ContainerConfigurer() {
+			@Override
 			public void configure(SimpleMessageListenerContainer container) {
 				container.setQueues(queue1, queue2);
 			}
@@ -77,6 +78,7 @@ public class MessageListenerContainerMultipleQueueIntegrationTests {
 	@Test
 	public void testMultipleQueueNames() {
 		doTest(1, new ContainerConfigurer() {
+			@Override
 			public void configure(SimpleMessageListenerContainer container) {
 				container.setQueueNames(queue1.getName(), queue2.getName());
 			}
@@ -86,6 +88,7 @@ public class MessageListenerContainerMultipleQueueIntegrationTests {
 	@Test
 	public void testMultipleQueuesWithConcurrentConsumers() {
 		doTest(3, new ContainerConfigurer() {
+			@Override
 			public void configure(SimpleMessageListenerContainer container) {
 				container.setQueues(queue1, queue2);
 			}
@@ -95,6 +98,7 @@ public class MessageListenerContainerMultipleQueueIntegrationTests {
 	@Test
 	public void testMultipleQueueNamesWithConcurrentConsumers() {
 		doTest(3, new ContainerConfigurer() {
+			@Override
 			public void configure(SimpleMessageListenerContainer container) {
 				container.setQueueNames(queue1.getName(), queue2.getName());
 			}
@@ -106,6 +110,7 @@ public class MessageListenerContainerMultipleQueueIntegrationTests {
 		int messageCount = 10;
 		RabbitTemplate template = new RabbitTemplate();
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(concurrentConsumers);
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);
@@ -156,7 +161,7 @@ public class MessageListenerContainerMultipleQueueIntegrationTests {
 	@SuppressWarnings("unused")
 	private static class PojoListener {
 
-		private AtomicInteger count = new AtomicInteger();
+		private final AtomicInteger count = new AtomicInteger();
 
 		private final CountDownLatch latch;
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerRetryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerRetryIntegrationTests.java
@@ -89,6 +89,7 @@ public class MessageListenerContainerRetryIntegrationTests {
 	private RabbitTemplate createTemplate(int concurrentConsumers) {
 		RabbitTemplate template = new RabbitTemplate();
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(concurrentConsumers);
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerManualAckIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerManualAckIntegrationTests.java
@@ -76,6 +76,7 @@ public class MessageListenerManualAckIntegrationTests {
 	@Before
 	public void createConnectionFactory() {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(concurrentConsumers);
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryCachingConnectionIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryCachingConnectionIntegrationTests.java
@@ -90,6 +90,7 @@ public class MessageListenerRecoveryCachingConnectionIntegrationTests {
 
 	protected ConnectionFactory createConnectionFactory() {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(concurrentConsumers);
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		return connectionFactory;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryRepeatIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryRepeatIntegrationTests.java
@@ -137,6 +137,7 @@ public class MessageListenerRecoveryRepeatIntegrationTests {
 
 	private ConnectionFactory createConnectionFactory() {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(concurrentConsumers);
 		// connectionFactory.setPort(BrokerTestUtils.getTracerPort());
 		connectionFactory.setPort(BrokerTestUtils.getPort());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoverySingleConnectionIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoverySingleConnectionIntegrationTests.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.springframework.amqp.rabbit.listener;
 
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -6,8 +18,10 @@ import org.springframework.amqp.rabbit.test.BrokerTestUtils;
 
 public class MessageListenerRecoverySingleConnectionIntegrationTests extends MessageListenerRecoveryCachingConnectionIntegrationTests {
 
+	@Override
 	protected ConnectionFactory createConnectionFactory() {
 		SingleConnectionFactory connectionFactory = new SingleConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		return connectionFactory;
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerTxSizeIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerTxSizeIntegrationTests.java
@@ -76,6 +76,7 @@ public class MessageListenerTxSizeIntegrationTests {
 	@Before
 	public void createConnectionFactory() {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(concurrentConsumers);
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -73,6 +73,7 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 	@Before
 	public void declareQueues() {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);
 		admin = new RabbitAdmin(connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -56,6 +56,7 @@ import com.rabbitmq.client.Channel;
 /**
  * @author Dave Syer
  * @author Gunnar Hillert
+ * @author Gary Russell
  * @since 1.0
  *
  */
@@ -151,6 +152,7 @@ public class SimpleMessageListenerContainerIntegrationTests {
 	@Before
 	public void declareQueue() {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		connectionFactory.setChannelCacheSize(concurrentConsumers);
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		template.setConnectionFactory(connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerLongTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerLongTests.java
@@ -52,7 +52,7 @@ public class SimpleMessageListenerContainerLongTests {
 
 	@Test
 	public void testChangeConsumerCount() throws Exception {
-		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory();
+		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory("localhost");
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(singleConnectionFactory);
 		container.setMessageListener(new MessageListenerAdapter(this));
 		container.setQueueNames("foo");
@@ -80,7 +80,7 @@ public class SimpleMessageListenerContainerLongTests {
 
 	@Test
 	public void testAddQueuesAndStartInCycle() throws Exception {
-		final SingleConnectionFactory connectionFactory = new SingleConnectionFactory();
+		final SingleConnectionFactory connectionFactory = new SingleConnectionFactory("localhost");
 		final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		container.setMessageListener(new MessageListener() {
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -87,7 +87,7 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testInconsistentTransactionConfiguration() throws Exception {
-		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory();
+		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory("localhost");
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(singleConnectionFactory);
 		container.setMessageListener(new MessageListenerAdapter(this));
 		container.setQueueNames("foo");
@@ -101,7 +101,7 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testInconsistentAcknowledgeConfiguration() throws Exception {
-		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory();
+		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory("localhost");
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(singleConnectionFactory);
 		container.setMessageListener(new MessageListenerAdapter(this));
 		container.setQueueNames("foo");
@@ -114,7 +114,7 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testDefaultConsumerCount() throws Exception {
-		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory();
+		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory("localhost");
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(singleConnectionFactory);
 		container.setMessageListener(new MessageListenerAdapter(this));
 		container.setQueueNames("foo");
@@ -126,7 +126,7 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testLazyConsumerCount() throws Exception {
-		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory();
+		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory("localhost");
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(singleConnectionFactory) {
 			@Override
 			protected void doStart() throws Exception {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerWithRabbitMQ.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerWithRabbitMQ.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.springframework.amqp.rabbit.listener;
 
 import static org.junit.Assert.assertNotNull;
@@ -27,6 +39,7 @@ public class SimpleMessageListenerWithRabbitMQ {
 
 	public static void main(String[] args) throws InterruptedException {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory("localhost");
+		connectionFactory.setHost("localhost");
 		connectionFactory.setUsername("guest");
 		connectionFactory.setPassword("guest");
 		assertNotNull(connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderConfiguration.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 by the original author(s).
+ * Copyright (c) 2011-2014 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,60 +35,62 @@ import org.springframework.context.annotation.Scope;
 @Configuration
 public class AmqpAppenderConfiguration {
 
-  static {
-    //DOMConfigurator.configure(AmqpAppenderTests.class.getResource("/log4j.xml"));
-  }
+	static {
+		// DOMConfigurator.configure(AmqpAppenderTests.class.getResource("/log4j.xml"));
+	}
 
-  static final String QUEUE = "amqp.appender.test";
-  static final String EXCHANGE = "logs";
-  static final String ROUTING_KEY = "AmqpAppenderTest.#";
+	static final String QUEUE = "amqp.appender.test";
 
-  @Bean
-  public SingleConnectionFactory connectionFactory() {
-    return new SingleConnectionFactory();
-  }
+	static final String EXCHANGE = "logs";
 
-  @Bean
-  public TopicExchange testExchange() {
-    return new TopicExchange(EXCHANGE, true, false);
-  }
+	static final String ROUTING_KEY = "AmqpAppenderTest.#";
 
-  @Bean
-  public Queue testQueue() {
-    return new Queue(QUEUE);
-  }
+	@Bean
+	public SingleConnectionFactory connectionFactory() {
+		return new SingleConnectionFactory("localhost");
+	}
 
-  @Bean
-  public Binding testBinding() {
-    return BindingBuilder.bind(testQueue()).to(testExchange()).with(ROUTING_KEY);
-  }
+	@Bean
+	public TopicExchange testExchange() {
+		return new TopicExchange(EXCHANGE, true, false);
+	}
 
-  @Bean
-  public RabbitAdmin rabbitAdmin() {
-    return new RabbitAdmin(connectionFactory());
-  }
+	@Bean
+	public Queue testQueue() {
+		return new Queue(QUEUE);
+	}
 
-  @Bean
-  @Scope(BeanDefinition.SCOPE_PROTOTYPE)
-  public SimpleMessageListenerContainer listenerContainer() {
-    SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory());
-    Queue q = testQueue();
+	@Bean
+	public Binding testBinding() {
+		return BindingBuilder.bind(testQueue()).to(testExchange()).with(ROUTING_KEY);
+	}
 
-    RabbitAdmin admin = rabbitAdmin();
-    admin.declareQueue(q);
-    admin.declareBinding(testBinding());
+	@Bean
+	public RabbitAdmin rabbitAdmin() {
+		return new RabbitAdmin(connectionFactory());
+	}
 
-    container.setQueues(q);
-    //container.setMessageListener(testListener(4));
-    container.setAutoStartup(false);
-    container.setAcknowledgeMode(AcknowledgeMode.AUTO);
+	@Bean
+	@Scope(BeanDefinition.SCOPE_PROTOTYPE)
+	public SimpleMessageListenerContainer listenerContainer() {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory());
+		Queue q = testQueue();
 
-    return container;
-  }
+		RabbitAdmin admin = rabbitAdmin();
+		admin.declareQueue(q);
+		admin.declareBinding(testBinding());
 
-  @Bean
-  @Scope(BeanDefinition.SCOPE_PROTOTYPE)
-  public TestListener testListener(int count) {
-    return new TestListener(count);
-  }
+		container.setQueues(q);
+		// container.setMessageListener(testListener(4));
+		container.setAutoStartup(false);
+		container.setAcknowledgeMode(AcknowledgeMode.AUTO);
+
+		return container;
+	}
+
+	@Bean
+	@Scope(BeanDefinition.SCOPE_PROTOTYPE)
+	public TestListener testListener(int count) {
+		return new TestListener(count);
+	}
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AnnotationConfigContextLoader.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AnnotationConfigContextLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 by the original author(s).
+ * Copyright (c) 2011-2014 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,13 @@ import org.springframework.test.context.ContextLoader;
  * @author Jon Brisbin <jbrisbin@vmware.com>
  */
 public class AnnotationConfigContextLoader implements ContextLoader {
-  public String[] processLocations(Class<?> clazz, String... locations) {
-    return locations;
-  }
+	@Override
+	public String[] processLocations(Class<?> clazz, String... locations) {
+		return locations;
+	}
 
-  public ApplicationContext loadContext(String... locations) throws Exception {
-    return new AnnotationConfigApplicationContext(locations);
-  }
+	@Override
+	public ApplicationContext loadContext(String... locations) throws Exception {
+		return new AnnotationConfigApplicationContext(locations);
+	}
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/TestListener.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/TestListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 by the original author(s).
+ * Copyright (c) 2011-2014 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.amqp.rabbit.log4j;
 
 import java.util.concurrent.CountDownLatch;
@@ -28,41 +27,42 @@ import org.springframework.amqp.core.MessageProperties;
  */
 public class TestListener implements MessageListener {
 
-  private final CountDownLatch latch;
+	private final CountDownLatch latch;
 
-  private volatile Message message;
+	private volatile Message message;
 
-  public TestListener(int count) {
-    latch = new CountDownLatch(count);
-  }
-
-  public CountDownLatch getLatch() {
-    return latch;
-  }
-
-  public Message getMessage() {
-	return message;
-  }
-
-  public Object getId() {
-	if (this.message == null || this.getMessageProperties() == null) {
-		throw new IllegalStateException("No MessageProperties received");
+	public TestListener(int count) {
+		latch = new CountDownLatch(count);
 	}
-	return this.message.getMessageProperties().getMessageId();
-  }
 
-  public MessageProperties getMessageProperties() {
-    if (this.message == null) {
-      throw new IllegalStateException("No Message received");
-    }
-    return this.message.getMessageProperties();
-  }
+	public CountDownLatch getLatch() {
+		return latch;
+	}
 
-  public void onMessage(Message message) {
-    System.out.println("MESSAGE: " + message);
-    System.out.println("BODY: " + new String(message.getBody()));
-    this.message = message;
-    latch.countDown();
-  }
+	public Message getMessage() {
+		return message;
+	}
+
+	public Object getId() {
+		if (this.message == null || this.getMessageProperties() == null) {
+			throw new IllegalStateException("No MessageProperties received");
+		}
+		return this.message.getMessageProperties().getMessageId();
+	}
+
+	public MessageProperties getMessageProperties() {
+		if (this.message == null) {
+			throw new IllegalStateException("No Message received");
+		}
+		return this.message.getMessageProperties();
+	}
+
+	@Override
+	public void onMessage(Message message) {
+		System.out.println("MESSAGE: " + message);
+		System.out.println("BODY: " + new String(message.getBody()));
+		this.message = message;
+		latch.countDown();
+	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/MissingIdRetryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/MissingIdRetryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.aopalliance.aop.Advice;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.config.StatefulRetryOperationsInterceptorFactoryBean;
@@ -34,7 +35,7 @@ import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.test.BrokerRunning;
 import org.springframework.beans.DirectFieldAccessor;
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.retry.policy.MapRetryContextCache;
 import org.springframework.retry.policy.RetryContextCache;
@@ -57,7 +58,7 @@ public class MissingIdRetryTests {
 	public void testWithNoId() throws Exception {
 		// 2 messsages; each retried once by missing id interceptor
 		this.latch = new CountDownLatch(4);
-		ApplicationContext ctx = new ClassPathXmlApplicationContext("retry-context.xml", this.getClass());
+		ConfigurableApplicationContext ctx = new ClassPathXmlApplicationContext("retry-context.xml", this.getClass());
 		RabbitTemplate template = ctx.getBean(RabbitTemplate.class);
 		ConnectionFactory connectionFactory = ctx.getBean(ConnectionFactory.class);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
@@ -86,6 +87,7 @@ public class MissingIdRetryTests {
 		Thread.sleep(2000);
 		assertEquals(0, ((Map) new DirectFieldAccessor(cache).getPropertyValue("map")).size());
 		container.stop();
+		ctx.close();
 	}
 
 	@SuppressWarnings("rawtypes")
@@ -93,7 +95,7 @@ public class MissingIdRetryTests {
 	public void testWithId() throws Exception {
 		// 2 messsages; each retried twice by retry interceptor
 		this.latch = new CountDownLatch(6);
-		ApplicationContext ctx = new ClassPathXmlApplicationContext("retry-context.xml", this.getClass());
+		ConfigurableApplicationContext ctx = new ClassPathXmlApplicationContext("retry-context.xml", this.getClass());
 		RabbitTemplate template = ctx.getBean(RabbitTemplate.class);
 		ConnectionFactory connectionFactory = ctx.getBean(ConnectionFactory.class);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
@@ -127,11 +129,11 @@ public class MissingIdRetryTests {
 		Thread.sleep(2000);
 		assertEquals(0, ((Map) new DirectFieldAccessor(cache).getPropertyValue("map")).size());
 		container.stop();
+		ctx.close();
 	}
 
 	public class POJO {
 		public void handleMessage(String foo) {
-//			System.out.println(foo);
 			latch.countDown();
 			throw new RuntimeException("fail");
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/BrokerRunning.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/BrokerRunning.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @see AssumptionViolatedException
  *
  * @author Dave Syer
+ * @author Gary Russell
  *
  */
 public class BrokerRunning extends TestWatcher {
@@ -165,6 +166,7 @@ public class BrokerRunning extends TestWatcher {
 		}
 
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 
 		try {
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/transaction/RabbitTransactionManagerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/transaction/RabbitTransactionManagerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 by the original author(s).
+ * Copyright (c) 2011-2014 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.test.BrokerRunning;
@@ -47,6 +48,7 @@ public class RabbitTransactionManagerIntegrationTests {
 	@Before
 	public void init() {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 		template = new RabbitTemplate(connectionFactory);
 		template.setChannelTransacted(true);
 		RabbitTransactionManager transactionManager = new RabbitTransactionManager(connectionFactory);
@@ -61,6 +63,7 @@ public class RabbitTransactionManagerIntegrationTests {
 	@Test
 	public void testSendAndReceiveInTransaction() throws Exception {
 		String result = transactionTemplate.execute(new TransactionCallback<String>() {
+			@Override
 			public String doInTransaction(TransactionStatus status) {
 				template.convertAndSend(ROUTE, "message");
 				return (String) template.receiveAndConvert(ROUTE);
@@ -75,6 +78,7 @@ public class RabbitTransactionManagerIntegrationTests {
 	public void testReceiveInTransaction() throws Exception {
 		template.convertAndSend(ROUTE, "message");
 		String result = transactionTemplate.execute(new TransactionCallback<String>() {
+			@Override
 			public String doInTransaction(TransactionStatus status) {
 				return (String) template.receiveAndConvert(ROUTE);
 			}
@@ -91,6 +95,7 @@ public class RabbitTransactionManagerIntegrationTests {
 		template.convertAndSend(ROUTE, "message");
 		try {
 			transactionTemplate.execute(new TransactionCallback<String>() {
+				@Override
 				public String doInTransaction(TransactionStatus status) {
 					template.receiveAndConvert(ROUTE);
 					throw new PlannedException();
@@ -110,6 +115,7 @@ public class RabbitTransactionManagerIntegrationTests {
 	public void testSendInTransaction() throws Exception {
 		template.setChannelTransacted(true);
 		transactionTemplate.execute(new TransactionCallback<Void>() {
+			@Override
 			public Void doInTransaction(TransactionStatus status) {
 				template.convertAndSend(ROUTE, "message");
 				return null;
@@ -126,6 +132,7 @@ public class RabbitTransactionManagerIntegrationTests {
 		template.setChannelTransacted(true);
 		try {
 			transactionTemplate.execute(new TransactionCallback<Void>() {
+				@Override
 				public Void doInTransaction(TransactionStatus status) {
 					template.convertAndSend(ROUTE, "message");
 					throw new PlannedException();

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-0-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-0-context.xml
@@ -5,8 +5,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<bean id="connectionFactory"
-		class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory" />
+	<rabbit:connection-factory id="connectionFactory"  host="localhost" />
 
 	<!-- Valid configuration -->
 	<rabbit:admin connection-factory="connectionFactory" />

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-2-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-2-context.xml
@@ -5,8 +5,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<bean id="connectionFactory"
-		class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory" />
+	<rabbit:connection-factory id="connectionFactory"  host="localhost" />
 
 	<!-- Valid configuration -->
 	<rabbit:admin id="admin-test" connection-factory="connectionFactory" auto-startup="false"/>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ExchangeParserIntegrationTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ExchangeParserIntegrationTests-context.xml
@@ -47,6 +47,6 @@
 
 	<admin id="admin-test" connection-factory="connectionFactory" auto-startup="true"/>
 
-	<connection-factory id="connectionFactory"/>
+	<connection-factory id="connectionFactory" host="localhost" />
 
 </beans:beans>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/MismatchedQueueDeclarationTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/MismatchedQueueDeclarationTests-context.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<rabbit:connection-factory id="connectionFactory" />
+	<rabbit:connection-factory id="connectionFactory" host="localhost" />
 
 	<beans profile="basicAdmin">
 		<rabbit:admin connection-factory="connectionFactory" />

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
-	<rabbit:connection-factory id="rabbitConnectionFactory" />
+	<rabbit:connection-factory id="rabbitConnectionFactory" host="localhost" />
 
 	<rabbit:queue id="anon" />
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/StopStartIntegrationTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/StopStartIntegrationTests-context.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <rabbit:connection-factory id="connectionFactory"/>
+    <rabbit:connection-factory id="connectionFactory" host="localhost" />
 
     <rabbit:template id="amqpTemplate" connection-factory="connectionFactory"
 		exchange="stop.start.exchange" routing-key="stop.start.binding" />

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/remoting/RemotingTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/remoting/RemotingTests-context.xml
@@ -18,7 +18,7 @@
 
 	<bean id="service" class="org.springframework.amqp.rabbit.remoting.RemotingTests$ServiceImpl" />
 
-	<rabbit:connection-factory id="connectionFactory" />
+	<rabbit:connection-factory id="connectionFactory" host="localhost" />
 
 	<rabbit:template id="template" connection-factory="connectionFactory" reply-timeout="2000"
 		routing-key="remoting.test.binding" exchange="remoting.test.exchange" />

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/retry/retry-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/retry/retry-context.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
-    <rabbit:connection-factory id="connectionFactory" />
+    <rabbit:connection-factory id="connectionFactory" host="localhost" />
 
     <rabbit:template id="amqpTemplate" connection-factory="connectionFactory" />
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-397

Since Rabbit 3.3.0, the guest user is not allowed
to use interfaces other than the loopback (127.0.0.1).

Change all tests to explicitly use `localhost`.
