### PR TITLE
Rabbit annotation-driven endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ ext {
 	javadocLinks = [
 		"http://docs.oracle.com/javase/6/docs/api",
 		"http://docs.oracle.com/javaee/6/api",
-		"http://docs.spring.io/spring/docs/3.1.x/javadoc-api"
+		"http://docs.spring.io/spring/docs/4.1.x/javadoc-api/"
 	] as String[]
 }
 
@@ -81,7 +81,7 @@ subprojects { subproject ->
 		mockitoVersion = '1.9.5'
 		rabbitmqVersion = project.hasProperty('rabbitmqVersion') ? project.rabbitmqVersion : '3.3.4'
 
-		springVersion = project.hasProperty('springVersion') ? project.springVersion : '4.0.5.RELEASE'
+		springVersion = project.hasProperty('springVersion') ? project.springVersion : '4.1.0.BUILD-SNAPSHOT'
 
 		springRetryVersion = '1.1.0.RELEASE'
 	}
@@ -174,6 +174,7 @@ project('spring-amqp') {
 	dependencies {
 
 		compile "org.springframework:spring-core:$springVersion"
+		compile ("org.springframework:spring-messaging:$springVersion", optional)
 		compile ("org.springframework:spring-oxm:$springVersion", optional)
 		compile ("org.springframework:spring-context:$springVersion", optional)
 		compile ("org.codehaus.jackson:jackson-core-asl:$jacksonVersion", optional)
@@ -209,6 +210,7 @@ project('spring-rabbit') {
 
 		compile ("org.springframework:spring-aop:$springVersion", optional)
 		compile "org.springframework:spring-context:$springVersion"
+		compile "org.springframework:spring-messaging:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
 
 		compile "org.springframework.retry:spring-retry:$springRetryVersion"

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaderMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaderMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support;
+
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.messaging.support.HeaderMapper;
+
+/**
+ * Strategy interface for mapping messaging Message headers to an outbound
+ * {@link MessageProperties} (e.g. to configure AMQP properties) or
+ * extracting messaging header values from an inbound {@link MessageProperties}.
+ *
+ * @author Mark Fisher
+ * @author Oleg Zhurakousky
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public interface AmqpHeaderMapper extends HeaderMapper<MessageProperties> {
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support;
+
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Pre-defined names and prefixes to be used for setting and/or retrieving AMQP
+ * MessageProperties from/to {@link org.springframework.messaging.Message
+ * Message} Headers.
+ *
+ * @author Mark Fisher
+ * @since 2.0
+ */
+public abstract class AmqpHeaders {
+
+	/**
+	 * Prefix used for AMQP related headers in order to distinguish from
+	 * user-defined headers and other internal headers (e.g. replyTo).
+	 * @see SimpleAmqpHeaderMapper
+	 */
+	public static final String PREFIX = "amqp_";
+
+
+	// Header Name Constants
+
+	public static final String APP_ID = PREFIX + "appId";
+
+	public static final String CLUSTER_ID = PREFIX + "clusterId";
+
+	public static final String CONTENT_ENCODING = PREFIX + "contentEncoding";
+
+	public static final String CONTENT_LENGTH = PREFIX + "contentLength";
+
+	public static final String CONTENT_TYPE = MessageHeaders.CONTENT_TYPE;
+
+	public static final String CORRELATION_ID = PREFIX + "correlationId";
+
+	public static final String DELIVERY_MODE = PREFIX + "deliveryMode";
+
+	public static final String DELIVERY_TAG = PREFIX + "deliveryTag";
+
+	public static final String EXPIRATION = PREFIX + "expiration";
+
+	public static final String MESSAGE_COUNT = PREFIX + "messageCount";
+
+	public static final String MESSAGE_ID = PREFIX + "messageId";
+
+	public static final String RECEIVED_EXCHANGE = PREFIX + "receivedExchange";
+
+	public static final String RECEIVED_ROUTING_KEY = PREFIX + "receivedRoutingKey";
+
+	public static final String REDELIVERED = PREFIX + "redelivered";
+
+	public static final String REPLY_TO = PREFIX + "replyTo";
+
+	public static final String TIMESTAMP = PREFIX + "timestamp";
+
+	public static final String TYPE = PREFIX + "type";
+
+	public static final String USER_ID = PREFIX + "userId";
+
+	public static final String SPRING_REPLY_CORRELATION = PREFIX + "springReplyCorrelation";
+
+	public static final String SPRING_REPLY_TO_STACK = PREFIX + "springReplyToStack";
+
+	public static final String PUBLISH_CONFIRM = PREFIX + "publishConfirm";
+
+	public static final String RETURN_REPLY_CODE = PREFIX + "returnReplyCode";
+
+	public static final String RETURN_REPLY_TEXT = PREFIX + "returnReplyText";
+
+	public static final String RETURN_EXCHANGE = PREFIX + "returnExchange";
+
+	public static final String RETURN_ROUTING_KEY = PREFIX + "returnRoutingKey";
+
+	public static final String CHANNEL = PREFIX + "channel";
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpMessageHeaderAccessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpMessageHeaderAccessor.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.NativeMessageHeaderAccessor;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeType;
+
+/**
+ * A {@link org.springframework.messaging.support.MessageHeaderAccessor}
+ * implementation giving access to AMQP-specific headers.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public class AmqpMessageHeaderAccessor extends NativeMessageHeaderAccessor {
+
+	public static final String PRIORITY = "priority";
+
+	protected AmqpMessageHeaderAccessor(Map<String, List<String>> nativeHeaders) {
+		super(nativeHeaders);
+	}
+
+	protected AmqpMessageHeaderAccessor(Message<?> message) {
+		super(message);
+	}
+
+	// Static factory method
+
+	/**
+	 * Create a {@link AmqpMessageHeaderAccessor} from the headers of an existing message.
+	 */
+	public static AmqpMessageHeaderAccessor wrap(Message<?> message) {
+		return new AmqpMessageHeaderAccessor(message);
+	}
+
+	@Override
+	protected void verifyType(String headerName, Object headerValue) {
+		super.verifyType(headerName, headerValue);
+		if (PRIORITY.equals(headerName)) {
+			Assert.isTrue(Integer.class.isAssignableFrom(headerValue.getClass()), "The '" + headerName
+					+ "' header value must be an Integer.");
+		}
+	}
+
+	public String getAppId() {
+		return (String) getHeader(AmqpHeaders.APP_ID);
+	}
+
+	public String getClusterId() {
+		return (String) getHeader(AmqpHeaders.CLUSTER_ID);
+	}
+
+	public String getContentEncoding() {
+		return (String) getHeader(AmqpHeaders.CONTENT_ENCODING);
+	}
+
+	public Long getContentLength() {
+		return (Long) getHeader(AmqpHeaders.CONTENT_LENGTH);
+	}
+
+	@Override
+	public MimeType getContentType() {
+		Object value = getHeader(AmqpHeaders.CONTENT_TYPE);
+		if (value != null && value instanceof String) {
+			return MimeType.valueOf((String) value);
+		}
+		else {
+			return super.getContentType();
+		}
+	}
+
+	public byte[] getCorrelationId() {
+		return (byte[]) getHeader(AmqpHeaders.CORRELATION_ID);
+	}
+
+	public MessageDeliveryMode getDeliveryMode() {
+		return (MessageDeliveryMode) getHeader(AmqpHeaders.DELIVERY_MODE);
+	}
+
+	public Long getDeliveryTag() {
+		return (Long) getHeader(AmqpHeaders.DELIVERY_TAG);
+	}
+
+	public String getExpiration() {
+		return (String) getHeader(AmqpHeaders.EXPIRATION);
+	}
+
+	public Integer getMessageCount() {
+		return (Integer) getHeader(AmqpHeaders.MESSAGE_COUNT);
+	}
+
+	public String getMessageId() {
+		return (String) getHeader(AmqpHeaders.MESSAGE_ID);
+	}
+
+	public Integer getPriority() {
+		return (Integer) getHeader(PRIORITY);
+	}
+
+	public String getReceivedExchange() {
+		return (String) getHeader(AmqpHeaders.RECEIVED_EXCHANGE);
+	}
+
+	public String getReceivedRoutingKey() {
+		return (String) getHeader(AmqpHeaders.RECEIVED_ROUTING_KEY);
+	}
+
+	public Boolean getRedelivered() {
+		return (Boolean) getHeader(AmqpHeaders.REDELIVERED);
+	}
+
+	public String getReplyTo() {
+		return (String) getHeader(AmqpHeaders.REPLY_TO);
+	}
+
+	public Long getTimestamp() {
+		Date amqpTimestamp = (Date) getHeader(AmqpHeaders.TIMESTAMP);
+		if (amqpTimestamp != null) {
+			return amqpTimestamp.getTime();
+		}
+		else {
+			return super.getTimestamp();
+		}
+	}
+
+	public String getType() {
+		return (String) getHeader(AmqpHeaders.TYPE);
+	}
+
+	public String getUserId() {
+		return (String) getHeader(AmqpHeaders.USER_ID);
+	}
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/SimpleAmqpHeaderMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/SimpleAmqpHeaderMapper.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.AbstractHeaderMapper;
+import org.springframework.util.StringUtils;
+
+/**
+ * Simple implementation of {@link AmqpHeaderMapper}.
+ *
+ * <p>This implementation copies AMQP API headers (e.g. appId) to and from
+ * {@link MessageHeaders}.Any used-defined properties will also be copied
+ * from an AMQP Message to a {@link org.springframework.amqp.core.Message
+ * Message}, and any other headers on a Message (beyond the AMQP headers)
+ * will likewise be copied to an AMQP Message. Those other headers will be
+ * copied to the general headers of a {@link MessageProperties} whereas the
+ * AMQP API headers are passed to the appropriate setter methods (e.g.
+ * {@link MessageProperties#setAppId}.
+ *
+ * <p>Constants for the AMQP header keys are defined in {@link AmqpHeaders}.
+ *
+ * @author Mark Fisher
+ * @author Oleg Zhurakousky
+ * @author Gary Russell
+ * @author Artem Bilan
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public class SimpleAmqpHeaderMapper extends AbstractHeaderMapper<MessageProperties> implements AmqpHeaderMapper {
+
+	@Override
+	public void fromHeaders(MessageHeaders headers, MessageProperties amqpMessageProperties) {
+		String appId = getHeaderIfAvailable(headers, AmqpHeaders.APP_ID, String.class);
+		if (StringUtils.hasText(appId)) {
+			amqpMessageProperties.setAppId(appId);
+		}
+		String clusterId = getHeaderIfAvailable(headers, AmqpHeaders.CLUSTER_ID, String.class);
+		if (StringUtils.hasText(clusterId)) {
+			amqpMessageProperties.setClusterId(clusterId);
+		}
+		String contentEncoding = getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_ENCODING, String.class);
+		if (StringUtils.hasText(contentEncoding)) {
+			amqpMessageProperties.setContentEncoding(contentEncoding);
+		}
+		Long contentLength = getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_LENGTH, Long.class);
+		if (contentLength != null) {
+			amqpMessageProperties.setContentLength(contentLength);
+		}
+		String contentType = this.extractContentTypeAsString(headers);
+
+		if (StringUtils.hasText(contentType)) {
+			amqpMessageProperties.setContentType(contentType);
+		}
+		Object correlationId = headers.get(AmqpHeaders.CORRELATION_ID);
+		if (correlationId instanceof byte[]) {
+			amqpMessageProperties.setCorrelationId((byte[]) correlationId);
+		}
+		MessageDeliveryMode deliveryMode = getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_MODE, MessageDeliveryMode.class);
+		if (deliveryMode != null) {
+			amqpMessageProperties.setDeliveryMode(deliveryMode);
+		}
+		Long deliveryTag = getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_TAG, Long.class);
+		if (deliveryTag != null) {
+			amqpMessageProperties.setDeliveryTag(deliveryTag);
+		}
+		String expiration = getHeaderIfAvailable(headers, AmqpHeaders.EXPIRATION, String.class);
+		if (StringUtils.hasText(expiration)) {
+			amqpMessageProperties.setExpiration(expiration);
+		}
+		Integer messageCount = getHeaderIfAvailable(headers, AmqpHeaders.MESSAGE_COUNT, Integer.class);
+		if (messageCount != null) {
+			amqpMessageProperties.setMessageCount(messageCount);
+		}
+		String messageId = getHeaderIfAvailable(headers, AmqpHeaders.MESSAGE_ID, String.class);
+		if (StringUtils.hasText(messageId)) {
+			amqpMessageProperties.setMessageId(messageId);
+		}
+		Integer priority = getHeaderIfAvailable(headers, AmqpMessageHeaderAccessor.PRIORITY, Integer.class);
+		if (priority != null) {
+			amqpMessageProperties.setPriority(priority);
+		}
+		String receivedExchange = getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_EXCHANGE, String.class);
+		if (StringUtils.hasText(receivedExchange)) {
+			amqpMessageProperties.setReceivedExchange(receivedExchange);
+		}
+		String receivedRoutingKey = getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_ROUTING_KEY, String.class);
+		if (StringUtils.hasText(receivedRoutingKey)) {
+			amqpMessageProperties.setReceivedRoutingKey(receivedRoutingKey);
+		}
+		Boolean redelivered = getHeaderIfAvailable(headers, AmqpHeaders.REDELIVERED, Boolean.class);
+		if (redelivered != null) {
+			amqpMessageProperties.setRedelivered(redelivered);
+		}
+		String replyTo = getHeaderIfAvailable(headers, AmqpHeaders.REPLY_TO, String.class);
+		if (replyTo != null) {
+			amqpMessageProperties.setReplyTo(replyTo);
+		}
+		Date timestamp = getHeaderIfAvailable(headers, AmqpHeaders.TIMESTAMP, Date.class);
+		if (timestamp != null) {
+			amqpMessageProperties.setTimestamp(timestamp);
+		}
+		String type = getHeaderIfAvailable(headers, AmqpHeaders.TYPE, String.class);
+		if (type != null) {
+			amqpMessageProperties.setType(type);
+		}
+		String userId = getHeaderIfAvailable(headers, AmqpHeaders.USER_ID, String.class);
+		if (StringUtils.hasText(userId)) {
+			amqpMessageProperties.setUserId(userId);
+		}
+
+		String replyCorrelation = getHeaderIfAvailable(headers, AmqpHeaders.SPRING_REPLY_CORRELATION, String.class);
+		if (StringUtils.hasLength(replyCorrelation)) {
+			amqpMessageProperties.setHeader("spring_reply_correlation", replyCorrelation);
+		}
+		String replyToStack = getHeaderIfAvailable(headers, AmqpHeaders.SPRING_REPLY_TO_STACK, String.class);
+		if (StringUtils.hasLength(replyToStack)) {
+			amqpMessageProperties.setHeader("spring_reply_to", replyToStack);
+		}
+
+		// Map custom headers
+		for (Map.Entry<String, Object> entry : headers.entrySet()) {
+			String headerName = entry.getKey();
+			if (StringUtils.hasText(headerName) && !headerName.startsWith(AmqpHeaders.PREFIX)) {
+				Object value = entry.getValue();
+				if (value != null) {
+					String propertyName = this.fromHeaderName(headerName);
+					if (!amqpMessageProperties.getHeaders().containsKey(headerName)) {
+						amqpMessageProperties.setHeader(propertyName, value);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public MessageHeaders toHeaders(MessageProperties amqpMessageProperties) {
+		Map<String, Object> headers = new HashMap<String, Object>();
+		try {
+			String appId = amqpMessageProperties.getAppId();
+			if (StringUtils.hasText(appId)) {
+				headers.put(AmqpHeaders.APP_ID, appId);
+			}
+			String clusterId = amqpMessageProperties.getClusterId();
+			if (StringUtils.hasText(clusterId)) {
+				headers.put(AmqpHeaders.CLUSTER_ID, clusterId);
+			}
+			String contentEncoding = amqpMessageProperties.getContentEncoding();
+			if (StringUtils.hasText(contentEncoding)) {
+				headers.put(AmqpHeaders.CONTENT_ENCODING, contentEncoding);
+			}
+			long contentLength = amqpMessageProperties.getContentLength();
+			if (contentLength > 0) {
+				headers.put(AmqpHeaders.CONTENT_LENGTH, contentLength);
+			}
+			String contentType = amqpMessageProperties.getContentType();
+			if (StringUtils.hasText(contentType)) {
+				headers.put(AmqpHeaders.CONTENT_TYPE, contentType);
+			}
+			byte[] correlationId = amqpMessageProperties.getCorrelationId();
+			if (correlationId != null && correlationId.length > 0) {
+				headers.put(AmqpHeaders.CORRELATION_ID, correlationId);
+			}
+			MessageDeliveryMode deliveryMode = amqpMessageProperties.getDeliveryMode();
+			if (deliveryMode != null) {
+				headers.put(AmqpHeaders.DELIVERY_MODE, deliveryMode);
+			}
+			long deliveryTag = amqpMessageProperties.getDeliveryTag();
+			if (deliveryTag > 0) {
+				headers.put(AmqpHeaders.DELIVERY_TAG, deliveryTag);
+			}
+			String expiration = amqpMessageProperties.getExpiration();
+			if (StringUtils.hasText(expiration)) {
+				headers.put(AmqpHeaders.EXPIRATION, expiration);
+			}
+			Integer messageCount = amqpMessageProperties.getMessageCount();
+			if (messageCount != null && messageCount > 0) {
+				headers.put(AmqpHeaders.MESSAGE_COUNT, messageCount);
+			}
+			String messageId = amqpMessageProperties.getMessageId();
+			if (StringUtils.hasText(messageId)) {
+				headers.put(AmqpHeaders.MESSAGE_ID, messageId);
+			}
+			Integer priority = amqpMessageProperties.getPriority();
+			if (priority != null && priority > 0) {
+				headers.put(AmqpMessageHeaderAccessor.PRIORITY, priority);
+			}
+			String receivedExchange = amqpMessageProperties.getReceivedExchange();
+			if (StringUtils.hasText(receivedExchange)) {
+				headers.put(AmqpHeaders.RECEIVED_EXCHANGE, receivedExchange);
+			}
+			String receivedRoutingKey = amqpMessageProperties.getReceivedRoutingKey();
+			if (StringUtils.hasText(receivedRoutingKey)) {
+				headers.put(AmqpHeaders.RECEIVED_ROUTING_KEY, receivedRoutingKey);
+			}
+			Boolean redelivered = amqpMessageProperties.isRedelivered();
+			if (redelivered != null) {
+				headers.put(AmqpHeaders.REDELIVERED, redelivered);
+			}
+			String replyTo = amqpMessageProperties.getReplyTo();
+			if (replyTo != null) {
+				headers.put(AmqpHeaders.REPLY_TO, replyTo);
+			}
+			Date timestamp = amqpMessageProperties.getTimestamp();
+			if (timestamp != null) {
+				headers.put(AmqpHeaders.TIMESTAMP, timestamp);
+			}
+			String type = amqpMessageProperties.getType();
+			if (StringUtils.hasText(type)) {
+				headers.put(AmqpHeaders.TYPE, type);
+			}
+			String userId = amqpMessageProperties.getUserId();
+			if (StringUtils.hasText(userId)) {
+				headers.put(AmqpHeaders.USER_ID, userId);
+			}
+
+			// Map custom headers
+			for (Map.Entry<String, Object> entry : amqpMessageProperties.getHeaders().entrySet()) {
+				headers.put(entry.getKey(), entry.getValue());
+			}
+		}
+		catch (Exception e) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("error occurred while mapping from AMQP properties to MessageHeaders", e);
+			}
+		}
+		return new MessageHeaders(headers);
+	}
+
+	/**
+	 * Will extract Content-Type from MessageHeaders and convert it to String if possible
+	 * Required since Content-Type can be represented as org.springframework.http.MediaType
+	 * see INT-2713 for more details
+	 *
+	 */
+	private String extractContentTypeAsString(Map<String, Object> headers) {
+		String contentTypeStringValue = null;
+
+		Object contentType = getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_TYPE, Object.class);
+
+		if (contentType != null) {
+			String contentTypeClassName = contentType.getClass().getName();
+
+			if (contentTypeClassName.equals("org.springframework.http.MediaType")) { // see INT-2713
+				contentTypeStringValue = contentType.toString();
+			}
+			else if (contentType instanceof String) {
+				contentTypeStringValue = (String) contentType;
+			}
+			else {
+				if (logger.isWarnEnabled()) {
+					logger.warn("skipping header '" + AmqpHeaders.CONTENT_TYPE +
+							"' since it is not of expected type [" + contentTypeClassName + "]");
+				}
+			}
+		}
+		return contentTypeStringValue;
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessagingMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessagingMessageConverter.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support.converter;
+
+import java.util.Map;
+
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.AmqpHeaderMapper;
+import org.springframework.amqp.support.SimpleAmqpHeaderMapper;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
+
+/**
+ * Convert a {@link Message} from the messaging abstraction to and from a
+ * {@link org.springframework.amqp.core.Message} using an underlying
+ * {@link MessageConverter} for the payload and a
+ * {@link org.springframework.amqp.support.AmqpHeaderMapper} to map the
+ * AMQP headers to and from standard message headers.
+ *
+ * <p>The inbound flag determines how headers should be mapped. If {@code true}
+ * (default), the caller is an inbound listener (i.e. parsing an AMQP message
+ * is considered to be a request).
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public class MessagingMessageConverter implements MessageConverter, InitializingBean {
+
+	private MessageConverter payloadConverter;
+
+	private AmqpHeaderMapper headerMapper;
+
+
+	/**
+	 * Create an instance with a default payload converter for an inbound
+	 * handler.
+	 * @see org.springframework.amqp.support.converter.SimpleMessageConverter
+	 * @see org.springframework.amqp.support.SimpleAmqpHeaderMapper
+	 */
+	public MessagingMessageConverter() {
+		this(new SimpleMessageConverter(), new SimpleAmqpHeaderMapper());
+	}
+
+	/**
+	 * Create an instance with the specified payload converter and
+	 * header mapper.
+	 */
+	public MessagingMessageConverter(MessageConverter payloadConverter, AmqpHeaderMapper headerMapper) {
+		Assert.notNull(payloadConverter, "PayloadConverter must not be null");
+		Assert.notNull(headerMapper, "HeaderMapper must not be null");
+		this.payloadConverter = payloadConverter;
+		this.headerMapper = headerMapper;
+	}
+
+
+	/**
+	 * Set the {@link MessageConverter} to use to convert the payload.
+	 */
+	public void setPayloadConverter(MessageConverter payloadConverter) {
+		this.payloadConverter = payloadConverter;
+	}
+
+	/**
+	 * Set the {@link AmqpHeaderMapper} to use to map AMQP headers to and from
+	 * standard message headers.
+	 */
+	public void setHeaderMapper(AmqpHeaderMapper headerMapper) {
+		this.headerMapper = headerMapper;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		Assert.notNull(this.payloadConverter, "Property 'payloadConverter' is required");
+		Assert.notNull(this.headerMapper, "Property 'headerMapper' is required");
+	}
+
+	@Override
+	public org.springframework.amqp.core.Message toMessage(Object object, MessageProperties messageProperties) throws MessageConversionException {
+		if (!(object instanceof Message)) {
+			throw new IllegalArgumentException("Could not convert [" + object + "] - only [" +
+					Message.class.getName() + "] is handled by this converter");
+		}
+		Message<?> input = (Message<?>) object;
+		org.springframework.amqp.core.Message amqpMessage = this.payloadConverter.toMessage(
+				input.getPayload(), messageProperties);
+
+		this.headerMapper.fromHeaders(input.getHeaders(), messageProperties);
+		return amqpMessage;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
+		if (message == null) {
+			return null;
+		}
+		Map<String, Object> mappedHeaders = this.headerMapper.toHeaders(message.getMessageProperties());
+		Object convertedObject = extractPayload(message);
+		MessageBuilder<Object> builder = (convertedObject instanceof org.springframework.messaging.Message) ?
+				MessageBuilder.fromMessage((org.springframework.messaging.Message<Object>) convertedObject) :
+				MessageBuilder.withPayload(convertedObject);
+		return builder.copyHeadersIfAbsent(mappedHeaders).build();
+	}
+
+	/**
+	 * Extract the payload of the specified {@link org.springframework.amqp.core.Message}.
+	 */
+	protected Object extractPayload(org.springframework.amqp.core.Message message) {
+		return this.payloadConverter.fromMessage(message);
+	}
+
+}

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/AmqpMessageHeaderAccessorTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/AmqpMessageHeaderAccessorTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.MimeType;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class AmqpMessageHeaderAccessorTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void validateAmqpHeaders() throws Exception {
+		byte[] correlationId = "correlation-id-1234".getBytes();
+		Date timestamp = new Date();
+
+		MessageProperties properties = new MessageProperties();
+		properties.setAppId("app-id-1234");
+		properties.setClusterId("cluster-id-1234");
+		properties.setContentEncoding("UTF-16");
+		properties.setContentLength(200L);
+		properties.setContentType("text/plain");
+		properties.setCorrelationId(correlationId);
+		properties.setDeliveryMode(MessageDeliveryMode.NON_PERSISTENT);
+		properties.setDeliveryTag(555L);
+		properties.setExpiration("expiration-1234");
+		properties.setMessageCount(42);
+		properties.setMessageId("message-id-1234");
+		properties.setPriority(9);
+		properties.setReceivedExchange("received-exchange-1234");
+		properties.setReceivedRoutingKey("received-routing-key-1234");
+		properties.setRedelivered(true);
+		properties.setReplyTo("reply-to-1234");
+		properties.setTimestamp(timestamp);
+		properties.setType("type-1234");
+		properties.setUserId("user-id-1234");
+
+		SimpleAmqpHeaderMapper amqpHeaderMapper = new SimpleAmqpHeaderMapper();
+
+		Map<String, Object> mappedHeaders = amqpHeaderMapper.toHeaders(properties);
+		Message<String> message = MessageBuilder.withPayload("test").copyHeaders(mappedHeaders).build();
+		AmqpMessageHeaderAccessor headerAccessor = AmqpMessageHeaderAccessor.wrap(message);
+
+		assertEquals("app-id-1234", headerAccessor.getAppId());
+		assertEquals("cluster-id-1234", headerAccessor.getClusterId());
+		assertEquals("UTF-16", headerAccessor.getContentEncoding());
+		assertEquals(Long.valueOf(200), headerAccessor.getContentLength());
+		assertEquals(MimeType.valueOf("text/plain"), headerAccessor.getContentType());
+		assertEquals(correlationId, headerAccessor.getCorrelationId());
+		assertEquals(MessageDeliveryMode.NON_PERSISTENT, headerAccessor.getDeliveryMode());
+		assertEquals(Long.valueOf(555), headerAccessor.getDeliveryTag());
+		assertEquals("expiration-1234", headerAccessor.getExpiration());
+		assertEquals(Integer.valueOf(42), headerAccessor.getMessageCount());
+		assertEquals("message-id-1234", headerAccessor.getMessageId());
+		assertEquals(Integer.valueOf(9), headerAccessor.getPriority());
+		assertEquals("received-exchange-1234", headerAccessor.getReceivedExchange());
+		assertEquals("received-routing-key-1234", headerAccessor.getReceivedRoutingKey());
+		assertEquals(true, headerAccessor.getRedelivered());
+		assertEquals("reply-to-1234", headerAccessor.getReplyTo());
+		assertEquals(Long.valueOf(timestamp.getTime()), headerAccessor.getTimestamp());
+		assertEquals("type-1234", headerAccessor.getType());
+		assertEquals("user-id-1234", headerAccessor.getUserId());
+
+		// Making sure replyChannel is not mixed with replyTo
+		assertNull(headerAccessor.getReplyChannel());
+	}
+
+	@Test
+	public void prioritySet() {
+		Message<?> message = MessageBuilder.withPayload("payload").
+				setHeader(AmqpMessageHeaderAccessor.PRIORITY, 90).build();
+		AmqpMessageHeaderAccessor accessor = new AmqpMessageHeaderAccessor(message);
+		assertEquals(Integer.valueOf(90), accessor.getPriority());
+	}
+
+	@Test
+	public void priorityMustBeInteger() {
+		AmqpMessageHeaderAccessor accessor = new AmqpMessageHeaderAccessor(MessageBuilder.withPayload("foo").build());
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("priority");
+		accessor.setHeader(AmqpMessageHeaderAccessor.PRIORITY, "Foo");
+	}
+
+}

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/SimpleAmqpHeaderMapperTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/SimpleAmqpHeaderMapperTests.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.converter.JsonMessageConverter;
+import org.springframework.messaging.MessageHeaders;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Mark Fisher
+ * @author Gary Russell
+ * @author Oleg Zhurakousky
+ */
+public class SimpleAmqpHeaderMapperTests {
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void fromHeaders() {
+		SimpleAmqpHeaderMapper headerMapper = new SimpleAmqpHeaderMapper();
+		Map<String, Object> headerMap = new HashMap<String, Object>();
+		headerMap.put(AmqpHeaders.APP_ID, "test.appId");
+		headerMap.put(AmqpHeaders.CLUSTER_ID, "test.clusterId");
+		headerMap.put(AmqpHeaders.CONTENT_ENCODING, "test.contentEncoding");
+		headerMap.put(AmqpHeaders.CONTENT_LENGTH, 99L);
+		headerMap.put(AmqpHeaders.CONTENT_TYPE, "test.contentType");
+		byte[] testCorrelationId = new byte[] {1, 2, 3};
+		headerMap.put(AmqpHeaders.CORRELATION_ID, testCorrelationId);
+		headerMap.put(AmqpHeaders.DELIVERY_MODE, MessageDeliveryMode.NON_PERSISTENT);
+		headerMap.put(AmqpHeaders.DELIVERY_TAG, 1234L);
+		headerMap.put(AmqpHeaders.EXPIRATION, "test.expiration");
+		headerMap.put(AmqpHeaders.MESSAGE_COUNT, 42);
+		headerMap.put(AmqpHeaders.MESSAGE_ID, "test.messageId");
+		headerMap.put(AmqpHeaders.RECEIVED_EXCHANGE, "test.receivedExchange");
+		headerMap.put(AmqpHeaders.RECEIVED_ROUTING_KEY, "test.receivedRoutingKey");
+		headerMap.put(AmqpHeaders.REPLY_TO, "test.replyTo");
+		Date testTimestamp = new Date();
+		headerMap.put(AmqpHeaders.TIMESTAMP, testTimestamp);
+		headerMap.put(AmqpHeaders.TYPE, "test.type");
+		headerMap.put(AmqpHeaders.USER_ID, "test.userId");
+		headerMap.put(AmqpHeaders.SPRING_REPLY_CORRELATION, "test.correlation");
+		headerMap.put(AmqpHeaders.SPRING_REPLY_TO_STACK, "test.replyTo2");
+		MessageHeaders messageHeaders = new MessageHeaders(headerMap);
+		MessageProperties amqpProperties = new MessageProperties();
+		headerMapper.fromHeaders(messageHeaders, amqpProperties);
+		Set<String> headerKeys = amqpProperties.getHeaders().keySet();
+		for (String headerKey : headerKeys) {
+			if (headerKey.startsWith(AmqpHeaders.PREFIX)) {
+				fail();
+			}
+		}
+		assertEquals("test.appId", amqpProperties.getAppId());
+		assertEquals("test.clusterId", amqpProperties.getClusterId());
+		assertEquals("test.contentEncoding", amqpProperties.getContentEncoding());
+		assertEquals(99L, amqpProperties.getContentLength());
+		assertEquals("test.contentType", amqpProperties.getContentType());
+		assertEquals(testCorrelationId, amqpProperties.getCorrelationId());
+		assertEquals(MessageDeliveryMode.NON_PERSISTENT, amqpProperties.getDeliveryMode());
+		assertEquals(1234L, amqpProperties.getDeliveryTag());
+		assertEquals("test.expiration", amqpProperties.getExpiration());
+		assertEquals(new Integer(42), amqpProperties.getMessageCount());
+		assertEquals("test.messageId", amqpProperties.getMessageId());
+		assertEquals("test.receivedExchange", amqpProperties.getReceivedExchange());
+		assertEquals("test.receivedRoutingKey", amqpProperties.getReceivedRoutingKey());
+		assertEquals("test.replyTo", amqpProperties.getReplyTo());
+		assertEquals(testTimestamp, amqpProperties.getTimestamp());
+		assertEquals("test.type", amqpProperties.getType());
+		assertEquals("test.userId", amqpProperties.getUserId());
+	}
+
+	@Test
+	public void fromHeadersWithContentTypeAsMediaType() {
+		SimpleAmqpHeaderMapper headerMapper = new SimpleAmqpHeaderMapper();
+		Map<String, Object> headerMap = new HashMap<String, Object>();
+
+		headerMap.put(AmqpHeaders.CONTENT_TYPE, "text/html");
+
+		MessageHeaders messageHeaders = new MessageHeaders(headerMap);
+		MessageProperties amqpProperties = new MessageProperties();
+		headerMapper.fromHeaders(messageHeaders, amqpProperties);
+
+		assertEquals("text/html", amqpProperties.getContentType());
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void toHeaders() {
+		SimpleAmqpHeaderMapper headerMapper = new SimpleAmqpHeaderMapper();
+		MessageProperties amqpProperties = new MessageProperties();
+		amqpProperties.setAppId("test.appId");
+		amqpProperties.setClusterId("test.clusterId");
+		amqpProperties.setContentEncoding("test.contentEncoding");
+		amqpProperties.setContentLength(99L);
+		amqpProperties.setContentType("test.contentType");
+		byte[] testCorrelationId = new byte[] {1, 2, 3};
+		amqpProperties.setCorrelationId(testCorrelationId);
+		amqpProperties.setDeliveryMode(MessageDeliveryMode.NON_PERSISTENT);
+		amqpProperties.setDeliveryTag(1234L);
+		amqpProperties.setExpiration("test.expiration");
+		amqpProperties.setMessageCount(42);
+		amqpProperties.setMessageId("test.messageId");
+		amqpProperties.setPriority(22);
+		amqpProperties.setReceivedExchange("test.receivedExchange");
+		amqpProperties.setReceivedRoutingKey("test.receivedRoutingKey");
+		amqpProperties.setRedelivered(true);
+		amqpProperties.setReplyTo("test.replyTo");
+		Date testTimestamp = new Date();
+		amqpProperties.setTimestamp(testTimestamp);
+		amqpProperties.setType("test.type");
+		amqpProperties.setUserId("test.userId");
+		amqpProperties.setHeader(AmqpHeaders.SPRING_REPLY_CORRELATION, "test.correlation");
+		amqpProperties.setHeader(AmqpHeaders.SPRING_REPLY_TO_STACK, "test.replyTo2");
+		Map<String, Object> headerMap = headerMapper.toHeaders(amqpProperties);
+		assertEquals("test.appId", headerMap.get(AmqpHeaders.APP_ID));
+		assertEquals("test.clusterId", headerMap.get(AmqpHeaders.CLUSTER_ID));
+		assertEquals("test.contentEncoding", headerMap.get(AmqpHeaders.CONTENT_ENCODING));
+		assertEquals(99L, headerMap.get(AmqpHeaders.CONTENT_LENGTH));
+		assertEquals("test.contentType", headerMap.get(AmqpHeaders.CONTENT_TYPE));
+		assertEquals(testCorrelationId, headerMap.get(AmqpHeaders.CORRELATION_ID));
+		assertEquals(MessageDeliveryMode.NON_PERSISTENT, headerMap.get(AmqpHeaders.DELIVERY_MODE));
+		assertEquals(1234L, headerMap.get(AmqpHeaders.DELIVERY_TAG));
+		assertEquals("test.expiration", headerMap.get(AmqpHeaders.EXPIRATION));
+		assertEquals(42, headerMap.get(AmqpHeaders.MESSAGE_COUNT));
+		assertEquals("test.messageId", headerMap.get(AmqpHeaders.MESSAGE_ID));
+		assertEquals("test.receivedExchange", headerMap.get(AmqpHeaders.RECEIVED_EXCHANGE));
+		assertEquals("test.receivedRoutingKey", headerMap.get(AmqpHeaders.RECEIVED_ROUTING_KEY));
+		assertEquals("test.replyTo", headerMap.get(AmqpHeaders.REPLY_TO));
+		assertEquals(testTimestamp, headerMap.get(AmqpHeaders.TIMESTAMP));
+		assertEquals("test.type", headerMap.get(AmqpHeaders.TYPE));
+		assertEquals("test.userId", headerMap.get(AmqpHeaders.USER_ID));
+		assertEquals("test.correlation", headerMap.get(AmqpHeaders.SPRING_REPLY_CORRELATION));
+		assertEquals("test.replyTo2", headerMap.get(AmqpHeaders.SPRING_REPLY_TO_STACK));
+	}
+
+	@Test // INT-2090
+	public void jsonTypeIdNotOverwritten() {
+		SimpleAmqpHeaderMapper headerMapper = new SimpleAmqpHeaderMapper();
+		JsonMessageConverter converter = new JsonMessageConverter();
+		MessageProperties amqpProperties = new MessageProperties();
+		converter.toMessage("123", amqpProperties);
+		Map<String, Object> headerMap = new HashMap<String, Object>();
+		headerMap.put("__TypeId__", "java.lang.Integer");
+		MessageHeaders messageHeaders = new MessageHeaders(headerMap);
+		headerMapper.fromHeaders(messageHeaders, amqpProperties);
+		assertEquals("java.lang.String", amqpProperties.getHeaders().get("__TypeId__"));
+		Object result = converter.fromMessage(new Message("123".getBytes(), amqpProperties));
+		assertEquals(String.class, result.getClass());
+	}
+
+}

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/MessagingMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/MessagingMessageConverterTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support.converter;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class MessagingMessageConverterTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private final MessagingMessageConverter converter = new MessagingMessageConverter();
+
+	@Test
+	public void onlyHandlesMessage() {
+		thrown.expect(IllegalArgumentException.class);
+		converter.toMessage(new Object(), new MessageProperties());
+	}
+
+	@Test
+	public void toMessageWithTextMessage() {
+		org.springframework.amqp.core.Message message = converter
+				.toMessage(MessageBuilder.withPayload("Hello World").build(), new MessageProperties());
+
+		assertEquals(MessageProperties.CONTENT_TYPE_TEXT_PLAIN, message.getMessageProperties().getContentType());
+		assertEquals("Hello World", new String(message.getBody()));
+	}
+
+	@Test
+	public void fromNull() {
+		assertNull(converter.fromMessage(null));
+	}
+
+	@Test
+	public void customPayloadConverter() throws Exception {
+		converter.setPayloadConverter(new SimpleMessageConverter() {
+			@Override
+			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
+				String payload = new String(message.getBody());
+				return Long.parseLong(payload);
+			}
+		});
+
+		Message<?> msg = (Message<?>) converter.fromMessage(createTextMessage("1224"));
+		assertEquals(1224L, msg.getPayload());
+	}
+
+	@Test
+	public void payloadIsAMessage() {
+		final Message<String> message = MessageBuilder.withPayload("Test").setHeader("inside", true).build();
+		converter.setPayloadConverter(new SimpleMessageConverter() {
+
+			@Override
+			public Object fromMessage(org.springframework.amqp.core.Message amqpMessage) throws MessageConversionException {
+				return message;
+			}
+		});
+		Message<?> msg = (Message<?>) converter.fromMessage(createTextMessage("foo"));
+		assertEquals(message.getPayload(), msg.getPayload());
+		assertEquals(true, msg.getHeaders().get("inside"));
+	}
+
+	public org.springframework.amqp.core.Message createTextMessage(String body) {
+		MessageProperties properties = new MessageProperties();
+		properties.setContentType(MessageProperties.CONTENT_TYPE_TEXT_PLAIN);
+		return new org.springframework.amqp.core.Message(body.getBytes(), properties);
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/EnableRabbit.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/EnableRabbit.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+
+/**
+ * Enable Rabbit listener annotated endpoints that are created under the cover
+ * by a {@link org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory
+ * RabbitListenerContainerFactory}. To be used on
+ * {@link org.springframework.context.annotation.Configuration Configuration}
+ * classes as follows:
+ *
+ * <pre class="code">
+ * &#064;Configuration
+ * &#064;EnableRabbit
+ * public class AppConfig {
+ *     &#064;Bean
+ *     public SimpleRabbitListenerContainerFactory myRabbitListenerContainerFactory() {
+ *       SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+ *       factory.setConnectionFactory(connectionFactory());
+ *       factory.setMaxConcurrentConsumers(5);
+ *       return factory;
+ *     }
+ *     // other &#064;Bean definitions
+ * }</pre>
+ *
+ * The {@code RabbitListenerContainerFactory} is responsible to create the listener container
+ * responsible for a particular endpoint. Typical implementations, as the
+ * {@link org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory SimpleRabbitListenerContainerFactory}
+ * used in the sample above, provides the necessary configuration options that are supported by
+ * the underlying {@link org.springframework.amqp.rabbit.listener.MessageListenerContainer MessageListenerContainer}.
+ *
+ * <p>{@code @EnableRabbit} enables detection of {@link RabbitListener} annotations on any
+ * Spring-managed bean in the container. For example, given a class {@code MyService}:
+ *
+ * <pre class="code">
+ * package com.acme.foo;
+ *
+ * public class MyService {
+ *     &#064;RabbitListener(containerFactory="myRabbitListenerContainerFactory", queues="myQueue")
+ *     public void process(String msg) {
+ *         // process incoming message
+ *     }
+ * }</pre>
+ *
+ * The container factory to use is identified by the {@link RabbitListener#containerFactory() containerFactory}
+ * attribute defining the name of the {@code RabbitListenerContainerFactory} bean to use.  When none
+ * is set a {@code RabbitListenerContainerFactory} bean with name {@code rabbitListenerContainerFactory} is
+ * assumed to be present.
+ *
+ * <p>the following configuration would ensure that every time a {@link org.springframework.amqp.core.Message}
+ * is received on the {@link org.springframework.amqp.core.Queue} named "myQueue", {@code MyService.process()}
+ * is called with the content of the message:
+ *
+ * <pre class="code">
+ * &#064;Configuration
+ * &#064;EnableRabbit
+ * public class AppConfig {
+ *     &#064;Bean
+ *     public MyService myService() {
+ *         return new MyService();
+ *     }
+ *
+ *     // Rabbit infrastructure setup
+ * }</pre>
+ *
+ * Alternatively, if {@code MyService} were annotated with {@code @Component}, the
+ * following configuration would ensure that its {@code @RabbitListener} annotated
+ * method is invoked with a matching incoming message:
+ *
+ * <pre class="code">
+ * &#064;Configuration
+ * &#064;EnableRabbit
+ * &#064;ComponentScan(basePackages="com.acme.foo")
+ * public class AppConfig {
+ * }</pre>
+ *
+ * Note that the created containers are not registered against the application context
+ * but can be easily located for management purposes using the
+ * {@link org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry RabbitListenerEndpointRegistry}.
+ *
+ * <p>Annotated methods can use flexible signature; in particular, it is possible to use
+ * the {@link org.springframework.messaging.Message Message} abstraction and related annotations,
+ * see {@link RabbitListener} Javadoc for more details. For instance, the following would
+ * inject the content of the message and a a custom "myCounter" AMQP header:
+ *
+ * <pre class="code">
+ * &#064;RabbitListener(containerFactory = "myRabbitListenerContainerFactory", queues = "myQueue")
+ * public void process(String msg, @Header("myCounter") int counter) {
+ *     // process incoming message
+ * }</pre>
+ *
+ * These features are abstracted by the {@link org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory
+ * MessageHandlerMethodFactory} that is responsible to build the necessary invoker to process
+ * the annotated method. By default, {@link org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory
+ * DefaultMessageHandlerMethodFactory} is used.
+ *
+ * <p>When more control is desired, a {@code @Configuration} class may implement
+ * {@link RabbitListenerConfigurer}. This allows access to the underlying
+ * {@link org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistrar RabbitListenerEndpointRegistrar}
+ * instance. The following example demonstrates how to specify an explicit default
+ * {@code RabbitListenerContainerFactory}
+ *
+ * <pre class="code">
+ * &#064;Configuration
+ * &#064;EnableRabbit
+ * public class AppConfig implements RabbitListenerConfigurer {
+ *     &#064;Override
+ *     public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+ *         registrar.setContainerFactory(myRabbitListenerContainerFactory());
+ *     }
+ *
+ *     &#064;Bean
+ *     public RabbitListenerContainerFactory<?> myRabbitListenerContainerFactory() {
+ *         // factory settings
+ *     }
+ *
+ *     &#064;Bean
+ *     public MyService myService() {
+ *         return new MyService();
+ *     }
+ * }</pre>
+ *
+ * For reference, the example above can be compared to the following Spring XML
+ * configuration:
+ * <pre class="code">
+ * {@code <beans>
+ *     <rabbit:annotation-driven container-factory="myRabbitListenerContainerFactory"/>
+ *
+ *     <bean id="myRabbitListenerContainerFactory"
+ *           class="org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory">
+ *           // factory settings
+ *     </bean>
+ *
+ *     <bean id="myService" class="com.acme.foo.MyService"/>
+ * </beans>
+ * }</pre>
+ *
+ * It is also possible to specify a custom {@link org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry
+ * RabbitListenerEndpointRegistry} in case you need more control on the way the containers
+ * are created and managed. The example below also demonstrates how to customize the
+ * {@code RabbitHandlerMethodFactory} to use with a custom {@link org.springframework.validation.Validator
+ * Validator} so that payloads annotated with {@link org.springframework.validation.annotation.Validated
+ * Validated} are first validated against a custom {@code Validator}.
+ *
+ * <pre class="code">
+ * &#064;Configuration
+ * &#064;EnableRabbit
+ * public class AppConfig implements RabbitListenerConfigurer {
+ *     &#064;Override
+ *     public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+ *         registrar.setEndpointRegistry(myRabbitListenerEndpointRegistry());
+ *         registrar.setMessageHandlerMethodFactory(myMessageHandlerMethodFactory);
+ *     }
+ *
+ *     &#064;Bean
+ *     public RabbitListenerEndpointRegistry<?> myRabbitListenerEndpointRegistry() {
+ *         // registry configuration
+ *     }
+ *
+ *     &#064;Bean
+ *     public RabbitHandlerMethodFactory myMessageHandlerMethodFactory() {
+ *        DefaultRabbitHandlerMethodFactory factory = new DefaultRabbitHandlerMethodFactory();
+ *        factory.setValidator(new MyValidator());
+ *        return factory;
+ *     }
+ *
+ *     &#064;Bean
+ *     public MyService myService() {
+ *         return new MyService();
+ *     }
+ * }</pre>
+ *
+ * For reference, the example above can be compared to the following Spring XML
+ * configuration:
+ * <pre class="code">
+ * {@code <beans>
+ *     <rabbit:annotation-driven registry="myRabbitListenerEndpointRegistry"
+ *         handler-method-factory="myRabbitHandlerMethodFactory"/&gt;
+ *
+ *     <bean id="myRabbitListenerEndpointRegistry"
+ *           class="org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry">
+ *           // registry configuration
+ *     </bean>
+ *
+ *     <bean id="myRabbitHandlerMethodFactory"
+ *           class="org.springframework.amqp.rabbit.config.DefaultRabbitHandlerMethodFactory">
+ *         <property name="validator" ref="myValidator"/>
+ *     </bean>
+ *
+ *     <bean id="myService" class="com.acme.foo.MyService"/>
+ * </beans>
+ * }</pre>
+ *
+ * Implementing {@code RabbitListenerConfigurer} also allows for fine-grained
+ * control over endpoints registration via the {@code RabbitListenerEndpointRegistrar}.
+ * For example, the following configures an extra endpoint:
+ *
+ * <pre class="code">
+ * &#064;Configuration
+ * &#064;EnableRabbit
+ * public class AppConfig implements RabbitListenerConfigurer {
+ *     &#064;Override
+ *     public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+ *         SimpleRabbitListenerEndpoint myEndpoint = new SimpleRabbitListenerEndpoint();
+ *         // ... configure the endpoint
+ *         registrar.registerEndpoint(endpoint, anotherRabbitListenerContainerFactory());
+ *     }
+ *
+ *     &#064;Bean
+ *     public MyService myService() {
+ *         return new MyService();
+ *     }
+ *
+ *     &#064;Bean
+ *     public RabbitListenerContainerFactory<?> anotherRabbitListenerContainerFactory() {
+ *         // ...
+ *     }
+ *
+ *     // Rabbit infrastructure setup
+ * }</pre>
+ *
+ * Note that all beans implementing {@code RabbitListenerConfigurer} will be detected and
+ * invoked in a similar fashion. The example above can be translated in a regular bean
+ * definition registered in the context in case you use the XML configuration.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ * @see RabbitListener
+ * @see RabbitListenerAnnotationBeanPostProcessor
+ * @see org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistrar
+ * @see org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(RabbitBootstrapConfiguration.class)
+public @interface EnableRabbit {
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitBootstrapConfiguration.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitBootstrapConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import org.springframework.amqp.rabbit.config.RabbitListenerConfigUtils;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
+
+/**
+ * {@code @Configuration} class that registers a {@link RabbitListenerAnnotationBeanPostProcessor}
+ * bean capable of processing Spring's @{@link RabbitListener} annotation. Also register
+ * a default {@link RabbitListenerEndpointRegistry}.
+ *
+ * <p>This configuration class is automatically imported when using the @{@link EnableRabbit}
+ * annotation.  See {@link EnableRabbit} Javadoc for complete usage.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ * @see RabbitListenerAnnotationBeanPostProcessor
+ * @see RabbitListenerEndpointRegistry
+ * @see EnableRabbit
+ */
+@Configuration
+public class RabbitBootstrapConfiguration {
+
+	@Bean(name = RabbitListenerConfigUtils.RABBIT_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME)
+	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+	public RabbitListenerAnnotationBeanPostProcessor rabbitListenerAnnotationProcessor() {
+		return new RabbitListenerAnnotationBeanPostProcessor();
+	}
+
+	@Bean(name = RabbitListenerConfigUtils.RABBIT_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)
+	public RabbitListenerEndpointRegistry defaultRabbitListenerEndpointRegistry() {
+		return new RabbitListenerEndpointRegistry();
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+
+/**
+ * Annotation that marks a method to be the target of a Rabbit message
+ * listener on the specified {@link #queues()}. The {@link #containerFactory()}
+ * identifies the {@link org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory
+ * RabbitListenerContainerFactory} to use to build the rabbit listener container. If not
+ * set, a <em>default</em> container factory is assumed to be available with a bean
+ * name of {@code rabbitListenerContainerFactory} unless an explicit default has been
+ * provided through configuration.
+ *
+ * <p>Processing of {@code @RabbitListener} annotations is performed by
+ * registering a {@link RabbitListenerAnnotationBeanPostProcessor}. This can be
+ * done manually or, more conveniently, through the {@code <rabbit:annotation-driven/>}
+ * element or {@link EnableRabbit} annotation.
+ *
+ * <p>Annotated methods are allowed to have flexible signatures similar to what
+ * {@link MessageMapping} provides, that is
+ * <ul>
+ * <li>{@link com.rabbitmq.client.Channel} to get access to the Channel</li>
+ * <li>{@link org.springframework.amqp.core.Message} or one if subclass to get
+ * access to the raw AMQP message</li>
+ * <li>{@link org.springframework.messaging.Message} to use the messaging abstraction counterpart</li>
+ * <li>{@link org.springframework.messaging.handler.annotation.Payload @Payload}-annotated method
+ * arguments including the support of validation</li>
+ * <li>{@link org.springframework.messaging.handler.annotation.Header @Header}-annotated method
+ * arguments to extract a specific header value, including standard AMQP headers defined by
+ * {@link org.springframework.amqp.support.AmqpHeaders AmqpHeaders}</li>
+ * <li>{@link org.springframework.messaging.handler.annotation.Headers @Headers}-annotated
+ * argument that must also be assignable to {@link java.util.Map} for getting access to all
+ * headers.</li>
+ * <li>{@link org.springframework.messaging.MessageHeaders MessageHeaders} arguments for
+ * getting access to all headers.</li>
+ * <li>{@link org.springframework.messaging.support.MessageHeaderAccessor MessageHeaderAccessor}
+ * or {@link org.springframework.amqp.support.AmqpMessageHeaderAccessor AmqpMessageHeaderAccessor}
+ * for convenient access to all method arguments.</li>
+ * </ul>
+ *
+ * <p>Annotated method may have a non {@code void} return type. When they do, the result of the
+ * method invocation is sent as a reply to the queue defined by the
+ * {@link org.springframework.amqp.core.MessageProperties#getReplyTo() ReplyTo}  header of the
+ * incoming message. When this value is not set, a default queue can be provided by
+ * adding @{@link org.springframework.messaging.handler.annotation.SendTo SendTo} to the method
+ * declaration.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ * @see EnableRabbit
+ * @see RabbitListenerAnnotationBeanPostProcessor
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@MessageMapping
+@Documented
+public @interface RabbitListener {
+
+	/**
+	 * The unique identifier of the container managing this endpoint.
+	 * <p>if none is specified an auto-generated one is provided.
+	 * @see org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry#getListenerContainer(String)
+	 */
+	String id() default "";
+
+	/**
+	 * The bean name of the {@link org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory}
+	 * to use to create the message listener container responsible to serve this endpoint.
+	 * <p>If not specified, the default container factory is used, if any.
+	 */
+	String containerFactory() default "";
+
+	/**
+	 * The queues for this listener.
+	 */
+	String[] queues();
+
+	/**
+	 * When {@code true}, a single consumer in the container will have exclusive use of the
+	 * {@link #queues()}, preventing other consumers from receiving messages from the
+	 * queues. When {@code true}, requires a concurrency of 1. Default {@code false}.
+	 */
+	boolean exclusive() default false;
+
+	/**
+	 * The priority of this endpoint. Requires RabbitMQ 3.2 or higher.
+	 */
+	int priority() default -1;
+
+	/**
+	 * The routing key to send along with a response message.
+	 * <p>This will be applied in case of a request message that does not carry
+	 * a "replyTo" property. Note: This only applies to a listener method with
+	 * a return value, for which each result object will be converted into a
+	 * response message.
+	 */
+	String responseRoutingKey() default "";
+
+	/**
+	 * Reference to a {@link org.springframework.amqp.rabbit.core.RabbitAdmin
+	 * RabbitAdmin}. Required if the listener is using auto-delete
+	 * queues and those queues are configured for conditional declaration. This
+	 * is the admin that will (re)declare those queues when the container is
+	 * (re)started. See the reference documentation for more information.
+	 */
+	String admin() default "";
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.amqp.rabbit.config.MethodRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.config.RabbitListenerConfigUtils;
+import org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistrar;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Bean post-processor that registers methods annotated with {@link RabbitListener}
+ * to be invoked by a AMQP message listener container created under the cover
+ * by a {@link org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory}
+ * according to the parameters of the annotation.
+ *
+ * <p>Annotated methods can use flexible arguments as defined by {@link RabbitListener}.
+ *
+ * <p>This post-processor is automatically registered by Spring's
+ * {@code <rabbit:annotation-driven>} XML element, and also by the {@link EnableRabbit}
+ * annotation.
+ *
+ * <p>Auto-detect any {@link RabbitListenerConfigurer} instances in the container,
+ * allowing for customization of the registry to be used, the default container
+ * factory or for fine-grained control over endpoints registration. See
+ * {@link EnableRabbit} Javadoc for complete usage details.
+ *
+ * @author Stephane Nicoll
+ * @author Juergen Hoeller
+ * @since 2.0
+ * @see RabbitListener
+ * @see EnableRabbit
+ * @see RabbitListenerConfigurer
+ * @see RabbitListenerEndpointRegistrar
+ * @see RabbitListenerEndpointRegistry
+ * @see org.springframework.amqp.rabbit.config.RabbitListenerEndpoint
+ * @see MethodRabbitListenerEndpoint
+ */
+public class RabbitListenerAnnotationBeanPostProcessor
+		implements BeanPostProcessor, Ordered, BeanFactoryAware, SmartInitializingSingleton {
+
+	/**
+	 * The bean name of the default {@link org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory}.
+	 */
+	static final String DEFAULT_RABBIT_LISTENER_CONTAINER_FACTORY_BEAN_NAME = "rabbitListenerContainerFactory";
+
+
+	private RabbitListenerEndpointRegistry endpointRegistry;
+
+	private String containerFactoryBeanName = DEFAULT_RABBIT_LISTENER_CONTAINER_FACTORY_BEAN_NAME;
+
+	private BeanFactory beanFactory;
+
+	private final RabbitHandlerMethodFactoryAdapter messageHandlerMethodFactory = new RabbitHandlerMethodFactoryAdapter();
+
+	private final RabbitListenerEndpointRegistrar registrar = new RabbitListenerEndpointRegistrar();
+
+	private final AtomicInteger counter = new AtomicInteger();
+
+
+	@Override
+	public int getOrder() {
+		return LOWEST_PRECEDENCE;
+	}
+
+	/**
+	 * Set the {@link RabbitListenerEndpointRegistry} that will hold the created
+	 * endpoint and manage the lifecycle of the related listener container.
+	 */
+	public void setEndpointRegistry(RabbitListenerEndpointRegistry endpointRegistry) {
+		this.endpointRegistry = endpointRegistry;
+	}
+
+	/**
+	 * Set the name of the {@link RabbitListenerContainerFactory} to use by default.
+	 * <p>If none is specified, "rabbitListenerContainerFactory" is assumed to be defined.
+	 */
+	public void setContainerFactoryBeanName(String containerFactoryBeanName) {
+		this.containerFactoryBeanName = containerFactoryBeanName;
+	}
+
+	/**
+	 * Set the {@link MessageHandlerMethodFactory} to use to configure the message
+	 * listener responsible to serve an endpoint detected by this processor.
+	 * <p>By default, {@link DefaultMessageHandlerMethodFactory} is used and it
+	 * can be configured further to support additional method arguments
+	 * or to customize conversion and validation support. See
+	 * {@link DefaultMessageHandlerMethodFactory} Javadoc for more details.
+	 */
+	public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory messageHandlerMethodFactory) {
+		this.messageHandlerMethodFactory.setMessageHandlerMethodFactory(messageHandlerMethodFactory);
+	}
+
+	/**
+	 * Making a {@link BeanFactory} available is optional; if not set,
+	 * {@link RabbitListenerConfigurer} beans won't get autodetected and an
+	 * {@link #setEndpointRegistry endpoint registry} has to be explicitly configured.
+	 */
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) {
+		this.beanFactory = beanFactory;
+	}
+
+
+	@Override
+	public void afterSingletonsInstantiated() {
+		this.registrar.setBeanFactory(this.beanFactory);
+
+		if (this.beanFactory instanceof ListableBeanFactory) {
+			Map<String, RabbitListenerConfigurer> instances =
+					((ListableBeanFactory) this.beanFactory).getBeansOfType(RabbitListenerConfigurer.class);
+			for (RabbitListenerConfigurer configurer : instances.values()) {
+				configurer.configureRabbitListeners(this.registrar);
+			}
+		}
+
+		if (this.registrar.getEndpointRegistry() == null) {
+			if (this.endpointRegistry == null) {
+				Assert.state(this.beanFactory != null, "BeanFactory must be set to find endpoint registry by bean name");
+				this.endpointRegistry = this.beanFactory.getBean(
+						RabbitListenerConfigUtils.RABBIT_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME, RabbitListenerEndpointRegistry.class);
+			}
+			this.registrar.setEndpointRegistry(this.endpointRegistry);
+		}
+
+		if (this.containerFactoryBeanName != null) {
+			this.registrar.setContainerFactoryBeanName(this.containerFactoryBeanName);
+		}
+
+		// Set the custom handler method factory once resolved by the configurer
+		MessageHandlerMethodFactory handlerMethodFactory = this.registrar.getMessageHandlerMethodFactory();
+		if (handlerMethodFactory != null) {
+			this.messageHandlerMethodFactory.setMessageHandlerMethodFactory(handlerMethodFactory);
+		}
+
+		// Actually register all listeners
+		this.registrar.afterPropertiesSet();
+	}
+
+
+	@Override
+	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+		return bean;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(final Object bean, String beanName) throws BeansException {
+		Class<?> targetClass = AopUtils.getTargetClass(bean);
+		ReflectionUtils.doWithMethods(targetClass, new ReflectionUtils.MethodCallback() {
+			@Override
+			public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
+				RabbitListener rabbitListener = AnnotationUtils.getAnnotation(method, RabbitListener.class);
+				if (rabbitListener != null) {
+					processAmqpListener(rabbitListener, method, bean);
+				}
+			}
+		});
+		return bean;
+	}
+
+	protected void processAmqpListener(RabbitListener rabbitListener, Method method, Object bean) {
+		if (AopUtils.isJdkDynamicProxy(bean)) {
+			try {
+				// Found a @RabbitListener method on the target class for this JDK proxy ->
+				// is it also present on the proxy itself?
+				method = bean.getClass().getMethod(method.getName(), method.getParameterTypes());
+			}
+			catch (SecurityException ex) {
+				ReflectionUtils.handleReflectionException(ex);
+			}
+			catch (NoSuchMethodException ex) {
+				throw new IllegalStateException(String.format(
+						"@RabbitListener method '%s' found on bean target class '%s', " +
+								"but not found in any interface(s) for bean JDK proxy. Either " +
+								"pull the method up to an interface or switch to subclass (CGLIB) " +
+								"proxies by setting proxy-target-class/proxyTargetClass " +
+								"attribute to 'true'", method.getName(), method.getDeclaringClass().getSimpleName()));
+			}
+		}
+
+		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
+		endpoint.setBean(bean);
+		endpoint.setMethod(method);
+		endpoint.setMessageHandlerMethodFactory(this.messageHandlerMethodFactory);
+		endpoint.setId(getEndpointId(rabbitListener));
+		endpoint.setQueueNames(rabbitListener.queues());
+
+		endpoint.setExclusive(rabbitListener.exclusive());
+		if (rabbitListener.priority() >= 0) {
+			endpoint.setPriority(rabbitListener.priority());
+		}
+		if (StringUtils.hasText(rabbitListener.responseRoutingKey())) {
+			endpoint.setResponseRoutingKey(rabbitListener.responseRoutingKey());
+		}
+		if (StringUtils.hasText(rabbitListener.admin())) {
+			Assert.state(this.beanFactory != null, "BeanFactory must be set to resolve RabbitAdmin by bean name");
+			try {
+				endpoint.setAdmin(this.beanFactory.getBean(rabbitListener.admin(), RabbitAdmin.class));
+			}
+			catch (NoSuchBeanDefinitionException ex) {
+				throw new BeanInitializationException("Could not register rabbit listener endpoint on [" +
+						method + "], no " + RabbitAdmin.class.getSimpleName() + " with id '" +
+						rabbitListener.admin() + "' was found in the application context", ex);
+			}
+		}
+
+
+		RabbitListenerContainerFactory<?> factory = null;
+		String containerFactoryBeanName = rabbitListener.containerFactory();
+		if (StringUtils.hasText(containerFactoryBeanName)) {
+			Assert.state(this.beanFactory != null, "BeanFactory must be set to obtain container factory by bean name");
+			try {
+				factory = this.beanFactory.getBean(containerFactoryBeanName, RabbitListenerContainerFactory.class);
+			}
+			catch (NoSuchBeanDefinitionException ex) {
+				throw new BeanInitializationException("Could not register rabbit listener endpoint on [" +
+						method + "], no " + RabbitListenerContainerFactory.class.getSimpleName() + " with id '" +
+						containerFactoryBeanName + "' was found in the application context", ex);
+			}
+		}
+
+		this.registrar.registerEndpoint(endpoint, factory);
+	}
+
+	private String getEndpointId(RabbitListener rabbitListener) {
+		if (StringUtils.hasText(rabbitListener.id())) {
+			return rabbitListener.id();
+		}
+		else {
+			return "org.springframework.amqp.rabbit.RabbitListenerEndpointContainer#" + counter.getAndIncrement();
+		}
+	}
+
+
+	/**
+	 * An {@link MessageHandlerMethodFactory} adapter that offers a configurable underlying
+	 * instance to use. Useful if the factory to use is determined once the endpoints
+	 * have been registered but not created yet.
+	 * @see RabbitListenerEndpointRegistrar#setMessageHandlerMethodFactory
+	 */
+	private class RabbitHandlerMethodFactoryAdapter implements MessageHandlerMethodFactory {
+
+		private MessageHandlerMethodFactory messageHandlerMethodFactory;
+
+		public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory rabbitHandlerMethodFactory1) {
+			this.messageHandlerMethodFactory = rabbitHandlerMethodFactory1;
+		}
+
+		@Override
+		public InvocableHandlerMethod createInvocableHandlerMethod(Object bean, Method method) {
+			return getMessageHandlerMethodFactory().createInvocableHandlerMethod(bean, method);
+		}
+
+		private MessageHandlerMethodFactory getMessageHandlerMethodFactory() {
+			if (this.messageHandlerMethodFactory == null) {
+				this.messageHandlerMethodFactory = createDefaultMessageHandlerMethodFactory();
+			}
+			return this.messageHandlerMethodFactory;
+		}
+
+		private MessageHandlerMethodFactory createDefaultMessageHandlerMethodFactory() {
+			DefaultMessageHandlerMethodFactory defaultFactory = new DefaultMessageHandlerMethodFactory();
+			defaultFactory.setBeanFactory(beanFactory);
+			defaultFactory.afterPropertiesSet();
+			return defaultFactory;
+		}
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerConfigurer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerConfigurer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistrar;
+
+/**
+ * Optional interface to be implemented by Spring managed bean willing
+ * to customize how Rabbit listener endpoints are configured. Typically
+ * used to defined the default
+ * {@link org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory
+ * RabbitListenerContainerFactory} to use or for registering Rabbit endpoints
+ * in a <em>programmatic</em> fashion as opposed to the <em>declarative</em>
+ * approach of using the @{@link RabbitListener} annotation.
+ *
+ * <p>See @{@link EnableRabbit} for detailed usage examples.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ * @see EnableRabbit
+ * @see org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistrar
+ */
+public interface RabbitListenerConfigurer {
+
+	/**
+	 * Callback allowing a {@link org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry
+	 * RabbitListenerEndpointRegistry} and specific {@link org.springframework.amqp.rabbit.config.RabbitListenerEndpoint
+	 * RabbitListenerEndpoint} instances to be registered against the given
+	 * {@link RabbitListenerEndpointRegistrar}. The default
+	 * {@link org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory RabbitListenerContainerFactory}
+	 * can also be customized.
+	 * @param registrar the registrar to be configured
+	 */
+	void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar);
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/package-info.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/package-info.java
@@ -1,0 +1,6 @@
+
+/**
+ * Annotations and supporting classes for declarative Rabbit listener
+ * endpoint
+ */
+package org.springframework.amqp.rabbit.annotation;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.util.ErrorHandler;
+
+/**
+ * Base {@link RabbitListenerContainerFactory} for Spring's base container implementation.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ * @see AbstractMessageListenerContainer
+ */
+public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractMessageListenerContainer>
+		implements RabbitListenerContainerFactory<C> {
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private ConnectionFactory connectionFactory;
+
+	private ErrorHandler errorHandler;
+
+	private MessageConverter messageConverter;
+
+	private AcknowledgeMode acknowledgeMode;
+
+	private Boolean channelTransacted;
+
+	private Boolean autoStartup;
+
+	private Integer phase;
+
+	protected final AtomicInteger counter = new AtomicInteger();
+
+	/**
+	 * @see AbstractMessageListenerContainer#setConnectionFactory(ConnectionFactory)
+	 */
+	public void setConnectionFactory(ConnectionFactory connectionFactory) {
+		this.connectionFactory = connectionFactory;
+	}
+
+	/**
+	 * @see AbstractMessageListenerContainer#setErrorHandler(org.springframework.util.ErrorHandler)
+	 */
+	public void setErrorHandler(ErrorHandler errorHandler) {
+		this.errorHandler = errorHandler;
+	}
+
+	/**
+	 * @see AbstractMessageListenerContainer#setMessageConverter(MessageConverter)
+	 */
+	public void setMessageConverter(MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
+	}
+
+	/**
+	 * @see AbstractMessageListenerContainer#setAcknowledgeMode(AcknowledgeMode)
+	 */
+	public void setAcknowledgeMode(AcknowledgeMode acknowledgeMode) {
+		this.acknowledgeMode = acknowledgeMode;
+	}
+
+	/**
+	 * @see AbstractMessageListenerContainer#setChannelTransacted
+	 */
+	public void setChannelTransacted(Boolean channelTransacted) {
+		this.channelTransacted = channelTransacted;
+	}
+
+	/**
+	 * @see AbstractMessageListenerContainer#setAutoStartup(boolean)
+	 */
+	public void setAutoStartup(Boolean autoStartup) {
+		this.autoStartup = autoStartup;
+	}
+
+	/**
+	 * @see AbstractMessageListenerContainer#setPhase(int)
+	 */
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
+
+
+	@Override
+	public C createListenerContainer(RabbitListenerEndpoint endpoint) {
+		C instance = createContainerInstance();
+
+		if (this.connectionFactory != null) {
+			instance.setConnectionFactory(this.connectionFactory);
+		}
+		if (this.errorHandler != null) {
+			instance.setErrorHandler(this.errorHandler);
+		}
+		if (this.messageConverter != null) {
+			instance.setMessageConverter(this.messageConverter);
+		}
+		if (this.acknowledgeMode != null) {
+			instance.setAcknowledgeMode(this.acknowledgeMode);
+		}
+		if (this.channelTransacted != null) {
+			instance.setChannelTransacted(this.channelTransacted);
+		}
+		if (this.autoStartup != null) {
+			instance.setAutoStartup(this.autoStartup);
+		}
+		if (this.phase != null) {
+			instance.setPhase(this.phase);
+		}
+
+		endpoint.setupListenerContainer(instance);
+		initializeContainer(instance);
+
+		return instance;
+	}
+
+	/**
+	 * Create an empty container instance.
+	 */
+	protected abstract C createContainerInstance();
+
+	/**
+	 * Further initialize the specified container.
+	 * <p>Subclasses can inherit from this method to apply extra
+	 * configuration if necessary.
+	 */
+	protected void initializeContainer(C instance) {
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerEndpoint.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.AbstractAdaptableMessageListener;
+import org.springframework.util.Assert;
+
+/**
+ * Base model for a Rabbit listener endpoint
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ * @see MethodRabbitListenerEndpoint
+ * @see SimpleRabbitListenerEndpoint
+ */
+public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEndpoint {
+
+	private String id;
+
+	private Collection<Queue> queues = new ArrayList<Queue>();
+
+	private Collection<String> queueNames = new ArrayList<String>();
+
+	private boolean exclusive;
+
+	private Integer priority;
+
+	private String responseRoutingKey;
+
+	private RabbitAdmin admin;
+
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@Override
+	public String getId() {
+		return this.id;
+	}
+
+	/**
+	 * Set the queues to use. Either the {@link Queue} instances or the
+	 * queue names should be provided, but not both.
+	 * @see #setQueueNames
+	 */
+	public void setQueues(Queue... queues) {
+		Assert.notNull(queues, "Queues must not be null");
+		this.queues.clear();
+		this.queues.addAll(Arrays.asList(queues));
+	}
+
+	/**
+	 * Return the queues for this endpoint.
+	 */
+	public Collection<Queue> getQueues() {
+		return queues;
+	}
+
+	/**
+	 * Set the queue names to use. Either the {@link Queue} instances or the
+	 * queue names should be provided, but not both.
+	 * @see #setQueues
+	 */
+	public Collection<String> getQueueNames() {
+		return queueNames;
+	}
+
+	/**
+	 * Return the queue names for this endpoint.
+	 */
+	public void setQueueNames(String... queueNames) {
+		this.queueNames.clear();
+		this.queueNames.addAll(Arrays.asList(queueNames));
+	}
+
+	/**
+	 * Set if a single consumer in the container will have exclusive use of the
+	 * queues, preventing other consumers from receiving messages from the
+	 * queue(s).
+	 */
+	public void setExclusive(boolean exclusive) {
+		this.exclusive = exclusive;
+	}
+
+	/**
+	 * Specify if a single consumer in the container will have exclusive use of the
+	 * queues.
+	 */
+	public boolean isExclusive() {
+		return exclusive;
+	}
+
+	/**
+	 * Set the priority of this endpoint
+	 */
+	public void setPriority(Integer priority) {
+		this.priority = priority;
+	}
+
+	/**
+	 * Return the priority of this endpoint or {@code null} if
+	 * no priority is set.
+	 */
+	public Integer getPriority() {
+		return priority;
+	}
+
+	/**
+	 * Set the routing key to send along with a response message.
+	 */
+	public void setResponseRoutingKey(String responseRoutingKey) {
+		this.responseRoutingKey = responseRoutingKey;
+	}
+
+	/**
+	 * Return the routing key to send along with a response message.
+	 */
+	public String getResponseRoutingKey() {
+		return responseRoutingKey;
+	}
+
+	/**
+	 * Set the {@link RabbitAdmin} instance to use.
+	 */
+	public void setAdmin(RabbitAdmin admin) {
+		this.admin = admin;
+	}
+
+	/**
+	 * Return the {@link RabbitAdmin} instance to use or {@code null} if
+	 * none is configured.
+	 */
+	public RabbitAdmin getAdmin() {
+		return admin;
+	}
+
+	@Override
+	public void setupListenerContainer(MessageListenerContainer listenerContainer) {
+		SimpleMessageListenerContainer container = (SimpleMessageListenerContainer) listenerContainer;
+
+		boolean queuesEmpty = getQueues().isEmpty();
+		boolean queueNamesEmpty = getQueueNames().isEmpty();
+		if (!queuesEmpty && !queueNamesEmpty) {
+			throw new IllegalStateException("Queues or queue names must be provided but not both for " + this);
+		}
+		if (queuesEmpty) {
+			Collection<String> names = getQueueNames();
+			container.setQueueNames(names.toArray(new String[names.size()]));
+		}
+		else {
+			Collection<Queue> instances = getQueues();
+			container.setQueues(instances.toArray(new Queue[instances.size()]));
+		}
+
+		container.setExclusive(isExclusive());
+		if (getPriority() != null) {
+			Map<String, Object> args = new HashMap<String, Object>();
+			args.put("x-priority", getPriority());
+			container.setConsumerArguments(args);
+		}
+
+		if (getAdmin() != null) {
+			container.setRabbitAdmin(getAdmin());
+		}
+		setupMessageListener(listenerContainer);
+	}
+
+	/**
+	 * Create a {@link MessageListener} that is able to serve this endpoint for the
+	 * specified container.
+	 */
+	protected abstract MessageListener createMessageListener(MessageListenerContainer container);
+
+	private void setupMessageListener(MessageListenerContainer container) {
+		MessageListener messageListener = createMessageListener(container);
+		if (getResponseRoutingKey() != null && messageListener instanceof AbstractAdaptableMessageListener) {
+			((AbstractAdaptableMessageListener) messageListener).setResponseRoutingKey(getResponseRoutingKey());
+		}
+		Assert.state(messageListener != null, "Endpoint [" + this + "] must provide a non null message listener");
+		container.setupMessageListener(messageListener);
+	}
+
+	/**
+	 * Return a description for this endpoint.
+	 * <p>Available to subclasses, for inclusion in their {@code toString()} result.
+	 */
+	protected StringBuilder getEndpointDescription() {
+		StringBuilder result = new StringBuilder();
+		return result.append(getClass().getSimpleName()).append("[").append(this.id).
+				append("] queues=").append(this.queues).
+				append("' | queueNames='").append(this.queueNames).
+				append("' | exclusive='").append(this.exclusive).
+				append("' | priority='").append(this.priority).
+				append("' | responseRoutingKey='").append(this.responseRoutingKey).
+				append("' | admin='").append(this.admin).append("'");
+	}
+
+	@Override
+	public String toString() {
+		return getEndpointDescription().toString();
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AnnotationDrivenParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AnnotationDrivenParser.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.parsing.BeanComponentDefinition;
+import org.springframework.beans.factory.parsing.CompositeComponentDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.xml.BeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+
+/**
+ * Parser for the 'annotation-driven' element of the 'rabbit' namespace.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+class AnnotationDrivenParser implements BeanDefinitionParser {
+
+	@Override
+	public BeanDefinition parse(Element element, ParserContext parserContext) {
+		Object source = parserContext.extractSource(element);
+
+		// Register component for the surrounding <rabbit:annotation-driven> element.
+		CompositeComponentDefinition compDefinition = new CompositeComponentDefinition(element.getTagName(), source);
+		parserContext.pushContainingComponent(compDefinition);
+
+		// Nest the concrete post-processor bean in the surrounding component.
+		BeanDefinitionRegistry registry = parserContext.getRegistry();
+
+		if (registry.containsBeanDefinition(RabbitListenerConfigUtils.RABBIT_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME)) {
+			parserContext.getReaderContext().error(
+					"Only one RabbitListenerAnnotationBeanPostProcessor may exist within the context.", source);
+		}
+		else {
+			BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
+					"org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor");
+			builder.getRawBeanDefinition().setSource(source);
+			String endpointRegistry = element.getAttribute("registry");
+			if (StringUtils.hasText(endpointRegistry)) {
+				builder.addPropertyReference("endpointRegistry", endpointRegistry);
+			}
+			else {
+				registerDefaultEndpointRegistry(source, parserContext);
+			}
+
+			String containerFactory = element.getAttribute("container-factory");
+			if (StringUtils.hasText(containerFactory)) {
+				builder.addPropertyValue("containerFactoryBeanName", containerFactory);
+			}
+
+			String handlerMethodFactory = element.getAttribute("handler-method-factory");
+			if (StringUtils.hasText(handlerMethodFactory)) {
+				builder.addPropertyReference("messageHandlerMethodFactory", handlerMethodFactory);
+			}
+
+			registerInfrastructureBean(parserContext, builder,
+					RabbitListenerConfigUtils.RABBIT_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME);
+		}
+
+		// Finally register the composite component.
+		parserContext.popAndRegisterContainingComponent();
+
+		return null;
+	}
+
+	private static void registerDefaultEndpointRegistry(Object source, ParserContext parserContext) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
+				"org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry");
+		builder.getRawBeanDefinition().setSource(source);
+		registerInfrastructureBean(parserContext, builder,
+				RabbitListenerConfigUtils.RABBIT_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME);
+	}
+
+	private static void registerInfrastructureBean(
+			ParserContext parserContext, BeanDefinitionBuilder builder, String beanName) {
+
+		builder.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		parserContext.getRegistry().registerBeanDefinition(beanName, builder.getBeanDefinition());
+		BeanDefinitionHolder holder = new BeanDefinitionHolder(builder.getBeanDefinition(), beanName);
+		parserContext.registerComponent(new BeanComponentDefinition(holder));
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/MethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/MethodRabbitListenerEndpoint.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * A {@link RabbitListenerEndpoint} providing the method to invoke to process
+ * an incoming message for this endpoint.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint {
+
+	private Object bean;
+
+	private Method method;
+
+	private MessageHandlerMethodFactory messageHandlerMethodFactory;
+
+
+	/**
+	 * Set the object instance that should manage this endpoint.
+	 */
+	public void setBean(Object bean) {
+		this.bean = bean;
+	}
+
+	public Object getBean() {
+		return this.bean;
+	}
+
+	/**
+	 * Set the method to invoke to process a message managed by this endpoint.
+	 */
+	public void setMethod(Method method) {
+		this.method = method;
+	}
+
+	public Method getMethod() {
+		return this.method;
+	}
+
+	/**
+	 * Set the {@link MessageHandlerMethodFactory} to use to build the
+	 * {@link InvocableHandlerMethod} responsible to manage the invocation
+	 * of this endpoint.
+	 */
+	public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory messageHandlerMethodFactory) {
+		this.messageHandlerMethodFactory = messageHandlerMethodFactory;
+	}
+
+
+	@Override
+	protected MessagingMessageListenerAdapter createMessageListener(MessageListenerContainer container) {
+		Assert.state(this.messageHandlerMethodFactory != null,
+				"Could not create message listener - MessageHandlerMethodFactory not set");
+		MessagingMessageListenerAdapter messageListener = createMessageListenerInstance();
+		InvocableHandlerMethod invocableHandlerMethod =
+				this.messageHandlerMethodFactory.createInvocableHandlerMethod(getBean(), getMethod());
+		messageListener.setHandlerMethod(invocableHandlerMethod);
+		String responseExchange = getDefaultResponseExchange();
+		if (StringUtils.hasText(responseExchange)) {
+			messageListener.setResponseExchange(responseExchange);
+		}
+		MessageConverter messageConverter = container.getMessageConverter();
+		if (messageConverter != null) {
+			messageListener.setMessageConverter(messageConverter);
+		}
+		return messageListener;
+	}
+
+	/**
+	 * Create an empty {@link MessagingMessageListenerAdapter} instance.
+	 */
+	protected MessagingMessageListenerAdapter createMessageListenerInstance() {
+		return new MessagingMessageListenerAdapter();
+	}
+
+	private String getDefaultResponseExchange() {
+		SendTo ann = AnnotationUtils.getAnnotation(getMethod(), SendTo.class);
+		if (ann != null) {
+			Object[] destinations = ann.value();
+			if (destinations.length != 1) {
+				throw new IllegalStateException("Invalid @" + SendTo.class.getSimpleName() + " annotation on '"
+						+ getMethod() + "' one destination must be set (got " + Arrays.toString(destinations) + ")");
+			}
+			return (String) destinations[0];
+		}
+		return null;
+	}
+
+	@Override
+	protected StringBuilder getEndpointDescription() {
+		return super.getEndpointDescription()
+				.append(" | bean='").append(this.bean).append("'")
+				.append(" | method='").append(this.method).append("'");
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerConfigUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerConfigUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+/**
+ * Configuration constants for internal sharing across subpackages.
+ *
+ * @author Juergen Hoeller
+ * @since 2.0
+ */
+public abstract class RabbitListenerConfigUtils {
+
+	/**
+	 * The bean name of the internally managed Rabbit listener annotation processor.
+	 */
+	public static final String RABBIT_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME =
+			"org.springframework.amqp.rabbit.config.internalRabbitListenerAnnotationProcessor";
+
+	/**
+	 * The bean name of the internally managed Rabbit listener endpoint registry.
+	 */
+	public static final String RABBIT_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME =
+			"org.springframework.amqp.rabbit.config.internalRabbitListenerEndpointRegistry";
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+
+/**
+ * Factory of {@link MessageListenerContainer} based on a
+ * {@link RabbitListenerEndpoint} definition.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ * @see RabbitListenerEndpoint
+ */
+public interface RabbitListenerContainerFactory<C extends MessageListenerContainer> {
+
+	/**
+	 * Create a {@link MessageListenerContainer} for the given {@link RabbitListenerEndpoint}.
+	 * @param endpoint the endpoint to configure
+	 * @return the created container
+	 */
+	C createListenerContainer(RabbitListenerEndpoint endpoint);
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpoint.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+
+/**
+ * Model for a Rabbit listener endpoint. Can be used against a
+ * {@link org.springframework.amqp.rabbit.annotation.RabbitListenerConfigurer
+ * RabbitListenerConfigurer} to register endpoints programmatically.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public interface RabbitListenerEndpoint {
+
+	/**
+	 * Return the id of this endpoint. The id can be further qualified
+	 * when the endpoint is resolved against its actual listener
+	 * container.
+	 * @see RabbitListenerContainerFactory#createListenerContainer
+	 */
+	String getId();
+
+	/**
+	 * Setup the specified message listener container with the model
+	 * defined by this endpoint.
+	 * <p>This endpoint must provide the requested missing option(s) of
+	 * the specified container to make it usable. Usually, this is about
+	 * setting the {@code queues} and the {@code messageListener} to
+	 * use but an implementation may override any default setting that
+	 * was already set.
+	 * @param listenerContainer the listener container to configure
+	 */
+	void setupListenerContainer(MessageListenerContainer listenerContainer);
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpointRegistrar.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpointRegistrar.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.util.Assert;
+
+/**
+ * Helper bean for registering {@link RabbitListenerEndpoint} with
+ * a {@link RabbitListenerEndpointRegistry}.
+ *
+ * @author Stephane Nicoll
+ * @author Juergen Hoeller
+ * @since 2.0
+ * @see org.springframework.amqp.rabbit.annotation.RabbitListenerConfigurer
+ */
+public class RabbitListenerEndpointRegistrar implements BeanFactoryAware, InitializingBean {
+
+	private RabbitListenerEndpointRegistry endpointRegistry;
+
+	private MessageHandlerMethodFactory messageHandlerMethodFactory;
+
+	private RabbitListenerContainerFactory<?> containerFactory;
+
+	private String containerFactoryBeanName;
+
+	private BeanFactory beanFactory;
+
+	private final List<AmqpListenerEndpointDescriptor> endpointDescriptors =
+			new ArrayList<AmqpListenerEndpointDescriptor>();
+
+
+	/**
+	 * Set the {@link RabbitListenerEndpointRegistry} instance to use.
+	 */
+	public void setEndpointRegistry(RabbitListenerEndpointRegistry endpointRegistry) {
+		this.endpointRegistry = endpointRegistry;
+	}
+
+	/**
+	 * Return the {@link RabbitListenerEndpointRegistry} instance for this
+	 * registrar, may be {@code null}.
+	 */
+	public RabbitListenerEndpointRegistry getEndpointRegistry() {
+		return this.endpointRegistry;
+	}
+
+	/**
+	 * Set the {@link MessageHandlerMethodFactory} to use to configure the message
+	 * listener responsible to serve an endpoint detected by this processor.
+	 * <p>By default, {@link DefaultMessageHandlerMethodFactory} is used and it
+	 * can be configured further to support additional method arguments
+	 * or to customize conversion and validation support. See
+	 * {@link DefaultMessageHandlerMethodFactory} javadoc for more details.
+	 */
+	public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory rabbitHandlerMethodFactory) {
+		this.messageHandlerMethodFactory = rabbitHandlerMethodFactory;
+	}
+
+	/**
+	 * Return the custom {@link MessageHandlerMethodFactory} to use, if any.
+	 */
+	public MessageHandlerMethodFactory getMessageHandlerMethodFactory() {
+		return this.messageHandlerMethodFactory;
+	}
+
+	/**
+	 * Set the {@link RabbitListenerContainerFactory} to use in case a {@link RabbitListenerEndpoint}
+	 * is registered with a {@code null} container factory.
+	 * <p>Alternatively, the bean name of the {@link RabbitListenerContainerFactory} to use
+	 * can be specified for a lazy lookup, see {@link #setContainerFactoryBeanName}.
+	 */
+	public void setContainerFactory(RabbitListenerContainerFactory<?> containerFactory) {
+		this.containerFactory = containerFactory;
+	}
+
+	/**
+	 * Set the bean name of the {@link RabbitListenerContainerFactory} to use in case
+	 * a {@link RabbitListenerEndpoint} is registered with a {@code null} container factory.
+	 * Alternatively, the container factory instance can be registered directly:
+	 * see {@link #setContainerFactory(RabbitListenerContainerFactory)}.
+	 * @see #setBeanFactory
+	 */
+	public void setContainerFactoryBeanName(String containerFactoryBeanName) {
+		this.containerFactoryBeanName = containerFactoryBeanName;
+	}
+
+	/**
+	 * A {@link org.springframework.beans.factory.BeanFactory} only needs to be available in conjunction with
+	 * {@link #setContainerFactoryBeanName}.
+	 */
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) {
+		this.beanFactory = beanFactory;
+	}
+
+
+	@Override
+	public void afterPropertiesSet() {
+		registerAllEndpoints();
+	}
+
+	protected void registerAllEndpoints() {
+		for (AmqpListenerEndpointDescriptor descriptor : this.endpointDescriptors) {
+			this.endpointRegistry.registerListenerContainer(descriptor.endpoint, resolveContainerFactory(descriptor));
+		}
+	}
+
+	private RabbitListenerContainerFactory<?> resolveContainerFactory(AmqpListenerEndpointDescriptor descriptor) {
+		if (descriptor.containerFactory != null) {
+			return descriptor.containerFactory;
+		}
+		else if (this.containerFactory != null) {
+			return this.containerFactory;
+		}
+		else if (this.containerFactoryBeanName != null) {
+			Assert.state(this.beanFactory != null, "BeanFactory must be set to obtain container factory by bean name");
+			this.containerFactory = this.beanFactory.getBean(
+					this.containerFactoryBeanName, RabbitListenerContainerFactory.class);
+			return this.containerFactory;  // Consider changing this if live change of the factory is required
+		}
+		else {
+			throw new IllegalStateException("Could not resolve the " +
+					RabbitListenerContainerFactory.class.getSimpleName() + " to use for [" +
+					descriptor.endpoint + "] no factory was given and no default is set.");
+		}
+	}
+
+	/**
+	 * Register a new {@link RabbitListenerEndpoint} alongside the
+	 * {@link RabbitListenerContainerFactory} to use to create the underlying container.
+	 * <p>The {@code factory} may be {@code null} if the default factory has to be
+	 * used for that endpoint.
+	 */
+	public void registerEndpoint(RabbitListenerEndpoint endpoint, RabbitListenerContainerFactory<?> factory) {
+		Assert.notNull(endpoint, "Endpoint must be set");
+		Assert.hasText(endpoint.getId(), "Endpoint id must be set");
+		// Factory may be null, we defer the resolution right before actually creating the container
+		this.endpointDescriptors.add(new AmqpListenerEndpointDescriptor(endpoint, factory));
+	}
+
+	/**
+	 * Register a new {@link RabbitListenerEndpoint} using the default
+	 * {@link RabbitListenerContainerFactory} to create the underlying container.
+	 * @see #setContainerFactory(RabbitListenerContainerFactory)
+	 * @see #registerEndpoint(RabbitListenerEndpoint, RabbitListenerContainerFactory)
+	 */
+	public void registerEndpoint(RabbitListenerEndpoint endpoint) {
+		registerEndpoint(endpoint, null);
+	}
+
+
+	private static class AmqpListenerEndpointDescriptor {
+
+		public final RabbitListenerEndpoint endpoint;
+
+		public final RabbitListenerContainerFactory<?> containerFactory;
+
+		public AmqpListenerEndpointDescriptor(RabbitListenerEndpoint endpoint, RabbitListenerContainerFactory<?> containerFactory) {
+			this.endpoint = endpoint;
+			this.containerFactory = containerFactory;
+		}
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpointRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpointRegistry.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.util.Assert;
+
+/**
+ * Creates the necessary {@link MessageListenerContainer} instances for the
+ * registered {@linkplain RabbitListenerEndpoint endpoints}. Also manages the
+ * lifecycle of the listener containers, in particular within the lifecycle
+ * of the application context.
+ *
+ * <p>Contrary to {@link MessageListenerContainer}s created manually, listener
+ * containers managed by registry are not beans in the application context and
+ * are not candidates for autowiring. Use {@link #getListenerContainers()} if
+ * you need to access this registry's listener containers for management purposes.
+ * If you need to access to a specific message listener container, use
+ * {@link #getListenerContainer(String)} with the id of the endpoint.
+ *
+ * @author Stephane Nicoll
+ * @author Juergen Hoeller
+ * @since 2.0
+ * @see RabbitListenerEndpoint
+ * @see MessageListenerContainer
+ * @see RabbitListenerContainerFactory
+ */
+public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLifecycle {
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private final Map<String, MessageListenerContainer> listenerContainers =
+			new LinkedHashMap<String, MessageListenerContainer>();
+
+	private int phase = Integer.MAX_VALUE;
+
+
+	/**
+	 * Return the {@link MessageListenerContainer} with the specified id or
+	 * {@code null} if no such container exists.
+	 * @param id the id of the container
+	 * @return the container or {@code null} if no container with that id exists
+	 * @see RabbitListenerEndpoint#getId()
+	 */
+	public MessageListenerContainer getListenerContainer(String id) {
+		Assert.notNull(id, "Container identifier must not be null");
+		return this.listenerContainers.get(id);
+	}
+
+	/**
+	 * Return the managed {@link MessageListenerContainer} instance(s).
+	 */
+	public Collection<MessageListenerContainer> getListenerContainers() {
+		return Collections.unmodifiableCollection(this.listenerContainers.values());
+	}
+
+
+	/**
+	 * Create a message listener container for the given {@link RabbitListenerEndpoint}.
+	 * <p>This create the necessary infrastructure to honor that endpoint
+	 * with regards to its configuration.
+	 * @param endpoint the endpoint to add
+	 * @see #getListenerContainers()
+	 * @see #getListenerContainer(String)
+	 */
+	public void registerListenerContainer(RabbitListenerEndpoint endpoint, RabbitListenerContainerFactory<?> factory) {
+		Assert.notNull(endpoint, "Endpoint must not be null");
+		Assert.notNull(factory, "Factory must not be null");
+
+		String id = endpoint.getId();
+		Assert.notNull(id, "Endpoint id must not be null");
+		Assert.state(!this.listenerContainers.containsKey(id),
+				"Another endpoint is already registered with id '" + id + "'");
+
+		MessageListenerContainer container = createListenerContainer(endpoint, factory);
+		this.listenerContainers.put(id, container);
+	}
+
+	/**
+	 * Create and start a new container using the specified factory.
+	 */
+	protected MessageListenerContainer createListenerContainer(RabbitListenerEndpoint endpoint,
+			RabbitListenerContainerFactory<?> factory) {
+
+		MessageListenerContainer listenerContainer = factory.createListenerContainer(endpoint);
+
+		if (listenerContainer instanceof InitializingBean) {
+			try {
+				((InitializingBean) listenerContainer).afterPropertiesSet();
+			}
+			catch (Exception ex) {
+				throw new BeanInitializationException("Failed to initialize message listener container", ex);
+			}
+		}
+
+		int containerPhase = listenerContainer.getPhase();
+		if (containerPhase < Integer.MAX_VALUE) {  // a custom phase value
+			if (this.phase < Integer.MAX_VALUE && this.phase != containerPhase) {
+				throw new IllegalStateException("Encountered phase mismatch between container factory definitions: " +
+						this.phase + " vs " + containerPhase);
+			}
+			this.phase = listenerContainer.getPhase();
+		}
+
+		return listenerContainer;
+	}
+
+
+	@Override
+	public void destroy() {
+		for (MessageListenerContainer listenerContainer : getListenerContainers()) {
+			if (listenerContainer instanceof DisposableBean) {
+				try {
+					((DisposableBean) listenerContainer).destroy();
+				}
+				catch (Throwable ex) {
+					logger.warn("Failed to destroy message listener container", ex);
+				}
+			}
+		}
+	}
+
+
+	// Delegating implementation of SmartLifecycle
+
+	@Override
+	public int getPhase() {
+		return this.phase;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return true;
+	}
+
+	@Override
+	public void start() {
+		for (MessageListenerContainer listenerContainer : getListenerContainers()) {
+			if (listenerContainer.isAutoStartup()) {
+				listenerContainer.start();
+			}
+		}
+	}
+
+	@Override
+	public void stop() {
+		for (MessageListenerContainer listenerContainer : getListenerContainers()) {
+			listenerContainer.stop();
+		}
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		Collection<MessageListenerContainer> listenerContainers = getListenerContainers();
+		AggregatingCallback aggregatingCallback = new AggregatingCallback(listenerContainers.size(), callback);
+		for (MessageListenerContainer listenerContainer : listenerContainers) {
+			listenerContainer.stop(aggregatingCallback);
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		for (MessageListenerContainer listenerContainer : getListenerContainers()) {
+			if (listenerContainer.isRunning()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+
+	private static class AggregatingCallback implements Runnable {
+
+		private final AtomicInteger count;
+
+		private final Runnable finishCallback;
+
+		public AggregatingCallback(int count, Runnable finishCallback) {
+			this.count = new AtomicInteger(count);
+			this.finishCallback = finishCallback;
+		}
+
+		@Override
+		public void run() {
+			if (this.count.decrementAndGet() == 0) {
+				this.finishCallback.run();
+			}
+		}
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceHandler.java
@@ -39,6 +39,7 @@ public class RabbitNamespaceHandler extends NamespaceHandlerSupport {
 		registerBeanDefinitionParser("connection-factory", new ConnectionFactoryParser());
 		registerBeanDefinitionParser("template", new TemplateParser());
 		registerBeanDefinitionParser("queue-arguments", new QueueArgumentsParser());
+		registerBeanDefinitionParser("annotation-driven", new AnnotationDrivenParser());
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import java.util.concurrent.Executor;
+
+import org.aopalliance.aop.Advice;
+
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * A {@link RabbitListenerContainerFactory} implementation to build a regular
+ * {@link SimpleMessageListenerContainer}.
+ *
+ * <p>This should be the default for most users and a good transition paths
+ * for those that are used to build such container definition manually.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public class SimpleRabbitListenerContainerFactory
+		extends AbstractRabbitListenerContainerFactory<SimpleMessageListenerContainer> {
+
+	private Executor taskExecutor;
+
+	private PlatformTransactionManager transactionManager;
+
+	private Integer txSize;
+
+	private Integer concurrentConsumers;
+
+	private Integer maxConcurrentConsumers;
+
+	private Long startConsumerMinInterval;
+
+	private Long stopConsumerMinInterval;
+
+	private Integer consecutiveActiveTrigger;
+
+	private Integer consecutiveIdleTrigger;
+
+	private Integer prefetchCount;
+
+	private Long receiveTimeout;
+
+	private Boolean defaultRequeueRejected;
+
+	private Advice[] adviceChain;
+
+	private Long recoveryInterval;
+
+	private Boolean missingQueuesFatal;
+
+	/**
+	 * @see SimpleMessageListenerContainer#setTaskExecutor
+	 */
+	public void setTaskExecutor(Executor taskExecutor) {
+		this.taskExecutor = taskExecutor;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setTransactionManager
+	 */
+	public void setTransactionManager(PlatformTransactionManager transactionManager) {
+		this.transactionManager = transactionManager;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setTxSize
+	 */
+	public void setTxSize(Integer txSize) {
+		this.txSize = txSize;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setConcurrentConsumers
+	 */
+	public void setConcurrentConsumers(Integer concurrency) {
+		this.concurrentConsumers = concurrency;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setMaxConcurrentConsumers
+	 */
+	public void setMaxConcurrentConsumers(Integer maxConcurrency) {
+		this.maxConcurrentConsumers = maxConcurrency;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setStartConsumerMinInterval
+	 */
+	public void setStartConsumerMinInterval(Long minStartInterval) {
+		this.startConsumerMinInterval = minStartInterval;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setStopConsumerMinInterval
+	 */
+	public void setStopConsumerMinInterval(Long minStopInterval) {
+		this.stopConsumerMinInterval = minStopInterval;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setConsecutiveActiveTrigger
+	 */
+	public void setConsecutiveActiveTrigger(Integer minConsecutiveActive) {
+		this.consecutiveActiveTrigger = minConsecutiveActive;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setConsecutiveIdleTrigger
+	 */
+	public void setConsecutiveIdleTrigger(Integer minConsecutiveIdle) {
+		this.consecutiveIdleTrigger = minConsecutiveIdle;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setPrefetchCount(int)
+	 */
+	public void setPrefetchCount(Integer prefetch) {
+		this.prefetchCount = prefetch;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setReceiveTimeout
+	 */
+	public void setReceiveTimeout(Long receiveTimeout) {
+		this.receiveTimeout = receiveTimeout;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setDefaultRequeueRejected
+	 */
+	public void setDefaultRequeueRejected(Boolean requeueRejected) {
+		this.defaultRequeueRejected = requeueRejected;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setAdviceChain
+	 */
+	public void setAdviceChain(Advice... adviceChain) {
+		this.adviceChain = adviceChain;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setRecoveryInterval
+	 */
+	public void setRecoveryInterval(Long recoveryInterval) {
+		this.recoveryInterval = recoveryInterval;
+	}
+
+	/**
+	 * @see SimpleMessageListenerContainer#setMissingQueuesFatal
+	 */
+	public void setMissingQueuesFatal(Boolean missingQueuesFatal) {
+		this.missingQueuesFatal = missingQueuesFatal;
+	}
+
+	@Override
+	protected SimpleMessageListenerContainer createContainerInstance() {
+		return new SimpleMessageListenerContainer();
+	}
+
+	@Override
+	protected void initializeContainer(SimpleMessageListenerContainer instance) {
+		super.initializeContainer(instance);
+
+		if (this.taskExecutor != null) {
+			instance.setTaskExecutor(this.taskExecutor);
+		}
+		if (this.transactionManager != null) {
+			instance.setTransactionManager(this.transactionManager);
+		}
+		if (this.txSize != null) {
+			instance.setTxSize(this.txSize);
+		}
+		if (this.concurrentConsumers != null) {
+			instance.setConcurrentConsumers(this.concurrentConsumers);
+		}
+		if (this.maxConcurrentConsumers != null) {
+			instance.setMaxConcurrentConsumers(this.maxConcurrentConsumers);
+		}
+		if (this.startConsumerMinInterval != null) {
+			instance.setStartConsumerMinInterval(this.startConsumerMinInterval);
+		}
+		if (this.stopConsumerMinInterval != null) {
+			instance.setStopConsumerMinInterval(this.stopConsumerMinInterval);
+		}
+		if (this.consecutiveActiveTrigger != null) {
+			instance.setConsecutiveActiveTrigger(this.consecutiveActiveTrigger);
+		}
+		if (this.consecutiveIdleTrigger != null) {
+			instance.setConsecutiveIdleTrigger(this.consecutiveIdleTrigger);
+		}
+		if (this.prefetchCount != null) {
+			instance.setPrefetchCount(this.prefetchCount);
+		}
+		if (this.receiveTimeout != null) {
+			instance.setReceiveTimeout(this.receiveTimeout);
+		}
+		if (this.defaultRequeueRejected != null) {
+			instance.setDefaultRequeueRejected(this.defaultRequeueRejected);
+		}
+		if (this.adviceChain != null) {
+			instance.setAdviceChain(this.adviceChain);
+		}
+		if (this.recoveryInterval != null) {
+			instance.setRecoveryInterval(this.recoveryInterval);
+		}
+		if (this.missingQueuesFatal != null) {
+			instance.setMissingQueuesFatal(this.missingQueuesFatal);
+		}
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerEndpoint.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+
+/**
+ * A {@link RabbitListenerEndpoint} simply providing the {@link MessageListener} to
+ * invoke to process an incoming message for this endpoint.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public class SimpleRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint {
+
+	private MessageListener messageListener;
+
+
+	/**
+	 * Set the {@link MessageListener} to invoke when a message matching
+	 * the endpoint is received.
+	 */
+	public void setMessageListener(MessageListener messageListener) {
+		this.messageListener = messageListener;
+	}
+
+	/**
+	 * Return the {@link MessageListener} to invoke when a message matching
+	 * the endpoint is received.
+	 */
+	public MessageListener getMessageListener() {
+		return this.messageListener;
+	}
+
+
+	@Override
+	protected MessageListener createMessageListener(MessageListenerContainer container) {
+		return getMessageListener();
+	}
+
+	@Override
+	protected StringBuilder getEndpointDescription() {
+		return super.getEndpointDescription()
+				.append(" | messageListener='").append(this.messageListener).append("'");
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1,14 +1,17 @@
 /*
  * Copyright 2002-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.amqp.rabbit.listener;
@@ -30,6 +33,7 @@ import org.springframework.amqp.rabbit.connection.RabbitAccessor;
 import org.springframework.amqp.rabbit.connection.RabbitResourceHolder;
 import org.springframework.amqp.rabbit.connection.RabbitUtils;
 import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.ApplicationContext;
@@ -49,7 +53,7 @@ import com.rabbitmq.client.Channel;
  * @author Gary Russell
  */
 public abstract class AbstractMessageListenerContainer extends RabbitAccessor
-		implements ApplicationContextAware, BeanNameAware, DisposableBean, SmartLifecycle {
+		implements MessageListenerContainer, ApplicationContextAware, BeanNameAware, DisposableBean, SmartLifecycle {
 
 	private volatile String beanName;
 
@@ -66,6 +70,8 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	private volatile List<String> queueNames = new CopyOnWriteArrayList<String>();
 
 	private ErrorHandler errorHandler = new ConditionalRejectingErrorHandler();
+
+	private MessageConverter messageConverter;
 
 	private boolean exposeListenerChannel = true;
 
@@ -276,6 +282,19 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	}
 
 	/**
+	 * Set the {@link MessageConverter} strategy for converting AMQP Messages.
+	 * @param messageConverter the message converter to use
+	 */
+	public void setMessageConverter(MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
+	}
+
+	@Override
+	public MessageConverter getMessageConverter() {
+		return messageConverter;
+	}
+
+	/**
 	 * Set whether to automatically start the container after initialization.
 	 * <p>
 	 * Default is "true"; set this to "false" to allow for manual startup through the {@link #start()} method.
@@ -347,6 +366,11 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 						+ "transactional channel. Either use a different AcknowledgeMode or make sure channelTransacted=false");
 		validateConfiguration();
 		initialize();
+	}
+
+	@Override
+	public void setupMessageListener(Object messageListener) {
+		setMessageListener(messageListener);
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.SmartLifecycle;
+
+/**
+ * Internal abstraction used by the framework representing a message
+ * listener container. Not meant to be implemented externally.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public interface MessageListenerContainer extends SmartLifecycle {
+
+	/**
+	 * Setup the message listener to use. Throws an {@link IllegalArgumentException}
+	 * if that message listener type is not supported.
+	 */
+	void setupMessageListener(Object messageListener);
+
+	/**
+	 * Return the {@link MessageConverter} that can be used to
+	 * convert {@link org.springframework.amqp.core.Message}, if any.
+	 */
+	MessageConverter getMessageConverter();
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import com.rabbitmq.client.Channel;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.core.Address;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
+import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
+import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
+import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
+import org.springframework.amqp.support.AmqpHeaderMapper;
+import org.springframework.amqp.support.converter.MessageConversionException;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.MessagingMessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.util.Assert;
+
+/**
+ * An abstract {@link MessageListener} adapter providing the necessary infrastructure
+ * to extract the payload of a {@link Message}
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ * @see MessageListener
+ * @see ChannelAwareMessageListener
+ */
+public abstract class AbstractAdaptableMessageListener implements MessageListener, ChannelAwareMessageListener {
+
+	private static final String DEFAULT_RESPONSE_ROUTING_KEY = "";
+
+	private static final String DEFAULT_ENCODING = "UTF-8";
+
+
+	/** Logger available to subclasses */
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private String responseRoutingKey = DEFAULT_RESPONSE_ROUTING_KEY;
+
+	private String responseExchange = null;
+
+	private volatile boolean mandatoryPublish;
+
+	private MessageConverter messageConverter = new SimpleMessageConverter();
+
+	private volatile MessagePropertiesConverter messagePropertiesConverter = new DefaultMessagePropertiesConverter();
+
+	private final MessagingMessageConverterAdapter messagingMessageConverter = new MessagingMessageConverterAdapter();
+
+	private String encoding = DEFAULT_ENCODING;
+
+
+	/**
+	 * Set the routing key to use when sending response messages. This will be applied in case of a request message that
+	 * does not carry a "ReplyTo" property
+	 * <p>
+	 * Response destinations are only relevant for listener methods that return result objects, which will be wrapped in
+	 * a response message and sent to a response destination.
+	 *
+	 * @param responseRoutingKey The routing key.
+	 */
+	public void setResponseRoutingKey(String responseRoutingKey) {
+		this.responseRoutingKey = responseRoutingKey;
+	}
+
+	/**
+	 * The encoding to use when inter-converting between byte arrays and Strings in message properties.
+	 *
+	 * @param encoding the encoding to set
+	 */
+	public void setEncoding(String encoding) {
+		this.encoding = encoding;
+	}
+
+	/**
+	 * Set the exchange to use when sending response messages. This is only used if the exchange from the received
+	 * message is null.
+	 * <p>
+	 * Response destinations are only relevant for listener methods that return result objects, which will be wrapped in
+	 * a response message and sent to a response destination.
+	 * @param responseExchange The exchange.
+	 */
+	public void setResponseExchange(String responseExchange) {
+		this.responseExchange = responseExchange;
+	}
+
+	public void setMandatoryPublish(boolean mandatoryPublish) {
+		this.mandatoryPublish = mandatoryPublish;
+	}
+
+	/**
+	 * @param immediatePublish No longer supported.
+	 * @deprecated 'immediate' no longer support by RabbitMQ.
+	 */
+	@Deprecated
+	public void setImmediatePublish(boolean immediatePublish) {
+		// No-op
+	}
+
+	/**
+	 * Set the converter that will convert incoming Rabbit messages to listener method arguments, and objects returned
+	 * from listener methods back to Rabbit messages.
+	 * <p>
+	 * The default converter is a {@link SimpleMessageConverter}, which is able to handle "text" content-types.
+	 *
+	 * @param messageConverter The message converter.
+	 */
+	public void setMessageConverter(MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
+	}
+
+	/**
+	 * Return the converter that will convert incoming Rabbit messages to listener method arguments, and objects
+	 * returned from listener methods back to Rabbit messages.
+	 *
+	 * @return The message converter.
+	 */
+	protected MessageConverter getMessageConverter() {
+		return this.messageConverter;
+	}
+
+	/**
+	 * Set the {@link AmqpHeaderMapper} implementation to use to map the standard
+	 * AMQP headers. By default, a {@link org.springframework.amqp.support.SimpleAmqpHeaderMapper
+	 * SimpleAmqpHeaderMapper} is used.
+	 * @see org.springframework.amqp.support.SimpleAmqpHeaderMapper
+	 */
+	public void setHeaderMapper(AmqpHeaderMapper headerMapper) {
+		Assert.notNull(headerMapper, "HeaderMapper must not be null");
+		this.messagingMessageConverter.setHeaderMapper(headerMapper);
+	}
+
+	/**
+	 * Return the {@link MessagingMessageConverter} for this listener,
+	 * being able to convert {@link org.springframework.messaging.Message}.
+	 */
+	protected final MessagingMessageConverter getMessagingMessageConverter() {
+		return this.messagingMessageConverter;
+	}
+
+
+	/**
+	 * Rabbit {@link MessageListener} entry point.
+	 * <p>
+	 * Delegates the message to the target listener method, with appropriate conversion of the message argument. In case
+	 * of an exception, the {@link #handleListenerException(Throwable)} method will be invoked.
+	 * <p>
+	 * <b>Note:</b> Does not support sending response messages based on result objects returned from listener methods.
+	 * Use the {@link ChannelAwareMessageListener} entry point (typically through a Spring message listener container)
+	 * for handling result objects as well.
+	 * @param message the incoming Rabbit message
+	 * @see #handleListenerException
+	 * @see #onMessage(Message, com.rabbitmq.client.Channel)
+	 */
+	@Override
+	public void onMessage(Message message) {
+		try {
+			onMessage(message, null);
+		}
+		catch (Throwable ex) {
+			handleListenerException(ex);
+		}
+	}
+
+	/**
+	 * Handle the given exception that arose during listener execution. The default implementation logs the exception at
+	 * error level.
+	 * <p>
+	 * This method only applies when using a Rabbit {@link MessageListener}. With
+	 * {@link ChannelAwareMessageListener}, exceptions get handled by the
+	 * caller instead.
+	 * @param ex the exception to handle
+	 * @see #onMessage(Message)
+	 */
+	protected void handleListenerException(Throwable ex) {
+		logger.error("Listener execution failed", ex);
+	}
+
+	/**
+	 * Extract the message body from the given Rabbit message.
+	 * @param message the Rabbit <code>Message</code>
+	 * @return the content of the message, to be passed into the listener method as argument
+	 */
+	protected Object extractMessage(Message message) {
+		MessageConverter converter = getMessageConverter();
+		if (converter != null) {
+			return converter.fromMessage(message);
+		}
+		return message;
+	}
+
+	/**
+	 * Handle the given result object returned from the listener method, sending a response message back.
+	 * @param result the result object to handle (never <code>null</code>)
+	 * @param request the original request message
+	 * @param channel the Rabbit channel to operate on (may be <code>null</code>)
+	 * @throws Exception if thrown by Rabbit API methods
+	 * @see #buildMessage
+	 * @see #postProcessResponse
+	 * @see #getReplyToAddress(Message)
+	 * @see #sendResponse
+	 */
+	protected void handleResult(Object result, Message request, Channel channel) throws Exception {
+		if (channel != null) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Listener method returned result [" + result + "] - generating response message for it");
+			}
+			try {
+				Message response = buildMessage(channel, result);
+				postProcessResponse(request, response);
+				Address replyTo = getReplyToAddress(request);
+				sendResponse(channel, replyTo, response);
+			}
+			catch (Exception ex) {
+				throw new ReplyFailureException("Failed to send reply with payload '" + result + "'", ex);
+			}
+		}
+		else if (logger.isWarnEnabled()) {
+			logger.warn("Listener method returned result [" + result
+					+ "]: not generating response message for it because of no Rabbit Channel given");
+		}
+	}
+
+	protected String getReceivedExchange(Message request) {
+		return request.getMessageProperties().getReceivedExchange();
+	}
+
+	/**
+	 * Build a Rabbit message to be sent as response based on the given result object.
+	 * @param channel the Rabbit Channel to operate on
+	 * @param result the content of the message, as returned from the listener method
+	 * @return the Rabbit <code>Message</code> (never <code>null</code>)
+	 * @throws Exception if thrown by Rabbit API methods
+	 * @see #setMessageConverter
+	 */
+	protected Message buildMessage(Channel channel, Object result) throws Exception {
+		MessageConverter converter = getMessageConverter();
+		if (converter != null) {
+			if (result instanceof org.springframework.messaging.Message) {
+				return this.messagingMessageConverter.toMessage(result, new MessageProperties());
+			}
+			else {
+				return converter.toMessage(result, new MessageProperties());
+			}
+		}
+		else {
+			if (!(result instanceof Message)) {
+				throw new MessageConversionException("No MessageConverter specified - cannot handle message [" + result
+						+ "]");
+			}
+			return (Message) result;
+		}
+	}
+
+	/**
+	 * Post-process the given response message before it will be sent.
+	 * <p>
+	 * The default implementation sets the response's correlation id to the request message's correlation id, if any;
+	 * otherwise to the request message id.
+	 * @param request the original incoming Rabbit message
+	 * @param response the outgoing Rabbit message about to be sent
+	 * @throws Exception if thrown by Rabbit API methods
+	 */
+	protected void postProcessResponse(Message request, Message response) throws Exception {
+		byte[] correlation = request.getMessageProperties().getCorrelationId();
+
+		if (correlation == null) {
+			String messageId = request.getMessageProperties().getMessageId();
+			if (messageId != null) {
+				correlation = messageId.getBytes(SimpleMessageConverter.DEFAULT_CHARSET);
+			}
+		}
+		response.getMessageProperties().setCorrelationId(correlation);
+	}
+
+	/**
+	 * Determine a reply-to Address for the given message.
+	 * <p>
+	 * The default implementation first checks the Rabbit Reply-To Address of the supplied request; if that is not
+	 * <code>null</code> it is returned; if it is <code>null</code>, then the configured default response Exchange and
+	 * routing key are used to construct a reply-to Address. If the responseExchange property is also <code>null</code>,
+	 * then an {@link org.springframework.amqp.AmqpException} is thrown.
+	 * @param request the original incoming Rabbit message
+	 * @return the reply-to Address (never <code>null</code>)
+	 * @throws Exception if thrown by Rabbit API methods
+	 * @throws org.springframework.amqp.AmqpException if no {@link Address} can be determined
+	 * @see #setResponseExchange(String)
+	 * @see #setResponseRoutingKey(String)
+	 * @see org.springframework.amqp.core.Message#getMessageProperties()
+	 * @see org.springframework.amqp.core.MessageProperties#getReplyTo()
+	 */
+	protected Address getReplyToAddress(Message request) throws Exception {
+		Address replyTo = request.getMessageProperties().getReplyToAddress();
+		if (replyTo == null) {
+			if (this.responseExchange == null) {
+				throw new AmqpException(
+						"Cannot determine ReplyTo message property value: "
+								+ "Request message does not contain reply-to property, and no default response Exchange was set.");
+			}
+			replyTo = new Address(null, this.responseExchange, this.responseRoutingKey);
+		}
+		return replyTo;
+	}
+
+	/**
+	 * Send the given response message to the given destination.
+	 * @param channel the Rabbit channel to operate on
+	 * @param replyTo the Rabbit ReplyTo string to use when sending. Currently interpreted to be the routing key.
+	 * @param message the Rabbit message to send
+	 * @throws Exception if thrown by Rabbit API methods
+	 * @see #postProcessResponse(Message, Message)
+	 */
+	protected void sendResponse(Channel channel, Address replyTo, Message message) throws Exception {
+		postProcessChannel(channel, message);
+
+		try {
+			logger.debug("Publishing response to exchange = [" + replyTo.getExchangeName() + "], routingKey = ["
+					+ replyTo.getRoutingKey() + "]");
+			channel.basicPublish(replyTo.getExchangeName(), replyTo.getRoutingKey(), this.mandatoryPublish,
+					this.messagePropertiesConverter.fromMessageProperties(message.getMessageProperties(), encoding), message.getBody());
+		}
+		catch (Exception ex) {
+			throw RabbitExceptionTranslator.convertRabbitAccessException(ex);
+		}
+	}
+
+	/**
+	 * Post-process the given message before sending the response.
+	 * <p>
+	 * The default implementation is empty.
+	 *
+	 * @param channel The channel.
+	 * @param response the outgoing Rabbit message about to be sent
+	 * @throws Exception if thrown by Rabbit API methods
+	 */
+	protected void postProcessChannel(Channel channel, Message response) throws Exception {
+	}
+
+	/**
+	 * Delegates payload extraction to {@link #extractMessage(Message)} to
+	 * enforce backward compatibility.
+	 */
+	private class MessagingMessageConverterAdapter extends MessagingMessageConverter {
+
+		@Override
+		protected Object extractPayload(Message message) {
+			return extractMessage(message);
+		}
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
@@ -1,14 +1,17 @@
 /*
  * Copyright 2002-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.amqp.rabbit.listener.adapter;
@@ -18,22 +21,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 
 import com.rabbitmq.client.Channel;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
-import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpIOException;
 import org.springframework.amqp.AmqpIllegalStateException;
-import org.springframework.amqp.core.Address;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
-import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
 import org.springframework.amqp.rabbit.listener.ListenerExecutionFailedException;
-import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
-import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
-import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
-import org.springframework.amqp.support.converter.MessageConversionException;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.util.Assert;
@@ -129,41 +123,23 @@ import org.springframework.util.StringUtils;
  * @see org.springframework.amqp.rabbit.core.ChannelAwareMessageListener
  * @see org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer#setMessageListener
  */
-public class MessageListenerAdapter implements MessageListener, ChannelAwareMessageListener {
+public class MessageListenerAdapter extends AbstractAdaptableMessageListener {
 
 	/**
 	 * Out-of-the-box value for the default listener method: "handleMessage".
 	 */
 	public static final String ORIGINAL_DEFAULT_LISTENER_METHOD = "handleMessage";
 
-	private static final String DEFAULT_RESPONSE_ROUTING_KEY = "";
-
-	private static final String DEFAULT_ENCODING = "UTF-8";
-
-	/** Logger available to subclasses */
-	protected final Log logger = LogFactory.getLog(getClass());
 
 	private Object delegate;
 
 	private String defaultListenerMethod = ORIGINAL_DEFAULT_LISTENER_METHOD;
 
-	private String responseRoutingKey = DEFAULT_RESPONSE_ROUTING_KEY;
-
-	private String responseExchange = null;
-
-	private volatile boolean mandatoryPublish;
-
-	private MessageConverter messageConverter;
-
-	private volatile MessagePropertiesConverter messagePropertiesConverter = new DefaultMessagePropertiesConverter();
-
-	private String encoding = DEFAULT_ENCODING;
 
 	/**
 	 * Create a new {@link MessageListenerAdapter} with default settings.
 	 */
 	public MessageListenerAdapter() {
-		initDefaultStrategies();
 		this.delegate = this;
 	}
 
@@ -172,7 +148,6 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 	 * @param delegate the delegate object
 	 */
 	public MessageListenerAdapter(Object delegate) {
-		initDefaultStrategies();
 		setDelegate(delegate);
 	}
 
@@ -182,7 +157,6 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 	 * @param messageConverter the message converter to use
 	 */
 	public MessageListenerAdapter(Object delegate, MessageConverter messageConverter) {
-		initDefaultStrategies();
 		setDelegate(delegate);
 		setMessageConverter(messageConverter);
 	}
@@ -220,15 +194,6 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 	}
 
 	/**
-	 * The encoding to use when inter-converting between byte arrays and Strings in message properties.
-	 *
-	 * @param encoding the encoding to set
-	 */
-	public void setEncoding(String encoding) {
-		this.encoding = encoding;
-	}
-
-	/**
 	 * Specify the name of the default listener method to delegate to, for the case where no specific listener method
 	 * has been determined. Out-of-the-box value is {@link #ORIGINAL_DEFAULT_LISTENER_METHOD "handleMessage"}.
 	 *
@@ -245,88 +210,6 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 	 */
 	protected String getDefaultListenerMethod() {
 		return this.defaultListenerMethod;
-	}
-
-	/**
-	 * Set the routing key to use when sending response messages. This will be applied in case of a request message that
-	 * does not carry a "ReplyTo" property
-	 * <p>
-	 * Response destinations are only relevant for listener methods that return result objects, which will be wrapped in
-	 * a response message and sent to a response destination.
-	 *
-	 * @param responseRoutingKey The routing key.
-	 */
-	public void setResponseRoutingKey(String responseRoutingKey) {
-		this.responseRoutingKey = responseRoutingKey;
-	}
-
-	/**
-	 * Set the exchange to use when sending response messages. This is only used if the exchange from the received
-	 * message is null.
-	 * <p>
-	 * Response destinations are only relevant for listener methods that return result objects, which will be wrapped in
-	 * a response message and sent to a response destination.
-	 * @param responseExchange The exchange.
-	 */
-	public void setResponseExchange(String responseExchange) {
-		this.responseExchange = responseExchange;
-	}
-
-	/**
-	 * Set the converter that will convert incoming Rabbit messages to listener method arguments, and objects returned
-	 * from listener methods back to Rabbit messages.
-	 * <p>
-	 * The default converter is a {@link SimpleMessageConverter}, which is able to handle "text" content-types.
-	 *
-	 * @param messageConverter The message converter.
-	 */
-	public void setMessageConverter(MessageConverter messageConverter) {
-		this.messageConverter = messageConverter;
-	}
-
-	/**
-	 * Return the converter that will convert incoming Rabbit messages to listener method arguments, and objects
-	 * returned from listener methods back to Rabbit messages.
-	 *
-	 * @return The message converter.
-	 */
-	protected MessageConverter getMessageConverter() {
-		return this.messageConverter;
-	}
-
-	public void setMandatoryPublish(boolean mandatoryPublish) {
-		this.mandatoryPublish = mandatoryPublish;
-	}
-
-	/**
-	 * @param immediatePublish No longer supported.
-	 * @deprecated 'immediate' no longer support by RabbitMQ.
-	 */
-	@Deprecated
-	public void setImmediatePublish(boolean immediatePublish) {
-		// No-op
-	}
-
-	/**
-	 * Rabbit {@link MessageListener} entry point.
-	 * <p>
-	 * Delegates the message to the target listener method, with appropriate conversion of the message argument. In case
-	 * of an exception, the {@link #handleListenerException(Throwable)} method will be invoked.
-	 * <p>
-	 * <b>Note:</b> Does not support sending response messages based on result objects returned from listener methods.
-	 * Use the {@link ChannelAwareMessageListener} entry point (typically through a Spring message listener container)
-	 * for handling result objects as well.
-	 * @param message the incoming Rabbit message
-	 * @see #handleListenerException
-	 * @see #onMessage(Message, Channel)
-	 */
-	@Override
-	public void onMessage(Message message) {
-		try {
-			onMessage(message, null);
-		} catch (Throwable ex) {
-			handleListenerException(ex);
-		}
 	}
 
 	/**
@@ -348,7 +231,8 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 				if (channel != null) {
 					((ChannelAwareMessageListener) delegate).onMessage(message, channel);
 					return;
-				} else if (!(delegate instanceof MessageListener)) {
+				}
+				else if (!(delegate instanceof MessageListener)) {
 					throw new AmqpIllegalStateException("MessageListenerAdapter cannot handle a "
 							+ "ChannelAwareMessageListener delegate if it hasn't been invoked with a Channel itself");
 				}
@@ -373,46 +257,10 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 		Object result = invokeListenerMethod(methodName, listenerArguments, message);
 		if (result != null) {
 			handleResult(result, message, channel);
-		} else {
+		}
+		else {
 			logger.trace("No result object given - no result to handle");
 		}
-	}
-
-	/**
-	 * Initialize the default implementations for the adapter's strategies.
-	 * @see #setMessageConverter
-	 * @see org.springframework.amqp.support.converter.SimpleMessageConverter
-	 */
-	protected void initDefaultStrategies() {
-		setMessageConverter(new SimpleMessageConverter());
-	}
-
-	/**
-	 * Handle the given exception that arose during listener execution. The default implementation logs the exception at
-	 * error level.
-	 * <p>
-	 * This method only applies when using a Rabbit {@link MessageListener}. With
-	 * {@link ChannelAwareMessageListener}, exceptions get handled by the
-	 * caller instead.
-	 * @param ex the exception to handle
-	 * @see #onMessage(Message)
-	 */
-	protected void handleListenerException(Throwable ex) {
-		logger.error("Listener execution failed", ex);
-	}
-
-	/**
-	 * Extract the message body from the given Rabbit message.
-	 * @param message the Rabbit <code>Message</code>
-	 * @return the content of the message, to be passed into the listener method as argument
-	 * @throws Exception if thrown by Rabbit API methods
-	 */
-	protected Object extractMessage(Message message) throws Exception {
-		MessageConverter converter = getMessageConverter();
-		if (converter != null) {
-			return converter.fromMessage(message);
-		}
-		return message;
 	}
 
 	/**
@@ -444,7 +292,7 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 	 * a distinct method argument)
 	 */
 	protected Object[] buildListenerArguments(Object extractedMessage) {
-		return new Object[] { extractedMessage };
+		return new Object[] {extractedMessage};
 	}
 
 	/**
@@ -461,16 +309,17 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 	protected Object invokeListenerMethod(String methodName, Object[] arguments) throws Exception {
 		return this.invokeListenerMethod(methodName, arguments, null);
 	}
-		/**
-		 * Invoke the specified listener method.
-		 * @param methodName the name of the listener method
-		 * @param arguments the message arguments to be passed in
-		 * @param originalMessage the original message
-		 * @return the result returned from the listener method
-		 * @throws Exception if thrown by Rabbit API methods
-		 * @see #getListenerMethodName
-		 * @see #buildListenerArguments
-		 */
+
+	/**
+	 * Invoke the specified listener method.
+	 * @param methodName the name of the listener method
+	 * @param arguments the message arguments to be passed in
+	 * @param originalMessage the original message
+	 * @return the result returned from the listener method
+	 * @throws Exception if thrown by Rabbit API methods
+	 * @see #getListenerMethodName
+	 * @see #buildListenerArguments
+	 */
 	protected Object invokeListenerMethod(String methodName, Object[] arguments, Message originalMessage)
 			throws Exception {
 		try {
@@ -502,140 +351,6 @@ public class MessageListenerAdapter implements MessageListener, ChannelAwareMess
 					+ "' with argument type = [" + StringUtils.collectionToCommaDelimitedString(arrayClass)
 					+ "], value = [" + ObjectUtils.nullSafeToString(arguments) + "]", ex, originalMessage);
 		}
-	}
-
-	/**
-	 * Handle the given result object returned from the listener method, sending a response message back.
-	 * @param result the result object to handle (never <code>null</code>)
-	 * @param request the original request message
-	 * @param channel the Rabbit channel to operate on (may be <code>null</code>)
-	 * @throws Exception if thrown by Rabbit API methods
-	 * @see #buildMessage
-	 * @see #postProcessResponse
-	 * @see #getReplyToAddress(Message)
-	 * @see #sendResponse
-	 */
-	protected void handleResult(Object result, Message request, Channel channel) throws Exception {
-		if (channel != null) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("Listener method returned result [" + result + "] - generating response message for it");
-			}
-			Message response = buildMessage(channel, result);
-			postProcessResponse(request, response);
-			Address replyTo = getReplyToAddress(request);
-			sendResponse(channel, replyTo, response);
-		} else if (logger.isWarnEnabled()) {
-			logger.warn("Listener method returned result [" + result
-					+ "]: not generating response message for it because of no Rabbit Channel given");
-		}
-	}
-
-	protected String getReceivedExchange(Message request) {
-		return request.getMessageProperties().getReceivedExchange();
-	}
-
-	/**
-	 * Build a Rabbit message to be sent as response based on the given result object.
-	 * @param session the Rabbit Channel to operate on
-	 * @param result the content of the message, as returned from the listener method
-	 * @return the Rabbit <code>Message</code> (never <code>null</code>)
-	 * @throws Exception if thrown by Rabbit API methods
-	 * @see #setMessageConverter
-	 */
-	protected Message buildMessage(Channel session, Object result) throws Exception {
-		MessageConverter converter = getMessageConverter();
-		if (converter != null) {
-			return converter.toMessage(result, new MessageProperties());
-		} else {
-			if (!(result instanceof Message)) {
-				throw new MessageConversionException("No MessageConverter specified - cannot handle message [" + result
-						+ "]");
-			}
-			return (Message) result;
-		}
-	}
-
-	/**
-	 * Post-process the given response message before it will be sent.
-	 * <p>
-	 * The default implementation sets the response's correlation id to the request message's correlation id, if any;
-	 * otherwise to the request message id.
-	 * @param request the original incoming Rabbit message
-	 * @param response the outgoing Rabbit message about to be sent
-	 * @throws Exception if thrown by Rabbit API methods
-	 */
-	protected void postProcessResponse(Message request, Message response) throws Exception {
-		byte[] correlation = request.getMessageProperties().getCorrelationId();
-
-		if (correlation == null) {
-			String messageId = request.getMessageProperties().getMessageId();
-			if (messageId != null) {
-				correlation = messageId.getBytes(SimpleMessageConverter.DEFAULT_CHARSET);
-			}
-		}
-		response.getMessageProperties().setCorrelationId(correlation);
-	}
-
-	/**
-	 * Determine a reply-to Address for the given message.
-	 * <p>
-	 * The default implementation first checks the Rabbit Reply-To Address of the supplied request; if that is not
-	 * <code>null</code> it is returned; if it is <code>null</code>, then the configured default response Exchange and
-	 * routing key are used to construct a reply-to Address. If the responseExchange property is also <code>null</code>,
-	 * then an {@link AmqpException} is thrown.
-	 * @param request the original incoming Rabbit message
-	 * @return the reply-to Address (never <code>null</code>)
-	 * @throws Exception if thrown by Rabbit API methods
-	 * @throws AmqpException if no {@link Address} can be determined
-	 * @see #setResponseExchange(String)
-	 * @see #setResponseRoutingKey(String)
-	 * @see org.springframework.amqp.core.Message#getMessageProperties()
-	 * @see org.springframework.amqp.core.MessageProperties#getReplyTo()
-	 */
-	protected Address getReplyToAddress(Message request) throws Exception {
-		Address replyTo = request.getMessageProperties().getReplyToAddress();
-		if (replyTo == null) {
-			if (this.responseExchange == null) {
-				throw new AmqpException(
-						"Cannot determine ReplyTo message property value: "
-								+ "Request message does not contain reply-to property, and no default response Exchange was set.");
-			}
-			replyTo = new Address(null, this.responseExchange, this.responseRoutingKey);
-		}
-		return replyTo;
-	}
-
-	/**
-	 * Send the given response message to the given destination.
-	 * @param channel the Rabbit channel to operate on
-	 * @param replyTo the Rabbit ReplyTo string to use when sending. Currently interpreted to be the routing key.
-	 * @param message the Rabbit message to send
-	 * @throws Exception if thrown by Rabbit API methods
-	 * @see #postProcessResponse(Message, Message)
-	 */
-	protected void sendResponse(Channel channel, Address replyTo, Message message) throws Exception {
-		postProcessChannel(channel, message);
-
-		try {
-			logger.debug("Publishing response to exchanage = [" + replyTo.getExchangeName() + "], routingKey = ["
-					+ replyTo.getRoutingKey() + "]");
-			channel.basicPublish(replyTo.getExchangeName(), replyTo.getRoutingKey(), this.mandatoryPublish,
-					this.messagePropertiesConverter.fromMessageProperties(message.getMessageProperties(), encoding), message.getBody());
-		} catch (Exception ex) {
-			throw RabbitExceptionTranslator.convertRabbitAccessException(ex);
-		}
-	}
-
-	/**
-	 * Post-process the given message before sending the response.
-	 * <p>
-	 * The default implementation is empty.
-	 *
-	 * @param channel The channel.
-	 * @param response the outgoing Rabbit message about to be sent
-	 * @throws Exception if thrown by Rabbit API methods
-	 */
-	protected void postProcessChannel(Channel channel, Message response) throws Exception {
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import com.rabbitmq.client.Channel;
+
+import org.springframework.amqp.rabbit.listener.ListenerExecutionFailedException;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+
+/**
+ * A {@link org.springframework.amqp.core.MessageListener MessageListener}
+ * adapter that invokes a configurable {@link InvocableHandlerMethod}.
+ *
+ * <p>Wraps the incoming {@link org.springframework.amqp.core.Message
+ * AMQP Message} to Spring's {@link Message} abstraction, copying the
+ * standard headers using a configurable
+ * {@link org.springframework.amqp.support.AmqpHeaderMapper AmqpHeaderMapper}.
+ *
+ * <p>The original {@link org.springframework.amqp.core.Message Message} and
+ * the {@link Channel} are provided as additional arguments so that these can
+ * be injected as method arguments if necessary.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageListener {
+
+	private InvocableHandlerMethod handlerMethod;
+
+
+	/**
+	 * Set the {@link InvocableHandlerMethod} to use to invoke the method
+	 * processing an incoming {@link org.springframework.amqp.core.Message}.
+	 */
+	public void setHandlerMethod(InvocableHandlerMethod handlerMethod) {
+		this.handlerMethod = handlerMethod;
+	}
+
+
+	@Override
+	public void onMessage(org.springframework.amqp.core.Message amqpMessage, Channel channel) throws Exception {
+		Message<?> message = toMessagingMessage(amqpMessage);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Processing [" + message + "]");
+		}
+		Object result = invokeHandler(amqpMessage, channel, message);
+		if (result != null) {
+			handleResult(result, amqpMessage, channel);
+		}
+		else {
+			logger.trace("No result object given - no result to handle");
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	protected Message<?> toMessagingMessage(org.springframework.amqp.core.Message amqpMessage) {
+		return (Message<?>) getMessagingMessageConverter().fromMessage(amqpMessage);
+	}
+
+	/**
+	 * Invoke the handler, wrapping any exception to a {@link ListenerExecutionFailedException}
+	 * with a dedicated error message.
+	 */
+	private Object invokeHandler(org.springframework.amqp.core.Message amqpMessage, Channel channel, Message<?> message) {
+		try {
+			return this.handlerMethod.invoke(message, amqpMessage, channel);
+		}
+		catch (MessagingException ex) {
+			throw new ListenerExecutionFailedException(createMessagingErrorMessage("Listener method could not " +
+					"be invoked with the incoming message"), ex);
+		}
+		catch (Exception ex) {
+			throw new ListenerExecutionFailedException("Listener method '" +
+					this.handlerMethod.getMethod().toGenericString() + "' threw exception", ex);
+		}
+	}
+
+	private String createMessagingErrorMessage(String description) {
+		StringBuilder sb = new StringBuilder(description).append("\n")
+				.append("Endpoint handler details:\n")
+				.append("Method [").append(this.handlerMethod.getMethod()).append("]\n")
+				.append("Bean [").append(this.handlerMethod.getBean()).append("]\n");
+		return sb.toString();
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/ReplyFailureException.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/ReplyFailureException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import org.springframework.amqp.AmqpException;
+
+/**
+ * Exception to be thrown when the reply of a message failed to be sent.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+@SuppressWarnings("serial")
+public class ReplyFailureException extends AmqpException {
+
+	public ReplyFailureException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+}

--- a/spring-rabbit/src/main/resources/META-INF/spring.schemas
+++ b/spring-rabbit/src/main/resources/META-INF/spring.schemas
@@ -3,4 +3,5 @@ http\://www.springframework.org/schema/rabbit/spring-rabbit-1.1.xsd=org/springfr
 http\://www.springframework.org/schema/rabbit/spring-rabbit-1.2.xsd=org/springframework/amqp/rabbit/config/spring-rabbit-1.2.xsd
 http\://www.springframework.org/schema/rabbit/spring-rabbit-1.3.xsd=org/springframework/amqp/rabbit/config/spring-rabbit-1.3.xsd
 http\://www.springframework.org/schema/rabbit/spring-rabbit-1.4.xsd=org/springframework/amqp/rabbit/config/spring-rabbit-1.4.xsd
-http\://www.springframework.org/schema/rabbit/spring-rabbit.xsd=org/springframework/amqp/rabbit/config/spring-rabbit-1.4.xsd
+http\://www.springframework.org/schema/rabbit/spring-rabbit-2.0.xsd=org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
+http\://www.springframework.org/schema/rabbit/spring-rabbit.xsd=org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
@@ -1,0 +1,1196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/rabbit" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:beans="http://www.springframework.org/schema/beans" targetNamespace="http://www.springframework.org/schema/rabbit"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+
+	<xsd:element name="queue">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Creates a queue for consumers to retrieve messages.  Uses an existing queue
+				with the same name if it exists on the broker, or else declares a
+				new one.  If you want to send a message use an exchange.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="queue-arguments" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						The id of the queue in case it is different than the name.  Clients can receive or listen for messages by referring to the
+						queue itself, or to its name.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="name" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						The name of the queue.  Clients can receive or listen for messages by referring to the
+						queue itself, or to its name.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-delete" use="optional" type="xsd:string" default="false">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Flag indicating that an queue will be deleted when it is no longer in use, i.e. the connection that declared it is closed. Default is false.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="exclusive" use="optional" type="xsd:string" default="false">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					Flag indicating that the queue is exclusive to this connection.  Default is false.
+				]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="durable" use="optional" type="xsd:string" default="true">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					Flag indicating that the queue is durable, meaning that it will survive broker restarts (not that the messages in it will, although they might if they are persistent).  Default is true.
+				]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="queue-arguments" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					A reference to a <queue-arguments/> element.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="java.util.Map" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attributeGroup ref="declarable" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="queue-arguments" type="mapType">
+		<xsd:annotation>
+			<xsd:documentation source="java:java.util.Map"><![CDATA[
+						A Map to pass to the broker when this component is declared.
+						]]></xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="direct-exchange">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+					Creates a direct exchange for producers to send messages to.  Uses an existing exchange
+					with the same name if it exists on the broker, or declares a
+					new one.  A direct exchange routes messages
+					to queues that are bound to the exchange when the routing key in the message
+					matches that in the binding exactly.  You can set up bindings here too, either with
+					explicit routing keys, or using the queue name implicitly.
+				]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="exchangeType">
+					<xsd:sequence>
+						<xsd:element name="bindings" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Groups bindings of queues to this exchange.
+								]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:choice>
+									<xsd:element name="binding" maxOccurs="unbounded" type="directBindingType">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+											Declares a binding of a queue to this exchange either with
+											an explicit routing key, or using the queue name implicitly.
+										]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:choice>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="topic-exchange">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+					Creates a topic exchange for producers to send messages to.  Uses an existing exchange
+					with the same name if it exists on the broker, or declares a
+					new one.  A topic exchange routes messages
+					to queues that are bound to the exchange when the routing key in the message
+					matches the routing pattern in the binding of the queue.
+					You can set up bindings here too.
+				]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="exchangeType">
+					<xsd:sequence>
+						<xsd:element name="bindings" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Groups bindings of queues to this exchange.
+								]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:choice>
+									<xsd:element name="binding" maxOccurs="unbounded" type="topicBindingType">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+											Declares a binding of a queue to this exchange either with
+											a routing pattern, e.g. "uk.weather.*" or "uk.#".
+										]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:choice>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="fanout-exchange">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+					Creates a fanout exchange for producers to send messages to.  Uses an existing exchange
+					with the same name if it exists on the broker, or declares a
+					new one.  A fanout exchange routes messages
+					to all queues that are bound to the exchange.  You can set up bindings here too.
+				]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="exchangeType">
+					<xsd:sequence>
+						<xsd:element name="bindings" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Groups bindings of queues to this exchange.
+								]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:choice>
+									<xsd:element name="binding" maxOccurs="unbounded" type="bindingType">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+												Binds a queue to this exchange.  All messages sent to this exchange will be
+												placed on this queue by the broker.
+											]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:choice>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="headers-exchange">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+					Creates a headers exchange for producers to send messages to.  Uses an existing exchange
+					with the same name if it exists on the broker, or declares a
+					new one.  A headers exchange routes messages
+					to all queues where a message header matches that specified in the binding of the queue.
+					You can set up bindings here too.
+				]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="exchangeType">
+					<xsd:sequence>
+						<xsd:element name="bindings" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Groups bindings of queues to this exchange.
+								]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:complexType>
+								<xsd:choice>
+									<xsd:element name="binding" maxOccurs="unbounded" type="headersBindingType">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+												Binds a queue to this exchange.  Messages sent to this exchange will be
+												placed on this queue by the broker if they contain a header that matches
+												this binding (key-value pair).
+											]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:choice>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="exchangeType">
+		<xsd:sequence>
+			<xsd:element ref="exchange-arguments" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The id of the exchange bean definition in case it is different than the name.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="name" use="required" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The name of the exchange. Clients can send a message by referring to the
+					exchange itself, or to its name.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-delete" use="optional" type="xsd:string" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Flag indicating that an exchange will be deleted when no longer in use, i.e. the connection that declared it is closed. Default is false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="durable" use="optional" type="xsd:string" default="true">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Flag indicating that the exchange is durable, i.e. will survive broker restart.  Default is true.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="declarable" />
+	</xsd:complexType>
+
+	<xsd:element name="exchange-arguments" type="mapType">
+		<xsd:annotation>
+			<xsd:documentation source="java:java.util.Map"><![CDATA[
+				A Map to pass to the broker when this component is declared.
+			]]></xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="directBindingType">
+		<xsd:complexContent>
+			<xsd:extension base="bindingType">
+				<xsd:attribute name="key" use="optional">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+							An explicit routing key binding the queue to this exchange.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="topicBindingType">
+		<xsd:complexContent>
+			<xsd:extension base="bindingType">
+				<xsd:attribute name="pattern" use="required">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+						An explicit routing pattern binding the queue to this exchange.  In the pattern,
+						the symbol # matches one or more words and the symbol * matches any single word.
+						Typical bindings might be "uk.#" for all items in the uk, "#.weather" for all
+						weather items, or "uk.weather" for all uk weather items.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="headersBindingType">
+		<xsd:complexContent>
+			<xsd:extension base="bindingType">
+				<xsd:attribute name="key" use="optional">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+						The header name to match messages for routing.
+						This attribute is mutually exclusive with 'binding-arguments' sub-element.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="value" use="optional">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+						The header value to match messages for routing.
+						This attribute is mutually exclusive with 'binding-arguments' sub-element.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="bindingType">
+		<xsd:sequence>
+			<xsd:element ref="binding-arguments" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="queue" use="optional">
+			<xsd:annotation>
+				<xsd:documentation source="java:org.springframework.amqp.core.Queue"><![CDATA[
+				The bean name of the Queue to bind to this exchange.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.core.Queue" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="exchange" use="optional">
+			<xsd:annotation>
+				<xsd:documentation source="java:org.springframework.amqp.core.Exchange"><![CDATA[
+				The bean name of another exchange to bind to this exchange.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.core.Exchange" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="binding-arguments" type="mapType">
+		<xsd:annotation>
+			<xsd:documentation source="java:java.util.Map"><![CDATA[
+						A Map to pass to the broker when this component is declared.
+						]]></xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="mapType">
+		<xsd:complexContent>
+			<xsd:extension base="beans:mapType">
+				<xsd:attribute name="id" type="xsd:string" />
+				<xsd:attribute name="ref" use="optional">
+					<xsd:annotation>
+						<xsd:documentation source="java:java.util.Map"><![CDATA[
+						The bean name of the Map to pass to the broker when this component is declared.
+						]]></xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="java.util.Map" />
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="annotation-driven">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Enables the detection of @RabbitListener annotation on any Spring-managed object. If
+	present, a message listener container will be created to receive the relevant
+	messages and invoke the annotated method accordingly.
+
+	See Javadoc for the org.springframework.amqp.rabbit.annotation.EnableRabbit annotation
+	for	information	on code-based alternatives to this XML element.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="registry" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Specifies the org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry
+	instance to	use to register annotated listener endpoints. If not provided, a default
+	instance will be used by default.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="container-factory" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Specifies the org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory instance
+	to use to create the container for a listener endpoint that does not define a specific
+	factory. This permits in practice to omit the "containerFactory" attribute of the RabbitListener
+	annotation. This attribute is not required as each endpoint may define the factory to use and,
+	as a convenience, the RabbitListenerContainerFactory with name 'rabbitListenerContainerFactory'
+	is looked up by default.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.rabbit.config.RabbitListenerContainerFactory"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="handler-method-factory" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Specifies a custom org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory
+	instance to	use to configure the message listener responsible to serve an endpoint detected by this
+	processor. By default, DefaultMessageHandlerMethodFactory is used and it can be configured
+	further to support additional method arguments or to customize conversion and validation
+	support. See org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory
+	Javadoc for more details.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="listener-container">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Each listener child element will be hosted by a container whose configuration
+	is determined by this parent element. This variant builds RabbitMQ
+	listener containers, operating against a specified ConnectionFactory.
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="listenerContainerBaseType">
+					<xsd:sequence>
+						<xsd:element name="listener" type="listenerType" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+					<xsd:attribute name="connection-factory" type="xsd:string" default="rabbitConnectionFactory">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+				A reference to the org.springframework.amqp.rabbit.connection.ConnectionFactory.
+				Default referenced bean name is "rabbitConnectionFactory".
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.amqp.rabbit.connection.ConnectionFactory" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="message-converter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+				A reference to the MessageConverter strategy for converting AMQP Messages to
+				listener method arguments for any referenced 'listener' that is a POJO.
+				Default is a SimpleMessageConverter.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.amqp.support.converter.MessageConverter" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="listenerContainerBaseType">
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Optional bean id for the container.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="task-executor" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to a Spring TaskExecutor (or standard JDK 1.5 Executor) for executing
+	listener invokers. Default is a SimpleAsyncTaskExecutor, using internally managed threads.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.util.concurrent.Executor" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="error-handler" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to an ErrorHandler strategy for handling any uncaught Exceptions
+	that may occur during the execution of the MessageListener.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.util.ErrorHandler" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="acknowledge" default="auto">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The acknowledge mode: "auto", "manual", or "none".
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="auto" />
+					<xsd:enumeration value="manual" />
+					<xsd:enumeration value="none" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="transaction-manager" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to an external PlatformTransactionManager.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.transaction.PlatformTransactionManager" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="channel-transacted" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Flag to indicate that the channel should be used transactionally.
+	Cannot be 'true' if acknowledge is 'none'. Default is false.
+					]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="concurrency" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The number of concurrent consumers to start for each listener initially.
+	See also 'max-concurrency'.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-concurrency" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The maximum number of concurrent consumers to start, if needed, on demand.
+	Must be greater than or equal to 'concurrency'.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="min-start-interval" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The time in milliseconds which must elapse before each new consumer is started
+	on demand. Default 10000 (10 seconds).
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="min-stop-interval" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The time in milliseconds which must elapse before a consumer is stopped
+	since the last consumer was stopped when an idle consumer is detected.
+	Default 60000 (1 minute).
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="min-consecutive-active" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The minimum number of consecutive actions processed by consumer, without a receive
+	timeout occurring, when considering starting a new consumer.
+	Also impacted by 'transaction-size' see the
+	reference documentation. Default 10.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="min-consecutive-idle" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The minimum number of receive timeouts a consumer must experience before
+	considering stopping a consumer. Also impacted by 'transaction-size' see the
+	reference documentation. Default 10.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="prefetch" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Tells the broker how many messages to send to each consumer in a single request. Often this can be set quite high
+	to improve throughput. It should be greater than or equal to the transaction size.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="transaction-size" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Tells the container how many messages to process in a single transaction (if the channel is transactional). For
+	best results it should be less than or equal to the prefetch count. Also used to determine how often acks
+	are sent when using AUTO acknowledge mode.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="receive-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The time for which a consumer waits for a message; used together with 'transaction-size' to determine whether
+	or not a consumer is idle, why dynamic concurrency is enabled using 'max-concurrency'. When 'transaction-size'
+	is greater than 1 (default), acks for processed message(s) can be delayed up to ('transaction-size' - 1) *
+	this value because the ack is sent after `transaction-size` attempts to receive a message have occurred.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="requeue-rejected" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Tells the container the default requeue behavior when rejecting messages. Default is 'true' meaning messages
+	will be requeued, unless the listener signals not to by throwing an AmqpRejectAndDontRequeueException. When
+	set to false, messages will never be requeued.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="phase" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The lifecycle phase within which this container should start and stop. The lower
+	the value the earlier this container will start and the later it will stop. The
+	default is Integer.MAX_VALUE meaning the container will start as late as possible
+	and stop as soon as possible.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Flag to indicate that the container should start up automatically when the enclosing context is refreshed.  Default true.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="advice-chain" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Reference to a chain of AOP advice to be applied to the listener.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="recovery-interval" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The time in milliseconds between attempts to start a consumer if it fails to start with a non-fatal error. Default 5000.
+	See also 'missing-queues-fatal'. Fatal errors include authentication problems.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="missing-queues-fatal" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	When `true` (default), if none of the queues are available on the broker, the condition is considered fatal; this
+	can prevent application startup; it can also cause the container to stop if the queues are deleted while the
+	container is running. Set to 'false' and this condition will not be considered fatal, and the container will
+	continue to attempt to passively declare the queues, according to the 'recovery-interval'.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="listenerType">
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The unique identifier for this listener.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="queue-names" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The queue names for this listener as a comma-separated list. Either this or queues is required.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="queues" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The queues (bean references) for this listener as a comma-separated list. Either this or queue-names is required.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="exclusive" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	When true, a single consumer in the container will have exlusive use of the queue(s), preventing other consumers from
+	receiving messages from the queue(s). When true, requires a concurrency of 1. Default false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="priority" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The priority of this listener's Consumer. Requires RabbitMQ 3.2 or higher.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The bean name of the listener object, implementing
+	the MessageListener/ChannelAwareMessageListener interface
+	or defining the specified listener method. Required.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref" />
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="method" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The name of the listener method to invoke. If not specified,
+	the target bean is supposed to implement the MessageListener
+	or ChannelAwareMessageListener interface.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="response-exchange" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The name of the default response Exchange to send response messages to.
+	This will be applied in case of a request message that does not carry
+	a "replyTo" property. Note: This only applies to a listener method with
+	a return value, for which each result object will be converted into a
+	response message.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="response-routing-key" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The routing key to send along with a response message.
+	This will be applied in case of a request message that does not carry
+	a "replyTo" property. Note: This only applies to a listener method with
+	a return value, for which each result object will be converted into a
+	response message.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="admin" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Reference to a 'RabbitAdmin'. Required if the listener is using auto-delete
+	queues and those queues are configured for conditional declaration. This
+	is the admin that will (re)declare those queues when the container is
+	(re)started. See the reference documentation for more information.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.rabbit.core.RabbitAdmin" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="admin">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Creates a rabbit admin (org.springframework.amqp.rabbit.core.RabbitAdmin),
+	used to manage exchanges, queues and bindings.
+					]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Unique name for this rabbit admin used as a bean definition identifier.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-factory" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to rabbit connection factory. Either 'connection-factory' or
+	'template' attribute can be set.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.rabbit.connection.ConnectionFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" default="true">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Specifies if the queues, exchanges and bindings in the context should automatically be declared
+	(lazily, when a connection is established to the broker). Default value is 'true'.
+					]]></xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="ignore-declaration-exceptions" default="false">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	If automatic declaration is enabled (see 'auto-startup'), if this is set to 'true', exceptions will
+	be logged (WARNings) but declaration of other elements will continue. If false, declarations will
+	cease when an exception occurs. Default value is 'false'.
+					]]></xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="template">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Creates a rabbit template (org.springframework.amqp.rabbit.core.RabbitTemplate)
+	for convenient access to the broker.
+					]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="reply-listener" type="listenerContainerBaseType"
+					minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+	A <listener-container/> used to receive asynchronous replies on the reply-channel the
+	<listener/> child element is disallowed because the template itself is the listener.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Unique name for this rabbit template used as a bean definition identifier.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="routing-key" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Default routing key for sending messages.  Default is empty.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="exchange" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Default exchange for sending messages.  Default is empty (the default exchange).
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="queue" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Default queue for receiving messages. Default is empty (non-existent queue).
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-timeout" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Timeout for send and receive in milliseconds.  Default is 5000 (5 seconds).
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel-transacted" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Flag to indicate that the channel should be used transactionally.  Default is false.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="encoding" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Encoding to use for packing and unpacking MessageProperties of type String.  Default is UTF-8.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="message-converter" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	MessageConverter to convert between raw bytes and Java objects in the *convert* methods.  Defaults to a simple implementation that handles Strings, byte arrays and Serializable.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.support.converter.MessageConverter" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-factory" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to rabbit connection factory.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.rabbit.connection.ConnectionFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-queue" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to a <queue/> for replies; optional; if not supplied, methods expecting replies
+	will use a temporary, exclusive, auto-delete queue.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.core.Queue" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mandatory" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When 'true' sets the mandatory flag on basic.publish; only applies if
+	a 'return-callback' is provided.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="return-callback" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to an implementation of RabbitTemplate.ReturnCallback - invoked if
+	a return is received for a message published with mandatory set
+	that couldn't be delivered according to the semantics of that option.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.core.RabbitTemplate.ReturnCallback" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="confirm-callback" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to an implementation of RabbitTemplate.ConfirmCallback - invoked if
+	a confirm (ack or nack) return is received for a published message.
+	Requires a 'connection-factory' that has 'publisher-confirms' set to 'true'.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.core.RabbitTemplate.ConfirmCallback" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="correlation-key" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Header name used to convey correlation data for send and receive operations. If not specified, the standard
+	correlationId message property is used. Previous versions of spring-amqp used a header 'spring_reply_correlation'; if you
+	wish to continue to use that value, specify it here.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="retry-template" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to a RetryTemplate - used to invoke retries on Rabbit operations (such as when a connection fails).
+	By default, retries are not attempted.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.retry.support.RetryTemplate" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="connection-factory">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Creates a rabbit CachingConnectionFactory with sensible defaults.
+					]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Unique name for this rabbit connection factory used as a bean definition identifier.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="host" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Hostname to connect to broker.  Default is "localhost".
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="port" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Port number to connect to broker.  Default is 5672.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="addresses" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	List of addresses; e.g. host1,host2:4567,host3 - overrides host/port if supplied.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="username" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Username to connect to broker.  Default is "guest".
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="password" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Password to connect to broker.  Default is "guest".
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="virtual-host" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Virtual host name to connect to broker.  Default is "/".  Virtual hosts are logical partitions of the broker with separate queues, excchanges, users, etc.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel-cache-size" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Cache size for channels.  More channels can be used by clients, but in excess of this number they will not be cached.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-factory" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to native rabbit connection factory, where you can specify native features like client properties.  The other properties (host, port) etc. on this element
+	override the ones on the native connection factory (which is used as a parent bean definition).
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="com.rabbitmq.client.ConnectionFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="executor" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to an ExecutorService, or ThreadPoolTaskExecutor (as defined by a <task:executor/>
+	element). Passed to the Rabbit library when creating the connection. When not supplied, the
+	Rabbit library currently uses a fixed thread pool ExecutorService with 5 threads.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="java.util.concurrent.Executor" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="publisher-confirms" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When true, channels on connections created by this factory support publisher confirms.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="publisher-returns" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When true, channels on connections created by this factory support publisher returns.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="requested-heartbeat" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Sets the requested heardbeat interval on the underlying Rabbit connection factory.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="cache-mode" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When 'CHANNEL', channels are cached within a single connection (default); when 'CONNECTION',
+	connections and their channels are cached. CONNECTION might be suitable for a listener
+	container.
+					]]></xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="cacheModes xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="connection-cache-size" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	The size of the cache when cache-mode is 'CONNECTION'.
+	More connections can be used by clients, but in excess of this number they will not be cached.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:attributeGroup name="declarable">
+		<xsd:attribute name="auto-declare">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Specifies if the this element should automatically be declared
+	(lazily, when a connection is established to the broker).
+	See also 'declared-by'.
+	Default value is 'true'.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="declared-by" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	If 'auto-declare' is true, specifies a (comma-delimited) list of
+	RabbitAdmins (if they have 'auto-startup="true"') that should
+	declare this element (lazily, when a connection is established with the broker).
+	If not specified, or empty, then all auto-startup RabbitAdmins will declare the element.
+	Default value is all RabbitAdmins.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:simpleType name="cacheModes">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="CHANNEL"/>
+			<xsd:enumeration value="CONNECTION"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AbstractRabbitAnnotationDrivenTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AbstractRabbitAnnotationDrivenTests.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import java.util.Collection;
+
+import com.rabbitmq.client.Channel;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.config.AbstractRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.config.MethodRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.springframework.validation.annotation.Validated;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ *
+ * @author Stephane Nicoll
+ */
+public abstract class AbstractRabbitAnnotationDrivenTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public abstract void sampleConfiguration();
+
+	@Test
+	public abstract void fullConfiguration();
+
+	@Test
+	public abstract void noRabbitAdminConfiguration();
+
+	@Test
+	public abstract void customConfiguration();
+
+	@Test
+	public abstract void explicitContainerFactory();
+
+	@Test
+	public abstract void defaultContainerFactory();
+
+	@Test
+	public abstract void rabbitHandlerMethodFactoryConfiguration() throws Exception;
+
+	/**
+	 * Test for {@link SampleBean} discovery. If a factory with the default name
+	 * is set, an endpoint will use it automatically
+	 */
+	public void testSampleConfiguration(ApplicationContext context) {
+		RabbitListenerContainerTestFactory defaultFactory =
+				context.getBean("rabbitListenerContainerFactory", RabbitListenerContainerTestFactory.class);
+		RabbitListenerContainerTestFactory simpleFactory =
+				context.getBean("simpleFactory", RabbitListenerContainerTestFactory.class);
+		assertEquals(1, defaultFactory.getListenerContainers().size());
+		assertEquals(1, simpleFactory.getListenerContainers().size());
+	}
+
+	@Component
+	static class SampleBean {
+
+		@RabbitListener(queues = "myQueue")
+		public void defaultHandle(String msg) {
+		}
+
+		@RabbitListener(containerFactory = "simpleFactory", queues = "myQueue")
+		public void simpleHandle(String msg) {
+		}
+	}
+
+	/**
+	 * Test for {@link FullBean} discovery. In this case, no default is set because
+	 * all endpoints provide a default registry. This shows that the default factory
+	 * is only retrieved if it needs to be.
+	 */
+	public void testFullConfiguration(ApplicationContext context) {
+		RabbitListenerContainerTestFactory simpleFactory =
+				context.getBean("simpleFactory", RabbitListenerContainerTestFactory.class);
+		assertEquals(1, simpleFactory.getListenerContainers().size());
+		MethodRabbitListenerEndpoint endpoint = (MethodRabbitListenerEndpoint)
+				simpleFactory.getListenerContainers().get(0).getEndpoint();
+		assertEquals("listener1", endpoint.getId());
+		assertQueues(endpoint, "queue1", "queue2");
+		assertTrue("No queue instances should be set", endpoint.getQueues().isEmpty());
+		assertEquals(true, endpoint.isExclusive());
+		assertEquals(new Integer(34), endpoint.getPriority());
+		assertEquals("routing-123", endpoint.getResponseRoutingKey());
+		assertSame(context.getBean("rabbitAdmin"), endpoint.getAdmin());
+
+		// Resolve the container and invoke a message on it
+
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		endpoint.setupListenerContainer(container);
+		MessagingMessageListenerAdapter listener = (MessagingMessageListenerAdapter) container.getMessageListener();
+
+		MessageProperties properties = new MessageProperties();
+		properties.setContentType(MessageProperties.CONTENT_TYPE_TEXT_PLAIN);
+		Message amqpMessage = new Message("Hello".getBytes(), properties);
+
+		try {
+			listener.onMessage(amqpMessage, mock(Channel.class));
+		}
+		catch (Exception e) {
+			fail("should not have failed to process simple message but got " + e.getMessage());
+		}
+	}
+
+	@Component
+	static class FullBean {
+
+		@RabbitListener(id = "listener1", containerFactory = "simpleFactory", queues = {"queue1", "queue2"},
+				exclusive = true, priority = 34, responseRoutingKey = "routing-123", admin = "rabbitAdmin")
+		public void fullHandle(String msg) {
+
+		}
+	}
+
+	/**
+	 * Test for {@link CustomBean} and an manually endpoint registered
+	 * with "myCustomEndpointId". The custom endpoint does not provide
+	 * any factory so it's registered with the default one
+	 */
+	public void testCustomConfiguration(ApplicationContext context) {
+		RabbitListenerContainerTestFactory defaultFactory =
+				context.getBean("rabbitListenerContainerFactory", RabbitListenerContainerTestFactory.class);
+		RabbitListenerContainerTestFactory customFactory =
+				context.getBean("customFactory", RabbitListenerContainerTestFactory.class);
+		assertEquals(1, defaultFactory.getListenerContainers().size());
+		assertEquals(1, customFactory.getListenerContainers().size());
+		RabbitListenerEndpoint endpoint = defaultFactory.getListenerContainers().get(0).getEndpoint();
+		assertEquals("Wrong endpoint type", SimpleRabbitListenerEndpoint.class, endpoint.getClass());
+		assertEquals("Wrong listener set in custom endpoint", context.getBean("simpleMessageListener"),
+				((SimpleRabbitListenerEndpoint) endpoint).getMessageListener());
+
+		RabbitListenerEndpointRegistry customRegistry =
+				context.getBean("customRegistry", RabbitListenerEndpointRegistry.class);
+		assertEquals("Wrong number of containers in the registry", 2,
+				customRegistry.getListenerContainers().size());
+		assertNotNull("Container with custom id on the annotation should be found",
+				customRegistry.getListenerContainer("listenerId"));
+		assertNotNull("Container created with custom id should be found",
+				customRegistry.getListenerContainer("myCustomEndpointId"));
+	}
+
+	@Component
+	static class CustomBean {
+
+		@RabbitListener(id = "listenerId", containerFactory = "customFactory", queues = "myQueue")
+		public void customHandle(String msg) {
+		}
+	}
+
+	/**
+	 * Test for {@link DefaultBean} that does not define the container
+	 * factory to use as a default is registered with an explicit
+	 * default.
+	 */
+	public void testExplicitContainerFactoryConfiguration(ApplicationContext context) {
+		RabbitListenerContainerTestFactory defaultFactory =
+				context.getBean("simpleFactory", RabbitListenerContainerTestFactory.class);
+		assertEquals(1, defaultFactory.getListenerContainers().size());
+	}
+
+	/**
+	 * Test for {@link DefaultBean} that does not define the container
+	 * factory to use as a default is registered with the default name.
+	 */
+	public void testDefaultContainerFactoryConfiguration(ApplicationContext context) {
+		RabbitListenerContainerTestFactory defaultFactory =
+				context.getBean("rabbitListenerContainerFactory", RabbitListenerContainerTestFactory.class);
+		assertEquals(1, defaultFactory.getListenerContainers().size());
+	}
+
+	static class DefaultBean {
+
+		@RabbitListener(queues = "myQueue")
+		public void handleIt(String msg) {
+		}
+	}
+
+	/**
+	 * Test for {@link ValidationBean} with a validator ({@link TestValidator}) specified
+	 * in a custom {@link org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory}.
+	 *
+	 * The test should throw a {@link org.springframework.amqp.rabbit.listener.ListenerExecutionFailedException}
+	 */
+	public void testRabbitHandlerMethodFactoryConfiguration(ApplicationContext context) throws Exception {
+		RabbitListenerContainerTestFactory simpleFactory =
+				context.getBean("defaultFactory", RabbitListenerContainerTestFactory.class);
+		assertEquals(1, simpleFactory.getListenerContainers().size());
+		MethodRabbitListenerEndpoint endpoint = (MethodRabbitListenerEndpoint)
+				simpleFactory.getListenerContainers().get(0).getEndpoint();
+
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		endpoint.setupListenerContainer(container);
+		MessagingMessageListenerAdapter listener = (MessagingMessageListenerAdapter) container.getMessageListener();
+
+		MessageProperties properties = new MessageProperties();
+		properties.setContentType(MessageProperties.CONTENT_TYPE_TEXT_PLAIN);
+		Message amqpMessage = new Message("failValidation".getBytes(), properties);
+
+		listener.onMessage(amqpMessage, mock(Channel.class));
+	}
+
+	@Component
+	static class ValidationBean {
+
+		@RabbitListener(containerFactory = "defaultFactory", queues = "myQueue")
+		public void defaultHandle(@Validated String msg) {
+		}
+	}
+
+	private void assertQueues(AbstractRabbitListenerEndpoint actual, String... expectedQueues) {
+		Collection<String> actualQueues = actual.getQueueNames();
+		for (String expectedQueue : expectedQueues) {
+			assertTrue("Queue '" + expectedQueue + "' not found", actualQueues.contains(expectedQueue));
+		}
+		assertEquals("Wrong number of queues", expectedQueues.length, actualQueues.size());
+	}
+
+	private void assertQueues(AbstractRabbitListenerEndpoint actual, Queue... expectedQueues) {
+		Collection<Queue> actualQueues = actual.getQueues();
+		for (Queue expectedQueue : expectedQueues) {
+			assertTrue("Queue '" + expectedQueue + "' not found", actualQueues.contains(expectedQueue));
+		}
+		assertEquals("Wrong number of queues", expectedQueues.length, actualQueues.size());
+	}
+
+	static class TestValidator implements Validator {
+
+		@Override
+		public boolean supports(Class<?> clazz) {
+			return String.class.isAssignableFrom(clazz);
+		}
+
+		@Override
+		public void validate(Object target, Errors errors) {
+			String value = (String) target;
+			if ("failValidation".equals(value)) {
+				errors.reject("TEST: expected invalid value");
+			}
+		}
+	}
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AnnotationDrivenNamespaceTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AnnotationDrivenNamespaceTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistrar;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.listener.ListenerExecutionFailedException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class AnnotationDrivenNamespaceTests extends AbstractRabbitAnnotationDrivenTests {
+
+	@Override
+	@Test
+	public void sampleConfiguration() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"annotation-driven-sample-config.xml", getClass());
+		testSampleConfiguration(context);
+	}
+
+	@Override
+	@Test
+	public void fullConfiguration() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"annotation-driven-full-config.xml", getClass());
+		testFullConfiguration(context);
+	}
+
+	@Override
+	public void noRabbitAdminConfiguration() {
+		thrown.expect(BeanCreationException.class);
+		thrown.expectMessage("'rabbitAdmin'");
+		new ClassPathXmlApplicationContext("annotation-driven-no-rabbit-admin-config.xml", getClass());
+	}
+
+	@Override
+	@Test
+	public void customConfiguration() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"annotation-driven-custom-registry.xml", getClass());
+		testCustomConfiguration(context);
+	}
+
+	@Override
+	@Test
+	public void explicitContainerFactory() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"annotation-driven-custom-container-factory.xml", getClass());
+		testExplicitContainerFactoryConfiguration(context);
+	}
+
+	@Override
+	public void defaultContainerFactory() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"annotation-driven-default-container-factory.xml", getClass());
+		testDefaultContainerFactoryConfiguration(context);
+	}
+
+	@Override
+	public void rabbitHandlerMethodFactoryConfiguration() throws Exception {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"annotation-driven-custom-handler-method-factory.xml", getClass());
+
+		thrown.expect(ListenerExecutionFailedException.class);
+		thrown.expectCause(Is.<MethodArgumentNotValidException>isA(MethodArgumentNotValidException.class));
+		testRabbitHandlerMethodFactoryConfiguration(context);
+	}
+
+	static class CustomRabbitListenerConfigurer implements RabbitListenerConfigurer {
+
+		private MessageListener messageListener;
+
+		@Override
+		public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+			SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+			endpoint.setId("myCustomEndpointId");
+			endpoint.setQueueNames("myQueue");
+			endpoint.setMessageListener(this.messageListener);
+			registrar.registerEndpoint(endpoint);
+		}
+
+		public void setMessageListener(MessageListener messageListener) {
+			this.messageListener = messageListener;
+		}
+
+	}
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.test.BrokerRunning;
+import org.springframework.amqp.rabbit.test.MessageTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Stephane Nicoll
+ */
+@ContextConfiguration(classes = EnableRabbitIntegrationTests.EnableRabbitConfig.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
+public class EnableRabbitIntegrationTests {
+
+	@ClassRule
+	public static final BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues(
+			"test.simple", "test.header", "test.message", "test.reply");
+
+	@Autowired
+	private RabbitTemplate rabbitTemplate;
+
+	@Test
+	public void simpleEndpoint() {
+		assertEquals("FOO", rabbitTemplate.convertSendAndReceive("test.simple", "foo"));
+	}
+
+	@Test
+	public void endpointWithHeader() {
+		MessageProperties properties = new MessageProperties();
+		properties.setHeader("prefix", "prefix-");
+		Message request = MessageTestUtils.createTextMessage("foo", properties);
+		Message reply = rabbitTemplate.sendAndReceive("test.header", request);
+		assertEquals("prefix-FOO", MessageTestUtils.extractText(reply));
+	}
+
+	@Test
+	public void endpointWithMessage() {
+		MessageProperties properties = new MessageProperties();
+		properties.setHeader("prefix", "prefix-");
+		Message request = MessageTestUtils.createTextMessage("foo", properties);
+		Message reply = rabbitTemplate.sendAndReceive("test.message", request);
+		assertEquals("prefix-FOO", MessageTestUtils.extractText(reply));
+	}
+
+	@Test
+	public void endpointWithComplexReply() {
+		MessageProperties properties = new MessageProperties();
+		properties.setHeader("foo", "fooValue");
+		Message request = MessageTestUtils.createTextMessage("content", properties);
+		Message reply = rabbitTemplate.sendAndReceive("test.reply", request);
+		assertEquals("Wrong reply", "content", MessageTestUtils.extractText(reply));
+		assertEquals("Wrong foo header", "fooValue", reply.getMessageProperties().getHeaders().get("foo"));
+		assertEquals("Wrong bar header", "barValue", reply.getMessageProperties().getHeaders().get("bar"));
+	}
+
+	public static class MyService {
+
+		@RabbitListener(queues = "test.simple")
+		public String capitalize(String foo) {
+			return foo.toUpperCase();
+		}
+
+		@RabbitListener(queues = "test.header")
+		public String capitalizeWithHeader(@Payload String content, @Header String prefix) {
+			return prefix + content.toUpperCase();
+		}
+
+		@RabbitListener(queues = "test.message")
+		public String capitalizeWithMessage(org.springframework.messaging.Message<String> message) {
+			return message.getHeaders().get("prefix") + message.getPayload().toUpperCase();
+		}
+
+		@RabbitListener(queues = "test.reply")
+		public org.springframework.messaging.Message<?> reply(String payload, @Header String foo) {
+			return MessageBuilder.withPayload(payload)
+					.setHeader("foo", foo).setHeader("bar", "barValue").build();
+		}
+	}
+
+	@Configuration
+	@EnableRabbit
+	public static class EnableRabbitConfig {
+
+		@Bean
+		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() {
+			SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+			factory.setConnectionFactory(rabbitConnectionFactory());
+			return factory;
+		}
+
+		@Bean
+		public MyService myService() {
+			return new MyService();
+		}
+
+		// Rabbit infrastructure setup
+
+		@Bean
+		public ConnectionFactory rabbitConnectionFactory() {
+			CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+			connectionFactory.setHost("localhost");
+			return connectionFactory;
+		}
+
+		@Bean
+		public RabbitTemplate rabbitTemplate() {
+			return new RabbitTemplate(rabbitConnectionFactory());
+		}
+
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitTests.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+
+import org.hamcrest.core.Is;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistrar;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.listener.ListenerExecutionFailedException;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
+
+import static org.mockito.Mockito.*;
+
+/**
+ *
+ * @author Stephane Nicoll
+ */
+public class EnableRabbitTests extends AbstractRabbitAnnotationDrivenTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Override
+	@Test
+	public void sampleConfiguration() {
+		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				EnableRabbitSampleConfig.class, SampleBean.class);
+		testSampleConfiguration(context);
+	}
+
+	@Override
+	@Test
+	public void fullConfiguration() {
+		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				EnableRabbitFullConfig.class, FullBean.class);
+		testFullConfiguration(context);
+	}
+
+	@Override
+	public void noRabbitAdminConfiguration() {
+		thrown.expect(BeanCreationException.class);
+		thrown.expectMessage("'rabbitAdmin'");
+		new AnnotationConfigApplicationContext(EnableRabbitSampleConfig.class, FullBean.class);
+	}
+
+	@Override
+	@Test
+	public void customConfiguration() {
+		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				EnableRabbitCustomConfig.class, CustomBean.class);
+		testCustomConfiguration(context);
+	}
+
+	@Override
+	@Test
+	public void explicitContainerFactory() {
+		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				EnableRabbitCustomContainerFactoryConfig.class, DefaultBean.class);
+		testExplicitContainerFactoryConfiguration(context);
+	}
+
+	@Override
+	@Test
+	public void defaultContainerFactory() {
+		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				EnableRabbitDefaultContainerFactoryConfig.class, DefaultBean.class);
+		testDefaultContainerFactoryConfiguration(context);
+	}
+
+	@Override
+	@Test
+	public void rabbitHandlerMethodFactoryConfiguration() throws Exception {
+		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				EnableRabbitHandlerMethodFactoryConfig.class, ValidationBean.class);
+
+		thrown.expect(ListenerExecutionFailedException.class);
+		thrown.expectCause(Is.<MethodArgumentNotValidException>isA(MethodArgumentNotValidException.class));
+		testRabbitHandlerMethodFactoryConfiguration(context);
+	}
+
+	@Test
+	public void unknownFactory() {
+		thrown.expect(BeanCreationException.class);
+		thrown.expectMessage("customFactory"); // Not found
+		new AnnotationConfigApplicationContext(
+				EnableRabbitSampleConfig.class, CustomBean.class);
+	}
+
+	@EnableRabbit
+	@Configuration
+	static class EnableRabbitSampleConfig {
+
+		@Bean
+		public RabbitListenerContainerTestFactory rabbitListenerContainerFactory() {
+			return new RabbitListenerContainerTestFactory();
+		}
+
+		@Bean
+		public RabbitListenerContainerTestFactory simpleFactory() {
+			return new RabbitListenerContainerTestFactory();
+		}
+	}
+
+	@EnableRabbit
+	@Configuration
+	static class EnableRabbitFullConfig {
+
+		@Bean
+		public RabbitListenerContainerTestFactory simpleFactory() {
+			return new RabbitListenerContainerTestFactory();
+		}
+
+		@Bean
+		public RabbitAdmin rabbitAdmin() {
+			return mock(RabbitAdmin.class);
+		}
+	}
+
+	@Configuration
+	@EnableRabbit
+	static class EnableRabbitCustomConfig implements RabbitListenerConfigurer {
+
+		@Override
+		public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+			registrar.setEndpointRegistry(customRegistry());
+
+			// Also register a custom endpoint
+			SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+			endpoint.setId("myCustomEndpointId");
+			endpoint.setQueueNames("myQueue");
+			endpoint.setMessageListener(simpleMessageListener());
+			registrar.registerEndpoint(endpoint);
+		}
+
+		@Bean
+		public RabbitListenerContainerTestFactory rabbitListenerContainerFactory() {
+			return new RabbitListenerContainerTestFactory();
+		}
+
+		@Bean
+		public RabbitListenerEndpointRegistry customRegistry() {
+			return new RabbitListenerEndpointRegistry();
+		}
+
+		@Bean
+		public RabbitListenerContainerTestFactory customFactory() {
+			return new RabbitListenerContainerTestFactory();
+		}
+
+		@Bean
+		public MessageListener simpleMessageListener() {
+			return new MessageListenerAdapter();
+		}
+	}
+
+	@Configuration
+	@EnableRabbit
+	static class EnableRabbitCustomContainerFactoryConfig implements RabbitListenerConfigurer {
+
+		@Override
+		public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+			registrar.setContainerFactory(simpleFactory());
+		}
+
+		@Bean
+		public RabbitListenerContainerTestFactory simpleFactory() {
+			return new RabbitListenerContainerTestFactory();
+		}
+	}
+
+	@Configuration
+	@EnableRabbit
+	static class EnableRabbitDefaultContainerFactoryConfig {
+
+		@Bean
+		public RabbitListenerContainerTestFactory rabbitListenerContainerFactory() {
+			return new RabbitListenerContainerTestFactory();
+		}
+	}
+
+	@Configuration
+	@EnableRabbit
+	static class EnableRabbitHandlerMethodFactoryConfig implements RabbitListenerConfigurer {
+
+		@Override
+		public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+			registrar.setMessageHandlerMethodFactory(customMessageHandlerMethodFactory());
+		}
+
+		@Bean
+		public MessageHandlerMethodFactory customMessageHandlerMethodFactory() {
+			DefaultMessageHandlerMethodFactory factory = new DefaultMessageHandlerMethodFactory();
+			factory.setValidator(new TestValidator());
+			return factory;
+		}
+
+		@Bean
+		public RabbitListenerContainerTestFactory defaultFactory() {
+			return new RabbitListenerContainerTestFactory();
+		}
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.Test;
+
+import org.springframework.amqp.rabbit.config.AbstractRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.config.MessageListenerTestContainer;
+import org.springframework.amqp.rabbit.config.MethodRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Stephane Nicoll
+ * @author Juergen Hoeller
+ */
+public class RabbitListenerAnnotationBeanPostProcessorTests {
+
+	@Test
+	public void simpleMessageListener() {
+		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				Config.class, SimpleMessageListenerTestBean.class);
+
+		RabbitListenerContainerTestFactory factory = context.getBean(RabbitListenerContainerTestFactory.class);
+		assertEquals("One container should have been registered", 1, factory.getListenerContainers().size());
+		MessageListenerTestContainer container = factory.getListenerContainers().get(0);
+
+		RabbitListenerEndpoint endpoint = container.getEndpoint();
+		assertEquals("Wrong endpoint type", MethodRabbitListenerEndpoint.class, endpoint.getClass());
+		MethodRabbitListenerEndpoint methodEndpoint = (MethodRabbitListenerEndpoint) endpoint;
+		assertNotNull(methodEndpoint.getBean());
+		assertNotNull(methodEndpoint.getMethod());
+
+		SimpleMessageListenerContainer listenerContainer = new SimpleMessageListenerContainer();
+		methodEndpoint.setupListenerContainer(listenerContainer);
+		assertNotNull(listenerContainer.getMessageListener());
+
+		assertTrue("Should have been started " + container, container.isStarted());
+		context.close(); // Close and stop the listeners
+		assertTrue("Should have been stopped " + container, container.isStopped());
+	}
+
+	@Test
+	public void metaAnnotationIsDiscovered() {
+		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				Config.class, MetaAnnotationTestBean.class);
+
+		RabbitListenerContainerTestFactory factory = context.getBean(RabbitListenerContainerTestFactory.class);
+		assertEquals("one container should have been registered", 1, factory.getListenerContainers().size());
+		RabbitListenerEndpoint endpoint = factory.getListenerContainers().get(0).getEndpoint();
+		assertEquals("metaTestQueue", ((AbstractRabbitListenerEndpoint) endpoint).getQueueNames().iterator().next());
+	}
+
+
+	@Component
+	static class SimpleMessageListenerTestBean {
+
+		@RabbitListener(queues = "testQueue")
+		public void handleIt(String body) {
+		}
+
+	}
+
+
+	@Component
+	static class MetaAnnotationTestBean {
+
+		@FooListener
+		public void handleIt(String body) {
+		}
+	}
+
+
+	@RabbitListener(queues = "metaTestQueue")
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	static @interface FooListener {
+	}
+
+
+	@Configuration
+	static class Config {
+
+		@Bean
+		public RabbitListenerAnnotationBeanPostProcessor postProcessor() {
+			RabbitListenerAnnotationBeanPostProcessor postProcessor = new RabbitListenerAnnotationBeanPostProcessor();
+			postProcessor.setEndpointRegistry(rabbitListenerEndpointRegistry());
+			postProcessor.setContainerFactoryBeanName("testFactory");
+			return postProcessor;
+		}
+
+		@Bean
+		public RabbitListenerEndpointRegistry rabbitListenerEndpointRegistry() {
+			return new RabbitListenerEndpointRegistry();
+		}
+
+		@Bean
+		public RabbitListenerContainerTestFactory testFactory() {
+			return new RabbitListenerContainerTestFactory();
+		}
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MessageListenerTestContainer.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MessageListenerTestContainer.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class MessageListenerTestContainer
+		implements MessageListenerContainer, InitializingBean, DisposableBean {
+
+	private final RabbitListenerEndpoint endpoint;
+
+	private boolean startInvoked;
+
+	private boolean initializationInvoked;
+
+	private boolean stopInvoked;
+
+	private boolean destroyInvoked;
+
+	MessageListenerTestContainer(RabbitListenerEndpoint endpoint) {
+		this.endpoint = endpoint;
+	}
+
+	public RabbitListenerEndpoint getEndpoint() {
+		return endpoint;
+	}
+
+	public boolean isStarted() {
+		return startInvoked && initializationInvoked;
+	}
+
+	public boolean isStopped() {
+		return stopInvoked && destroyInvoked;
+	}
+
+	@Override
+	public void start() {
+		if (!initializationInvoked) {
+			throw new IllegalStateException("afterPropertiesSet should have been invoked before start on " + this);
+		}
+		if (startInvoked) {
+			throw new IllegalStateException("Start already invoked on " + this);
+		}
+		startInvoked = true;
+	}
+
+	@Override
+	public void stop() {
+		if (stopInvoked) {
+			throw new IllegalStateException("Stop already invoked on " + this);
+		}
+		stopInvoked = true;
+	}
+
+	@Override
+	public boolean isRunning() {
+		return startInvoked && !stopInvoked;
+	}
+
+	@Override
+	public int getPhase() {
+		return 0;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return true;
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		stopInvoked = true;
+		callback.run();
+	}
+
+	@Override
+	public void setupMessageListener(Object messageListener) {
+	}
+
+	@Override
+	public MessageConverter getMessageConverter() {
+		return null;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		initializationInvoked = true;
+	}
+
+	@Override
+	public void destroy() {
+		if (!stopInvoked) {
+			throw new IllegalStateException("Stop should have been invoked before " +
+					"destroy on " + this);
+		}
+		destroyInvoked = true;
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder("TestContainer{");
+		sb.append("endpoint=").append(endpoint);
+		sb.append(", startInvoked=").append(startInvoked);
+		sb.append(", initializationInvoked=").append(initializationInvoked);
+		sb.append(", stopInvoked=").append(stopInvoked);
+		sb.append(", destroyInvoked=").append(destroyInvoked);
+		sb.append('}');
+		return sb.toString();
+	}
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MethodRabbitListenerEndpointTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MethodRabbitListenerEndpointTests.java
@@ -1,0 +1,575 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.core.Address;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.listener.ListenerExecutionFailedException;
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
+import org.springframework.amqp.rabbit.listener.adapter.ReplyFailureException;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.amqp.support.AmqpMessageHeaderAccessor;
+import org.springframework.amqp.support.converter.MessageConversionException;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.amqp.utils.SerializationUtils;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentTypeMismatchException;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.springframework.validation.annotation.Validated;
+
+import static org.junit.Assert.*;
+import static org.mockito.AdditionalMatchers.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.amqp.rabbit.test.MessageTestUtils.*;
+
+
+/**
+ * @author Stephane Nicoll
+ */
+public class MethodRabbitListenerEndpointTests {
+
+	@Rule
+	public final TestName name = new TestName();
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private final DefaultMessageHandlerMethodFactory factory = new DefaultMessageHandlerMethodFactory();
+
+	private final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+
+	private final RabbitEndpointSampleBean sample = new RabbitEndpointSampleBean();
+
+
+	@Before
+	public void setup() {
+		initializeFactory(factory);
+	}
+
+	@Test
+	public void createMessageListenerNoFactory() {
+		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
+		endpoint.setBean(this);
+		endpoint.setMethod(getTestMethod());
+
+		thrown.expect(IllegalStateException.class);
+		endpoint.createMessageListener(container);
+	}
+
+	@Test
+	public void createMessageListener() {
+		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
+		endpoint.setBean(this);
+		endpoint.setMethod(getTestMethod());
+		endpoint.setMessageHandlerMethodFactory(factory);
+
+		assertNotNull(endpoint.createMessageListener(container));
+	}
+
+	@Test
+	public void resolveMessageAndSession() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(
+				org.springframework.amqp.core.Message.class, Channel.class);
+
+		Channel channel = mock(Channel.class);
+		listener.onMessage(createTextMessage("test"), channel);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void resolveGenericMessage() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(Message.class);
+
+		Channel channel = mock(Channel.class);
+		listener.onMessage(createTextMessage("test"), channel);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void resolveHeaderAndPayload() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(String.class, int.class);
+
+		Channel channel = mock(Channel.class);
+		MessageProperties properties = new MessageProperties();
+		properties.setHeader("myCounter", 55);
+		org.springframework.amqp.core.Message message = createTextMessage("my payload", properties);
+		listener.onMessage(message, channel);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void resolveCustomHeaderNameAndPayload() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(String.class, int.class);
+
+		Channel channel = mock(Channel.class);
+		MessageProperties properties = new MessageProperties();
+		properties.setHeader("myCounter", 24);
+		org.springframework.amqp.core.Message message = createTextMessage("my payload", properties);
+		listener.onMessage(message, channel);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void resolveHeaders() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(String.class, Map.class);
+
+		Channel channel = mock(Channel.class);
+		MessageProperties properties = new MessageProperties();
+		properties.setHeader("customInt", 1234);
+		properties.setMessageId("abcd-1234");
+		org.springframework.amqp.core.Message message = createTextMessage("my payload", properties);
+		listener.onMessage(message, channel);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void resolveMessageHeaders() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(MessageHeaders.class);
+
+		Channel channel = mock(Channel.class);
+		MessageProperties properties = new MessageProperties();
+		properties.setHeader("customLong", 4567L);
+		properties.setType("myMessageType");
+		org.springframework.amqp.core.Message message = createTextMessage("my payload", properties);
+		listener.onMessage(message, channel);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void resolveRabbitMessageHeaderAccessor() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(AmqpMessageHeaderAccessor.class);
+
+		Channel channel = mock(Channel.class);
+		MessageProperties properties = new MessageProperties();
+		properties.setHeader("customBoolean", true);
+		properties.setAppId("myAppId");
+		org.springframework.amqp.core.Message message = createTextMessage("my payload", properties);
+		listener.onMessage(message, channel);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void resolveObjectPayload() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(MyBean.class);
+		MyBean myBean = new MyBean();
+		myBean.name = "myBean name";
+
+		Channel channel = mock(Channel.class);
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType(MessageProperties.CONTENT_TYPE_SERIALIZED_OBJECT);
+		org.springframework.amqp.core.Message message =
+				new org.springframework.amqp.core.Message(SerializationUtils.serialize(myBean), messageProperties);
+		listener.onMessage(message, channel);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void resolveConvertedPayload() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(Integer.class);
+
+		Channel channel = mock(Channel.class);
+
+		listener.onMessage(createTextMessage("33"), channel);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void processAndReply() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(String.class);
+		String body = "echo text";
+		String correlationId = "link-1234";
+		String responseExchange = "fooQueue";
+		String responseRoutingKey = "abc-1234";
+
+		listener.setResponseExchange(responseExchange);
+		listener.setResponseRoutingKey(responseRoutingKey);
+		MessageProperties properties = new MessageProperties();
+		properties.setCorrelationId(correlationId.getBytes(SimpleMessageConverter.DEFAULT_CHARSET));
+		org.springframework.amqp.core.Message message = createTextMessage(body, properties);
+
+		processAndReply(listener, message, responseExchange, responseRoutingKey, false, correlationId);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void processAndReplyWithMessage() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(org.springframework.amqp.core.Message.class);
+		listener.setMessageConverter(null);
+		listener.setResponseExchange("fooQueue");
+		String body = "echo text";
+
+		org.springframework.amqp.core.Message message = createTextMessage(body, new MessageProperties());
+
+
+		processAndReply(listener, message, "fooQueue", "", false, null);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void processAndReplyWithMessageAndStringReply() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(org.springframework.amqp.core.Message.class);
+		listener.setMessageConverter(null);
+		listener.setResponseExchange("fooQueue");
+		String body = "echo text";
+
+		org.springframework.amqp.core.Message message = createTextMessage(body, new MessageProperties());
+
+		try {
+			processAndReply(listener, message, "fooQueue", "", false, null);
+			fail("Should have fail. Not converter and the reply is not a message");
+		}
+		catch (ReplyFailureException ex) {
+			Throwable cause = ex.getCause();
+			assertNotNull(cause);
+			assertEquals(MessageConversionException.class, cause.getClass());
+			assertTrue(ex.getMessage().contains("foo")); // exception holds the content of the reply
+		}
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void processAndReplyUsingReplyTo() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(String.class);
+		listener.setMandatoryPublish(true);
+		String body = "echo text";
+		Address replyTo = new Address(null, "replyToQueue", "myRouting");
+
+		MessageProperties properties = new MessageProperties();
+		properties.setReplyToAddress(replyTo);
+		org.springframework.amqp.core.Message message = createTextMessage(body, properties);
+
+
+		processAndReply(listener, message, "replyToQueue", "myRouting", true, null);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	@Test
+	public void processAndReplyWithSendTo() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(String.class);
+		String body = "echo text";
+		String messageId = "msgId-1234";
+
+		MessageProperties properties = new MessageProperties();
+		properties.setMessageId(messageId);
+		org.springframework.amqp.core.Message message = createTextMessage(body, properties);
+
+		// MessageId is used as fallback when no correlationId is set
+		processAndReply(listener, message, "replyDestination", "", false, messageId);
+		assertDefaultListenerMethodInvocation();
+	}
+
+	public void processAndReply(MessagingMessageListenerAdapter listener,
+			org.springframework.amqp.core.Message message, String expectedExchange, String routingKey,
+			boolean mandatory, String expectedCorrelationId) throws Exception {
+
+		Channel channel = mock(Channel.class);
+
+		listener.onMessage(message, channel);
+
+		ArgumentCaptor<AMQP.BasicProperties> argument = ArgumentCaptor.forClass(AMQP.BasicProperties.class);
+		verify(channel).basicPublish(eq(expectedExchange), eq(routingKey), eq(mandatory),
+				argument.capture(), aryEq(message.getBody()));
+		assertEquals("Wrong correlationId in reply", expectedCorrelationId, argument.getValue().getCorrelationId());
+	}
+
+	@Test
+	public void emptySendTo() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(String.class);
+
+		Channel channel = mock(Channel.class);
+
+		thrown.expect(ReplyFailureException.class);
+		thrown.expectCause(Matchers.isA(AmqpException.class));
+		listener.onMessage(createTextMessage("content"), channel);
+	}
+
+	@Test
+	public void invalidSendTo() {
+		thrown.expect(IllegalStateException.class);
+		thrown.expectMessage("firstDestination");
+		thrown.expectMessage("secondDestination");
+		createDefaultInstance(String.class);
+	}
+
+	@Test
+	public void validatePayloadValid() throws Exception {
+		String methodName = "validatePayload";
+
+		DefaultMessageHandlerMethodFactory customFactory = new DefaultMessageHandlerMethodFactory();
+		customFactory.setValidator(testValidator("invalid value"));
+		initializeFactory(customFactory);
+
+		Method method = getListenerMethod(methodName, String.class);
+		MessagingMessageListenerAdapter listener = createInstance(customFactory, method);
+		Channel channel = mock(Channel.class);
+		listener.onMessage(createTextMessage("test"), channel); // test is a valid value
+		assertListenerMethodInvocation(sample, methodName);
+	}
+
+	@Test
+	public void validatePayloadInvalid() throws Exception {
+		DefaultMessageHandlerMethodFactory customFactory = new DefaultMessageHandlerMethodFactory();
+		customFactory.setValidator(testValidator("invalid value"));
+
+		Method method = getListenerMethod("validatePayload", String.class);
+		MessagingMessageListenerAdapter listener = createInstance(customFactory, method);
+		Channel channel = mock(Channel.class);
+
+		thrown.expect(ListenerExecutionFailedException.class);
+		listener.onMessage(createTextMessage("invalid value"), channel); // test is an invalid value
+
+	}
+
+	// failure scenario
+
+	@Test
+	public void invalidPayloadType() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(Integer.class);
+		Channel channel = mock(Channel.class);
+
+		thrown.expect(ListenerExecutionFailedException.class);
+		thrown.expectCause(Matchers.isA(org.springframework.messaging.converter.MessageConversionException.class));
+		thrown.expectMessage(getDefaultListenerMethod(Integer.class).toGenericString()); // ref to method
+		listener.onMessage(createTextMessage("test"), channel); // test is not a valid integer
+	}
+
+	@Test
+	public void invalidMessagePayloadType() throws Exception {
+		MessagingMessageListenerAdapter listener = createDefaultInstance(Message.class);
+		Channel channel = mock(Channel.class);
+
+		thrown.expect(ListenerExecutionFailedException.class);
+		thrown.expectCause(Matchers.isA(MethodArgumentTypeMismatchException.class));
+		listener.onMessage(createTextMessage("test"), channel);  // Message<String> as Message<Integer>
+	}
+
+	private MessagingMessageListenerAdapter createInstance(
+			DefaultMessageHandlerMethodFactory factory, Method method, MessageListenerContainer container) {
+		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
+		endpoint.setBean(sample);
+		endpoint.setMethod(method);
+		endpoint.setMessageHandlerMethodFactory(factory);
+		MessagingMessageListenerAdapter messageListener = endpoint.createMessageListener(container);
+		return messageListener;
+	}
+
+	private MessagingMessageListenerAdapter createInstance(
+			DefaultMessageHandlerMethodFactory factory, Method method) {
+		return createInstance(factory, method, new SimpleMessageListenerContainer());
+	}
+
+	private MessagingMessageListenerAdapter createDefaultInstance(Class<?>... parameterTypes) {
+		return createInstance(this.factory, getDefaultListenerMethod(parameterTypes));
+	}
+
+	private Method getListenerMethod(String methodName, Class<?>... parameterTypes) {
+		Method method = ReflectionUtils.findMethod(RabbitEndpointSampleBean.class, methodName, parameterTypes);
+		assertNotNull("no method found with name " + methodName + " and parameters " + Arrays.toString(parameterTypes));
+		return method;
+	}
+
+	private Method getDefaultListenerMethod(Class<?>... parameterTypes) {
+		return getListenerMethod(name.getMethodName(), parameterTypes);
+	}
+
+	private void assertDefaultListenerMethodInvocation() {
+		assertListenerMethodInvocation(sample, name.getMethodName());
+	}
+
+	private void assertListenerMethodInvocation(RabbitEndpointSampleBean bean, String methodName) {
+		assertTrue("Method " + methodName + " should have been invoked", bean.invocations.get(methodName));
+	}
+
+	private void initializeFactory(DefaultMessageHandlerMethodFactory factory) {
+		factory.setBeanFactory(new StaticListableBeanFactory());
+		factory.afterPropertiesSet();
+	}
+
+	private Validator testValidator(final String invalidValue) {
+		return new Validator() {
+			@Override
+			public boolean supports(Class<?> clazz) {
+				return String.class.isAssignableFrom(clazz);
+			}
+
+			@Override
+			public void validate(Object target, Errors errors) {
+				String value = (String) target;
+				if (invalidValue.equals(value)) {
+					errors.reject("not a valid value");
+				}
+			}
+		};
+	}
+
+	private Method getTestMethod() {
+		return ReflectionUtils.findMethod(MethodRabbitListenerEndpointTests.class, name.getMethodName());
+	}
+
+	static class RabbitEndpointSampleBean {
+
+		private final Map<String, Boolean> invocations = new HashMap<String, Boolean>();
+
+		public void resolveMessageAndSession(org.springframework.amqp.core.Message message, Channel channel) {
+			invocations.put("resolveMessageAndSession", true);
+			assertNotNull("Message not injected", message);
+			assertNotNull("Channel not injected", channel);
+		}
+
+		public void resolveGenericMessage(Message<String> message) {
+			invocations.put("resolveGenericMessage", true);
+			assertNotNull("Generic message not injected", message);
+			assertEquals("Wrong message payload", "test", message.getPayload());
+		}
+
+		public void resolveHeaderAndPayload(@Payload String content, @Header int myCounter) {
+			invocations.put("resolveHeaderAndPayload", true);
+			assertEquals("Wrong @Payload resolution", "my payload", content);
+			assertEquals("Wrong @Header resolution", 55, myCounter);
+		}
+
+		public void resolveCustomHeaderNameAndPayload(@Payload String content, @Header("myCounter") int counter) {
+			invocations.put("resolveCustomHeaderNameAndPayload", true);
+			assertEquals("Wrong @Payload resolution", "my payload", content);
+			assertEquals("Wrong @Header resolution", 24, counter);
+		}
+
+		public void resolveHeaders(String content, @Headers Map<String, Object> headers) {
+			invocations.put("resolveHeaders", true);
+			assertEquals("Wrong payload resolution", "my payload", content);
+			assertNotNull("headers not injected", headers);
+			assertEquals("Missing AMQP message id header", "abcd-1234", headers.get(AmqpHeaders.MESSAGE_ID));
+			assertEquals("Missing custom header", 1234, headers.get("customInt"));
+		}
+
+		public void resolveMessageHeaders(MessageHeaders headers) {
+			invocations.put("resolveMessageHeaders", true);
+			assertNotNull("MessageHeaders not injected", headers);
+			assertEquals("Missing AMQP message type header", "myMessageType", headers.get(AmqpHeaders.TYPE));
+			assertEquals("Missing custom header", 4567L, (Long) headers.get("customLong"), 0.0);
+		}
+
+		public void resolveRabbitMessageHeaderAccessor(AmqpMessageHeaderAccessor headers) {
+			invocations.put("resolveRabbitMessageHeaderAccessor", true);
+			assertNotNull("MessageHeader accessor not injected", headers);
+			assertEquals("Missing AMQP AppID header", "myAppId", headers.getAppId());
+			assertEquals("Missing custom header", true, headers.getHeader("customBoolean"));
+		}
+
+		public void resolveObjectPayload(MyBean bean) {
+			invocations.put("resolveObjectPayload", true);
+			assertNotNull("Object payload not injected", bean);
+			assertEquals("Wrong content for payload", "myBean name", bean.name);
+		}
+
+		public void resolveConvertedPayload(Integer counter) {
+			invocations.put("resolveConvertedPayload", true);
+			assertNotNull("Payload not injected", counter);
+			assertEquals("Wrong content for payload", Integer.valueOf(33), counter);
+		}
+
+		public String processAndReply(@Payload String content) {
+			invocations.put("processAndReply", true);
+			return content;
+		}
+
+		public org.springframework.amqp.core.Message processAndReplyWithMessage(
+				org.springframework.amqp.core.Message content) {
+			invocations.put("processAndReplyWithMessage", true);
+			return content;
+		}
+
+		public String processAndReplyWithMessageAndStringReply(
+				org.springframework.amqp.core.Message content) {
+			invocations.put("processAndReplyWithMessageAndStringReply", true);
+			return "foo";
+		}
+
+		public String processAndReplyUsingReplyTo(String content) {
+			invocations.put("processAndReplyUsingReplyTo", true);
+			return content;
+		}
+
+		@SendTo("replyDestination")
+		public String processAndReplyWithSendTo(String content) {
+			invocations.put("processAndReplyWithSendTo", true);
+			return content;
+		}
+
+		@SendTo("")
+		public String emptySendTo(String content) {
+			invocations.put("emptySendTo", true);
+			return content;
+		}
+
+		@SendTo({"firstDestination", "secondDestination"})
+		public String invalidSendTo(String content) {
+			invocations.put("invalidSendTo", true);
+			return content;
+		}
+
+		public void validatePayload(@Validated String payload) {
+			invocations.put("validatePayload", true);
+		}
+
+		public void invalidPayloadType(@Payload Integer payload) {
+			throw new IllegalStateException("Should never be called.");
+		}
+
+		public void invalidMessagePayloadType(Message<Integer> message) {
+			throw new IllegalStateException("Should never be called.");
+		}
+
+	}
+
+
+	@SuppressWarnings("serial")
+	static class MyBean implements Serializable {
+		private String name;
+
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryIntegrationTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.rabbitmq.client.Channel;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.test.MessageTestUtils;
+import org.springframework.amqp.support.converter.MessageConversionException;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.util.ReflectionUtils;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class RabbitListenerContainerFactoryIntegrationTests {
+
+	private final SimpleRabbitListenerContainerFactory containerFactory = new SimpleRabbitListenerContainerFactory();
+
+	private final DefaultMessageHandlerMethodFactory factory = new DefaultMessageHandlerMethodFactory();
+
+	private final RabbitEndpointSampleBean sample = new RabbitEndpointSampleBean();
+
+
+	@Before
+	public void setup() {
+		initializeFactory(factory);
+	}
+
+	@Test
+	public void messageConverterUsedIfSet() throws Exception {
+		containerFactory.setMessageConverter(new UpperCaseMessageConverter());
+
+		MethodRabbitListenerEndpoint endpoint = createDefaultMethodRabbitEndpoint("expectFooBarUpperCase", String.class);
+		Message message = MessageTestUtils.createTextMessage("foo-bar");
+
+		invokeListener(endpoint, message);
+		assertListenerMethodInvocation("expectFooBarUpperCase");
+	}
+
+	@SuppressWarnings("unchecked")
+	private void invokeListener(RabbitListenerEndpoint endpoint, Message message) throws Exception {
+		SimpleMessageListenerContainer messageListenerContainer =
+				containerFactory.createListenerContainer(endpoint);
+		Object listener = messageListenerContainer.getMessageListener();
+		if (listener instanceof ChannelAwareMessageListener) {
+			((ChannelAwareMessageListener) listener).onMessage(message, mock(Channel.class));
+		}
+		else {
+			((MessageListener) listener).onMessage(message);
+		}
+	}
+
+	private void assertListenerMethodInvocation(String methodName) {
+		assertTrue("Method " + methodName + " should have been invoked", sample.invocations.get(methodName));
+	}
+
+
+	private MethodRabbitListenerEndpoint createMethodRabbitEndpoint(
+			DefaultMessageHandlerMethodFactory factory, Method method) {
+		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
+		endpoint.setBean(sample);
+		endpoint.setMethod(method);
+		endpoint.setMessageHandlerMethodFactory(factory);
+		return endpoint;
+	}
+
+	private MethodRabbitListenerEndpoint createDefaultMethodRabbitEndpoint(String methodName, Class<?>... parameterTypes) {
+		return createMethodRabbitEndpoint(this.factory, getListenerMethod(methodName, parameterTypes));
+	}
+
+	private Method getListenerMethod(String methodName, Class<?>... parameterTypes) {
+		Method method = ReflectionUtils.findMethod(RabbitEndpointSampleBean.class, methodName, parameterTypes);
+		assertNotNull("no method found with name " + methodName + " and parameters " + Arrays.toString(parameterTypes));
+		return method;
+	}
+
+
+	private void initializeFactory(DefaultMessageHandlerMethodFactory factory) {
+		factory.setBeanFactory(new StaticListableBeanFactory());
+		factory.afterPropertiesSet();
+	}
+
+
+	static class RabbitEndpointSampleBean {
+
+		private final Map<String, Boolean> invocations = new HashMap<String, Boolean>();
+
+		public void expectFooBarUpperCase(@Payload String msg) {
+			invocations.put("expectFooBarUpperCase", true);
+			assertEquals("Unexpected payload message", "FOO-BAR", msg);
+		}
+	}
+
+
+	private static class UpperCaseMessageConverter implements MessageConverter {
+
+		@Override
+		public Message toMessage(Object object, MessageProperties messageProperties) throws MessageConversionException {
+			return new Message(object.toString().toUpperCase().getBytes(), new MessageProperties());
+		}
+
+
+		@Override
+		public Object fromMessage(Message message) throws MessageConversionException {
+			String content = new String(message.getBody());
+			return content.toUpperCase();
+		}
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+
+import java.util.concurrent.Executor;
+
+import org.aopalliance.aop.Advice;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.util.ErrorHandler;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class RabbitListenerContainerFactoryTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private final SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+
+	private final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+
+	private final ErrorHandler errorHandler = mock(ErrorHandler.class);
+
+	private final MessageConverter messageConverter = new SimpleMessageConverter();
+
+	private final MessageListener messageListener = new MessageListenerAdapter();
+
+	@Test
+	public void createSimpleContainer() {
+		setBasicConfig(this.factory);
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setMessageListener(this.messageListener);
+		endpoint.setQueueNames("myQueue");
+
+		SimpleMessageListenerContainer container = this.factory.createListenerContainer(endpoint);
+
+		assertBasicConfig(container);
+		assertEquals(messageListener, container.getMessageListener());
+		assertEquals("myQueue", container.getQueueNames()[0]);
+	}
+
+	@Test
+	public void createContainerFullConfig() {
+		Executor executor = mock(Executor.class);
+		PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+		Advice advice = mock(Advice.class);
+
+		setBasicConfig(this.factory);
+		this.factory.setTaskExecutor(executor);
+		this.factory.setTransactionManager(transactionManager);
+		this.factory.setTxSize(10);
+		this.factory.setConcurrentConsumers(2);
+		this.factory.setMaxConcurrentConsumers(5);
+		this.factory.setStartConsumerMinInterval(2000L);
+		this.factory.setStopConsumerMinInterval(2500L);
+		this.factory.setConsecutiveActiveTrigger(8);
+		this.factory.setConsecutiveIdleTrigger(6);
+		this.factory.setPrefetchCount(3);
+		this.factory.setReceiveTimeout(1500L);
+		this.factory.setDefaultRequeueRejected(false);
+		this.factory.setAdviceChain(advice);
+		this.factory.setRecoveryInterval(3000L);
+		this.factory.setMissingQueuesFatal(true);
+
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+
+		endpoint.setMessageListener(this.messageListener);
+		endpoint.setQueueNames("myQueue");
+		SimpleMessageListenerContainer container = this.factory.createListenerContainer(endpoint);
+
+		assertBasicConfig(container);
+		DirectFieldAccessor fieldAccessor = new DirectFieldAccessor(container);
+		assertSame(executor, fieldAccessor.getPropertyValue("taskExecutor"));
+		assertSame(transactionManager, fieldAccessor.getPropertyValue("transactionManager"));
+		assertEquals(10, fieldAccessor.getPropertyValue("txSize"));
+		assertEquals(2, fieldAccessor.getPropertyValue("concurrentConsumers"));
+		assertEquals(5, fieldAccessor.getPropertyValue("maxConcurrentConsumers"));
+		assertEquals(2000L, fieldAccessor.getPropertyValue("startConsumerMinInterval"));
+		assertEquals(2500L, fieldAccessor.getPropertyValue("stopConsumerMinInterval"));
+		assertEquals(8, fieldAccessor.getPropertyValue("consecutiveActiveTrigger"));
+		assertEquals(6, fieldAccessor.getPropertyValue("consecutiveIdleTrigger"));
+		assertEquals(3, fieldAccessor.getPropertyValue("prefetchCount"));
+		assertEquals(1500L, fieldAccessor.getPropertyValue("receiveTimeout"));
+		assertEquals(false, fieldAccessor.getPropertyValue("defaultRequeueRejected"));
+		Advice[] actualAdviceChain = (Advice[]) fieldAccessor.getPropertyValue("adviceChain");
+		assertEquals("Wrong number of advice", 1, actualAdviceChain.length);
+		assertSame("Wrong advice", advice, actualAdviceChain[0]);
+		assertEquals(3000L, fieldAccessor.getPropertyValue("recoveryInterval"));
+		assertEquals(true, fieldAccessor.getPropertyValue("missingQueuesFatal"));
+		assertEquals(messageListener, container.getMessageListener());
+		assertEquals("myQueue", container.getQueueNames()[0]);
+	}
+
+	private SimpleRabbitListenerEndpoint createEndpoint() {
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setMessageListener(this.messageListener);
+		endpoint.setQueueNames("queue");
+		return endpoint;
+	}
+
+
+	private void setBasicConfig(AbstractRabbitListenerContainerFactory<?> factory) {
+		factory.setConnectionFactory(this.connectionFactory);
+		factory.setErrorHandler(this.errorHandler);
+		factory.setMessageConverter(this.messageConverter);
+		factory.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+		factory.setChannelTransacted(true);
+		factory.setAutoStartup(false);
+		factory.setPhase(99);
+	}
+
+	private void assertBasicConfig(AbstractMessageListenerContainer container) {
+		DirectFieldAccessor fieldAccessor = new DirectFieldAccessor(container);
+		assertSame(connectionFactory, container.getConnectionFactory());
+		assertSame(errorHandler, fieldAccessor.getPropertyValue("errorHandler"));
+		assertSame(messageConverter, container.getMessageConverter());
+		assertEquals(AcknowledgeMode.MANUAL, container.getAcknowledgeMode());
+		assertEquals(true, container.isChannelTransacted());
+		assertEquals(false, container.isAutoStartup());
+		assertEquals(99, container.getPhase());
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerTestFactory.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerTestFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ *
+ * @author Stephane Nicoll
+ */
+public class RabbitListenerContainerTestFactory implements RabbitListenerContainerFactory<MessageListenerTestContainer> {
+
+	private static final AtomicInteger counter = new AtomicInteger();
+
+	private final List<MessageListenerTestContainer> listenerContainers =
+			new ArrayList<MessageListenerTestContainer>();
+
+	public List<MessageListenerTestContainer> getListenerContainers() {
+		return listenerContainers;
+	}
+
+	@Override
+	public MessageListenerTestContainer createListenerContainer(RabbitListenerEndpoint endpoint) {
+		MessageListenerTestContainer container = new MessageListenerTestContainer(endpoint);
+		this.listenerContainers.add(container);
+
+		// resolve the id
+		if (endpoint.getId() == null && endpoint instanceof AbstractRabbitListenerEndpoint) {
+			((AbstractRabbitListenerEndpoint) endpoint).setId("endpoint#" + counter.getAndIncrement());
+		}
+		return container;
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpointRegistrarTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpointRegistrarTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class RabbitListenerEndpointRegistrarTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private final RabbitListenerEndpointRegistrar registrar = new RabbitListenerEndpointRegistrar();
+
+	private final RabbitListenerEndpointRegistry registry = new RabbitListenerEndpointRegistry();
+
+	private final RabbitListenerContainerTestFactory containerFactory = new RabbitListenerContainerTestFactory();
+
+
+	@Before
+	public void setup() {
+		registrar.setEndpointRegistry(registry);
+		registrar.setBeanFactory(new StaticListableBeanFactory());
+	}
+
+	@Test
+	public void registerNullEndpoint() {
+		thrown.expect(IllegalArgumentException.class);
+		registrar.registerEndpoint(null, containerFactory);
+	}
+
+	@Test
+	public void registerNullEndpointId() {
+		thrown.expect(IllegalArgumentException.class);
+		registrar.registerEndpoint(new SimpleRabbitListenerEndpoint(), containerFactory);
+	}
+
+	@Test
+	public void registerEmptyEndpointId() {
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setId("");
+
+		thrown.expect(IllegalArgumentException.class);
+		registrar.registerEndpoint(endpoint, containerFactory);
+	}
+
+	@Test
+	public void registerNullContainerFactoryIsAllowed() throws Exception {
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setId("some id");
+		registrar.setContainerFactory(containerFactory);
+		registrar.registerEndpoint(endpoint, null);
+		registrar.afterPropertiesSet();
+		assertNotNull("Container not created", registry.getListenerContainer("some id"));
+		assertEquals(1, registry.getListenerContainers().size());
+	}
+
+	@Test
+	public void registerNullContainerFactoryWithNoDefault() throws Exception {
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setId("some id");
+		registrar.registerEndpoint(endpoint, null);
+
+		thrown.expect(IllegalStateException.class);
+		thrown.expectMessage(endpoint.toString());
+		registrar.afterPropertiesSet();
+	}
+
+	@Test
+	public void registerContainerWithoutFactory() throws Exception {
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setId("myEndpoint");
+		registrar.setContainerFactory(containerFactory);
+		registrar.registerEndpoint(endpoint);
+		registrar.afterPropertiesSet();
+		assertNotNull("Container not created", registry.getListenerContainer("myEndpoint"));
+		assertEquals(1, registry.getListenerContainers().size());
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpointRegistryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerEndpointRegistryTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ *
+ * @author Stephane Nicoll
+ */
+public class RabbitListenerEndpointRegistryTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private final RabbitListenerEndpointRegistry registry = new RabbitListenerEndpointRegistry();
+
+	private final RabbitListenerContainerTestFactory containerFactory = new RabbitListenerContainerTestFactory();
+
+	@Test
+	public void createWithNullEndpoint() {
+		thrown.expect(IllegalArgumentException.class);
+		registry.registerListenerContainer(null, containerFactory);
+	}
+
+	@Test
+	public void createWithNullEndpointId() {
+		thrown.expect(IllegalArgumentException.class);
+		registry.registerListenerContainer(new SimpleRabbitListenerEndpoint(), containerFactory);
+	}
+
+	@Test
+	public void createWithNullContainerFactory() {
+		thrown.expect(IllegalArgumentException.class);
+		registry.registerListenerContainer(createEndpoint("foo", "myDestination"), null);
+	}
+
+	@Test
+	public void createWithDuplicateEndpointId() {
+		registry.registerListenerContainer(createEndpoint("test", "queue"), containerFactory);
+
+		thrown.expect(IllegalStateException.class);
+		registry.registerListenerContainer(createEndpoint("test", "queue"), containerFactory);
+	}
+
+	private SimpleRabbitListenerEndpoint createEndpoint(String id, String queueName) {
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setId(id);
+		endpoint.setQueueNames(queueName);
+		return endpoint;
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerEndpointTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerEndpointTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.config;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class SimpleRabbitListenerEndpointTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+
+	private final MessageListener messageListener = new MessageListenerAdapter();
+
+	@Test
+	public void createListener() {
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setMessageListener(messageListener);
+		assertSame(messageListener, endpoint.createMessageListener(container));
+	}
+
+	@Test
+	public void queueAndQueueNamesSet() {
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setMessageListener(messageListener);
+
+		endpoint.setQueueNames("foo", "bar");
+		endpoint.setQueues(mock(Queue.class));
+
+		thrown.expect(IllegalStateException.class);
+		endpoint.setupListenerContainer(container);
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import java.lang.reflect.Method;
+
+import com.rabbitmq.client.Channel;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.amqp.rabbit.listener.ListenerExecutionFailedException;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.ReflectionUtils;
+
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.amqp.rabbit.test.MessageTestUtils.*;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class MessagingMessageListenerAdapterTests {
+
+	private final DefaultMessageHandlerMethodFactory factory = new DefaultMessageHandlerMethodFactory();
+
+	private final SampleBean sample = new SampleBean();
+
+
+	@Before
+	public void setup() {
+		initializeFactory(factory);
+	}
+
+	@Test
+	public void buildMessageWithStandardMessage() throws Exception {
+		Message<String> result = MessageBuilder.withPayload("Response")
+				.setHeader("foo", "bar")
+				.setHeader(AmqpHeaders.TYPE, "msg_type")
+				.setHeader(AmqpHeaders.REPLY_TO, "reply")
+				.build();
+
+		Channel session = mock(Channel.class);
+		MessagingMessageListenerAdapter listener = getSimpleInstance("echo", Message.class);
+		org.springframework.amqp.core.Message replyMessage = listener.buildMessage(session, result);
+
+		assertNotNull("reply should never be null", replyMessage);
+		assertEquals("Response", new String(replyMessage.getBody()));
+		assertEquals("type header not copied", "msg_type", replyMessage.getMessageProperties().getType());
+		assertEquals("replyTo header not copied", "reply", replyMessage.getMessageProperties().getReplyTo());
+		assertEquals("custom header not copied", "bar", replyMessage.getMessageProperties().getHeaders().get("foo"));
+	}
+
+	@Test
+	public void exceptionInListener() {
+		org.springframework.amqp.core.Message message = createTextMessage("foo");
+		Channel channel = mock(Channel.class);
+		MessagingMessageListenerAdapter listener = getSimpleInstance("fail", String.class);
+
+		try {
+			listener.onMessage(message, channel);
+			fail("Should have thrown an exception");
+		}
+		catch (ListenerExecutionFailedException ex) {
+			assertEquals(IllegalArgumentException.class, ex.getCause().getClass());
+			assertEquals("Expected test exception", ex.getCause().getMessage());
+		}
+		catch (Exception ex) {
+			fail("Should not have thrown another exception");
+		}
+	}
+
+	@Test
+	public void exceptionInInvocation() {
+		org.springframework.amqp.core.Message message = createTextMessage("foo");
+		Channel channel = mock(Channel.class);
+		MessagingMessageListenerAdapter listener = getSimpleInstance("wrongParam", Integer.class);
+
+		try {
+			listener.onMessage(message, channel);
+			fail("Should have thrown an exception");
+		}
+		catch (ListenerExecutionFailedException ex) {
+			assertEquals(MessageConversionException.class, ex.getCause().getClass());
+		}
+		catch (Exception ex) {
+			fail("Should not have thrown another exception");
+		}
+	}
+
+	protected MessagingMessageListenerAdapter getSimpleInstance(String methodName, Class... parameterTypes) {
+		Method m = ReflectionUtils.findMethod(SampleBean.class, methodName, parameterTypes);
+		return createInstance(m);
+	}
+
+	protected MessagingMessageListenerAdapter createInstance(Method m) {
+		MessagingMessageListenerAdapter adapter = new MessagingMessageListenerAdapter();
+		adapter.setHandlerMethod(factory.createInvocableHandlerMethod(sample, m));
+		return adapter;
+	}
+
+	private void initializeFactory(DefaultMessageHandlerMethodFactory factory) {
+		factory.setBeanFactory(new StaticListableBeanFactory());
+		factory.afterPropertiesSet();
+	}
+
+	private static class SampleBean {
+
+		public Message<String> echo(Message<String> input) {
+			return MessageBuilder.withPayload(input.getPayload())
+					.setHeader(AmqpHeaders.TYPE, "reply")
+					.build();
+		}
+
+		public void fail(String input) {
+			throw new IllegalArgumentException("Expected test exception");
+		}
+
+		public void wrongParam(Integer i) {
+			throw new IllegalArgumentException("Should not have been called");
+		}
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/MessageTestUtils.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/MessageTestUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.test;
+
+import java.io.UnsupportedEncodingException;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+
+/**
+ * {@link org.springframework.amqp.core.Message} related utilities.
+ *
+ * @author Stephane Nicoll
+ * @since 2.0
+ */
+public abstract class MessageTestUtils {
+
+	/**
+	 * Create a text message with the specified {@link MessageProperties}. The
+	 * content type is set no matter
+	 */
+	public static Message createTextMessage(String body, MessageProperties properties) {
+		properties.setContentType(MessageProperties.CONTENT_TYPE_TEXT_PLAIN);
+		return new org.springframework.amqp.core.Message(toBytes(body), properties);
+	}
+
+	/**
+	 * Create a text message with the relevant content type.
+	 */
+	public static Message createTextMessage(String body) {
+		return createTextMessage(body, new MessageProperties());
+	}
+
+
+	/**
+	 * Extract the text from the specified message.
+	 */
+	public static String extractText(Message message) {
+		try {
+			return new String(message.getBody(), SimpleMessageConverter.DEFAULT_CHARSET);
+		}
+		catch (UnsupportedEncodingException e) {
+			throw new IllegalStateException("Should not happen", e);
+		}
+	}
+
+	private static byte[] toBytes(String content) {
+		try {
+			return content.getBytes(SimpleMessageConverter.DEFAULT_CHARSET);
+		}
+		catch (UnsupportedEncodingException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+}

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-container-factory.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-container-factory.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/rabbit
+	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+
+	<rabbit:annotation-driven container-factory="simpleFactory"/>
+
+	<bean class="org.springframework.amqp.rabbit.annotation.AbstractRabbitAnnotationDrivenTests$DefaultBean"/>
+
+	<bean id="simpleFactory" class="org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory"/>
+
+
+</beans>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-handler-method-factory.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-handler-method-factory.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/rabbit
+	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+
+	<rabbit:annotation-driven handler-method-factory="customMessageHandlerMethodFactory"/>
+
+	<bean id="customMessageHandlerMethodFactory" class="org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory">
+		<property name="validator">
+			<bean class="org.springframework.amqp.rabbit.annotation.AbstractRabbitAnnotationDrivenTests$TestValidator"/>
+		</property>
+	</bean>
+
+	<bean class="org.springframework.amqp.rabbit.annotation.AbstractRabbitAnnotationDrivenTests$ValidationBean"/>
+
+	<bean id="defaultFactory" class="org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory"/>
+
+
+</beans>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-registry.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-registry.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/rabbit
+	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+
+
+	<rabbit:annotation-driven registry="customRegistry"/>
+
+	<bean class="org.springframework.amqp.rabbit.annotation.AbstractRabbitAnnotationDrivenTests$CustomBean"/>
+
+	<bean id="customRegistry" class="org.springframework.amqp.rabbit.config.RabbitListenerEndpointRegistry"/>
+
+	<bean id="rabbitListenerContainerFactory" class="org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory"/>
+	<bean id="customFactory" class="org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory"/>
+
+	<bean id="simpleMessageListener" class="org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter"/>
+
+	<bean class="org.springframework.amqp.rabbit.annotation.AnnotationDrivenNamespaceTests$CustomRabbitListenerConfigurer">
+		<property name="messageListener" ref="simpleMessageListener"/>
+	</bean>
+
+
+</beans>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-default-container-factory.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-default-container-factory.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/rabbit
+	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+
+	<rabbit:annotation-driven/>
+
+	<bean class="org.springframework.amqp.rabbit.annotation.AbstractRabbitAnnotationDrivenTests$DefaultBean"/>
+
+	<bean id="rabbitListenerContainerFactory"
+		  class="org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory"/>
+
+
+</beans>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-full-config.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-full-config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/rabbit
+	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+
+	<rabbit:annotation-driven/>
+
+	<bean class="org.springframework.amqp.rabbit.annotation.AbstractRabbitAnnotationDrivenTests$FullBean"/>
+
+	<bean id="simpleFactory" class="org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory"/>
+
+	<bean id="rabbitAdmin" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.amqp.rabbit.core.RabbitAdmin"/>
+	</bean>
+
+
+</beans>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-no-rabbit-admin-config.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-no-rabbit-admin-config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/rabbit
+	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+
+	<rabbit:annotation-driven/>
+
+	<bean class="org.springframework.amqp.rabbit.annotation.AbstractRabbitAnnotationDrivenTests$FullBean"/>
+
+	<bean id="simpleFactory" class="org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory"/>
+
+
+</beans>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-sample-config.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-sample-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/rabbit
+	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+
+	<rabbit:annotation-driven/>
+
+	<bean class="org.springframework.amqp.rabbit.annotation.AbstractRabbitAnnotationDrivenTests$SampleBean"/>
+
+	<bean id="rabbitListenerContainerFactory"
+		  class="org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory"/>
+	<bean id="simpleFactory" class="org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory"/>
+
+
+</beans>


### PR DESCRIPTION
This commit adds the support of Rabbit annotated endpoint. Can be activated by both by `@EnableRabbit` or `<rabbit:annotation-driven/>` and detects methods of managed beans annotated with `@RabbitListener`, either directly or through a meta-annotation.

Containers are created and managed under the cover by a registry at application startup time. Container creation is delegated to a `RabbitListenerContainerFactory` that is identified by the `containerFactory` attribute of the  `RabbitListener` annotation. Containers can be retrieved from the registry using a custom id that can be specified directly on the annotation.

The configuration can be fine-tuned by implementing the `RabbitListenerConfigurer` interface which gives access to the registrar used to register endpoints. This includes a programmatic registration of endpoints in complement to the declarative approach. A default `RabbitListenerContainerFactory` can also be specified to be used if no `containerFactory` has been set on the annotation.

Annotated methods can have flexible method arguments that are similar to what `@MessageMapping` provides. In particular, rabbit listener endpoint methods can fully use the messaging abstraction, including convenient header accessor. It is also possible to inject the raw `org.springframework.amqp.core.Message` and the `Channel` for more
advanced use cases. The payload can be injected as long as the conversion service is able to convert it from the original body. By default, a `DefaultMessageHandlerMethodFactory` is used but it can be configured further to support additional method arguments or to customize conversion and validation support.

The return type of an annotated method can also be an instance of Spring's Message abstraction. Instead of just converting the payload, such response type allows to communicate standard and custom headers.

`AmqpHeaders` and `DefaultAmqpHeaderMapper` have been copied from Spring integration. `SimpleAmqpHeaderMapper` is a reduced version of the Spring integration counter part that does not support deprecated fields and JSON specific constructs. Method hook points are available so that a future version of Spring Integration can integrate those customizations in an extension. Note that the default know maps all user-defined headers so that the generated Message abstraction has all the information stored in the protocol specific message.

`MessagingMessageConverter` is a new `MessageConverter` implementation that produces a `org.springframework.messaging.Message` out of an AMQP message and vice versa. `AmqpMessageHeaderAccessor` provides an easy access of AMQP specific headers from a standard Message.

**NOTE**: you need [a special SNAPSHOT of the Spring Framework](https://github.com/snicoll/spring-framework/tree/amqp-mapper) to be able to build this branch. This branch is about to be merged in time for Spring 4.1.RC2
