### PR TITLE
AMQP-421 Fix Memory Leak with Publisher Confirms

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -40,6 +40,7 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.ReceiveAndReplyCallback;
 import org.springframework.amqp.core.ReceiveAndReplyMessageCallback;
 import org.springframework.amqp.core.ReplyToAddressCallback;
+import org.springframework.amqp.rabbit.connection.ChannelProxy;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactoryUtils;
 import org.springframework.amqp.rabbit.connection.RabbitAccessor;
@@ -958,8 +959,9 @@ public class RabbitTemplate extends RabbitAccessor implements RabbitOperations, 
 		if (channel instanceof PublisherCallbackChannel) {
 			PublisherCallbackChannel publisherCallbackChannel = (PublisherCallbackChannel) channel;
 			SortedMap<Long, PendingConfirm> pendingConfirms = publisherCallbackChannel.addListener(this);
-			if (!this.pendingConfirms.containsKey(channel)) {
-				this.pendingConfirms.put(channel, pendingConfirms);
+			Channel key = channel instanceof ChannelProxy ? ((ChannelProxy) channel).getTargetChannel() : channel;
+			if (!this.pendingConfirms.containsKey(key)) {
+				this.pendingConfirms.put(key, pendingConfirms);
 				if (logger.isDebugEnabled()) {
 					logger.debug("Added pending confirms for " + channel + " to map, size now " + this.pendingConfirms.size());
 				}

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -562,6 +562,13 @@ public AmqpTemplate rabbitTemplate();
         by calling <code>setConfirmCallback(ConfirmCallback callback)</code>. The callback
         must implement this method:
       </para>
+      <important>
+        Publisher Confirms only work when the channel is cached. Otherwise, the channel is closed after the
+        publish operation so, by definition, cannot receive the confirmation. Be sure to set the
+        connection factory's
+        <code>channelCacheSize</code> to a large enough value so that the channel on which a message is
+        published is returned to the cache instead of being closed.
+      </important>
       <programlisting language="java"><![CDATA[void confirm(CorrelationData correlationData, boolean ack, String cause);]]></programlisting>
       <para>
         The <classname>CorrelationData</classname> is an object supplied by the client when sending the


### PR DESCRIPTION
The wrong key is being used for `RabbitTemplate.pendingConfirms`. The rabbit template
stores the pending confirms map under the `ChannelProxy` whereas the
removal uses the actual `PublisherCallbackChannel` so the map
entry is not removed.

Use the correct key to store the pending callback map so that it
is removed from the template when closed.

Change a test case to use the `CachingConnectionFactory` instead of
a mock and veriy the map is cleared.

**Add docs explaining that Publisher Confirms and Returns only works
with cached channels - ensure the cache size is sufficiently large.
