### PR TITLE
AMQP-417 Fix Failing Test

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
@@ -324,7 +324,8 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		final CountDownLatch threadLatch = new CountDownLatch(1);
 		final CountDownLatch threadSentLatch = new CountDownLatch(1);
 		//Thread 1
-		Executors.newSingleThreadExecutor().execute(new Runnable() {
+		ExecutorService exec = Executors.newSingleThreadExecutor();
+		exec.execute(new Runnable() {
 
 			@Override
 			public void run() {
@@ -363,6 +364,8 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(template);
 		Map<?, ?> pendingConfirms = (Map<?, ?>) dfa.getPropertyValue("pendingConfirms");
 		assertThat(pendingConfirms.size(), greaterThan(0)); // might use 2 or only 1 channel
+		exec.shutdown();
+		assertTrue(exec.awaitTermination(10, TimeUnit.SECONDS));
 		ccf.destroy();
 		assertEquals(0, pendingConfirms.size());
 	}


### PR DESCRIPTION
- The executor thread returned its channel to the cache after the
  factory was destroyed.
- The `destroy()` method resets the connection; allowing forcing a new connection;
  it does not prevent the factory from being re-used. Adding a 'destroyed' boolean
  would change this behavior.
- Although 'dead' channels can be returned to the cache, they will be detected on
  next use, and refreshed.
- Stop the executor before destroying the CCF to fix the test case.
