### PR TITLE
AMQP-402 Fix Error Log on Normal Channel Close

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -238,7 +238,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory implemen
 
 	@Override
 	public void shutdownCompleted(ShutdownSignalException cause) {
-		if (!RabbitUtils.isNormalShutdown(cause)) {
+		if (!RabbitUtils.isNormalChannelClose(cause)) {
 			logger.error("Channel shutdown: " + cause.getMessage());
 		}
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-402

Incorrect Method (Connection.Close) examined for
normal close instead of Channel.Close.

Also fix memory leak - remove entries from
`listenerForSeq` when processing confirms.

**cherry-pick to 1.3.x**
