### PR TITLE
Add RabbitMessagingTemplate

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitMessageOperations.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitMessageOperations.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.core;
+
+import java.util.Map;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.core.MessagePostProcessor;
+import org.springframework.messaging.core.MessageReceivingOperations;
+import org.springframework.messaging.core.MessageRequestReplyOperations;
+import org.springframework.messaging.core.MessageSendingOperations;
+
+/**
+ * A specialization of {@link MessageSendingOperations} and {@link MessageRequestReplyOperations}
+ * for AMQP related operations that allow to specify not only the exchange but also the
+ * routing key to use.
+ *
+ * @author Stephane Nicoll
+ * @since 1.4
+ * @see org.springframework.amqp.rabbit.core.RabbitTemplate
+ */
+public interface RabbitMessageOperations extends MessageSendingOperations<String>,
+		MessageReceivingOperations<String>, MessageRequestReplyOperations<String> {
+
+	/**
+	 * Send a message to a specific exchange with a specific routing key.
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message the message to send
+	 */
+	void send(String exchange, String routingKey, Message<?> message) throws MessagingException;
+
+	/**
+	 * Convert the given Object to serialized form, possibly using a
+	 * {@link org.springframework.messaging.converter.MessageConverter},
+	 * wrap it as a message and send it to a specific exchange with a
+	 * specific routing key.
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param payload the Object to use as payload
+	 */
+	void convertAndSend(String exchange, String routingKey, Object payload) throws MessagingException;
+
+	/**
+	 * Convert the given Object to serialized form, possibly using a
+	 * {@link org.springframework.messaging.converter.MessageConverter},
+	 * wrap it as a message with the given headers and send it to a
+	 * specific exchange with a specific routing key.
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param payload the Object to use as payload
+	 * @param headers headers for the message to send
+	 */
+	void convertAndSend(String exchange, String routingKey, Object payload, Map<String, Object> headers)
+			throws MessagingException;
+
+	/**
+	 * Convert the given Object to serialized form, possibly using a
+	 * {@link org.springframework.messaging.converter.MessageConverter},
+	 * wrap it as a message, apply the given post processor, and send
+	 * the resulting message to a specific exchange with a specific
+	 * routing key.
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param payload the Object to use as payload
+	 * @param postProcessor the post processor to apply to the message
+	 */
+	void convertAndSend(String exchange, String routingKey, Object payload, MessagePostProcessor postProcessor)
+			throws MessagingException;
+
+	/**
+	 * Convert the given Object to serialized form, possibly using a
+	 * {@link org.springframework.messaging.converter.MessageConverter},
+	 * wrap it as a message with the given headers, apply the given post processor,
+	 * and send the resulting message to a specific exchange with a specific
+	 * routing key.
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param payload the Object to use as payload
+	 * @param headers headers for the message to send
+	 * @param postProcessor the post processor to apply to the message
+	 */
+	void convertAndSend(String exchange, String routingKey, Object payload, Map<String,
+			Object> headers, MessagePostProcessor postProcessor) throws MessagingException;
+
+	/**
+	 * Send a request message to a specific exchange with a specific routing key and
+	 * wait for the reply
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param requestMessage the message to send
+	 * @return the reply, possibly {@code null} if the message could not be received,
+	 * for example due to a timeout
+	 */
+	Message<?> sendAndReceive(String exchange, String routingKey, Message<?> requestMessage) throws MessagingException;
+
+	/**
+	 * Convert the given request Object to serialized form, possibly using a
+	 * {@link org.springframework.messaging.converter.MessageConverter}, send
+	 * it as a {@link Message} to a specific exchange with a specific routing key,
+	 * receive the reply and convert its body of the specified target class.
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param request payload for the request message to send
+	 * @param targetClass the target type to convert the payload of the reply to
+	 * @return the payload of the reply message, possibly {@code null} if the message
+	 * could not be received, for example due to a timeout
+	 */
+	<T> T convertSendAndReceive(String exchange, String routingKey, Object request, Class<T> targetClass)
+			throws MessagingException;
+
+	/**
+	 * Convert the given request Object to serialized form, possibly using a
+	 * {@link org.springframework.messaging.converter.MessageConverter}, send
+	 * it as a {@link Message} with the given headers, to a specific exchange
+	 * with a specific routing key, receive the reply and convert its body of
+	 * the specified target class.
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param request payload for the request message to send
+	 * @param headers headers for the request message to send
+	 * @param targetClass the target type to convert the payload of the reply to
+	 * @return the payload of the reply message, possibly {@code null} if the message
+	 * could not be received, for example due to a timeout
+	 */
+	<T> T convertSendAndReceive(String exchange, String routingKey, Object request, Map<String, Object> headers,
+			Class<T> targetClass) throws MessagingException;
+
+	/**
+	 * Convert the given request Object to serialized form, possibly using a
+	 * {@link org.springframework.messaging.converter.MessageConverter},
+	 * apply the given post processor and send the resulting {@link Message} to
+	 * a specific exchange with a specific routing key, receive the reply and
+	 * convert its body of the given target class.
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param request payload for the request message to send
+	 * @param targetClass the target type to convert the payload of the reply to
+	 * @param requestPostProcessor post process to apply to the request message
+	 * @return the payload of the reply message, possibly {@code null} if the message
+	 * could not be received, for example due to a timeout
+	 */
+	<T> T convertSendAndReceive(String exchange, String routingKey, Object request, Class<T> targetClass,
+			MessagePostProcessor requestPostProcessor) throws MessagingException;
+
+	/**
+	 * Convert the given request Object to serialized form, possibly using a
+	 * {@link org.springframework.messaging.converter.MessageConverter},
+	 * wrap it as a message with the given headers, apply the given post processor
+	 * and send the resulting {@link Message} to a specific exchange with a
+	 * specific routing key,, receive  the reply and convert its body of the
+	 * given target class.
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param request payload for the request message to send
+	 * @param targetClass the target type to convert the payload of the reply to
+	 * @param requestPostProcessor post process to apply to the request message
+	 * @return the payload of the reply message, possibly {@code null} if the message
+	 * could not be received, for example due to a timeout
+	 */
+	<T> T convertSendAndReceive(String exchange, String routingKey, Object request, Map<String, Object> headers,
+			Class<T> targetClass, MessagePostProcessor requestPostProcessor) throws MessagingException;
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplate.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.core;
+
+import java.util.Map;
+
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.MessagingMessageConverter;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.core.AbstractMessagingTemplate;
+import org.springframework.messaging.core.MessagePostProcessor;
+import org.springframework.util.Assert;
+
+/**
+ * An implementation of {@link RabbitMessageOperations}.
+ *
+ * @author Stephane Nicoll
+ * @since 1.4
+ */
+public class RabbitMessagingTemplate extends AbstractMessagingTemplate<String>
+		implements RabbitMessageOperations, InitializingBean {
+
+	private RabbitTemplate rabbitTemplate;
+
+	private MessageConverter amqpMessageConverter = new MessagingMessageConverter();
+
+
+	/**
+	 * Constructor for use with bean properties.
+	 * Requires {@link #setRabbitTemplate} to be called.
+	 */
+	public RabbitMessagingTemplate() {
+	}
+
+	/**
+	 * Create an instance with the {@link RabbitTemplate} to use.
+	 */
+	public RabbitMessagingTemplate(RabbitTemplate rabbitTemplate) {
+		Assert.notNull("RabbitTemplate must not be null");
+		this.rabbitTemplate = rabbitTemplate;
+	}
+
+
+	/**
+	 * Set the {@link RabbitTemplate} to use.
+	 */
+	public void setRabbitTemplate(RabbitTemplate rabbitTemplate) {
+		this.rabbitTemplate = rabbitTemplate;
+	}
+
+	/**
+	 * Return the configured {@link RabbitTemplate}.
+	 */
+	public RabbitTemplate getRabbitTemplate() {
+		return this.rabbitTemplate;
+	}
+
+	/**
+	 * Set the {@link MessageConverter} to use to convert a {@link Message} from
+	 * the messaging to and from a {@link org.springframework.amqp.core.Message}.
+	 * By default, a {@link MessagingMessageConverter} is defined using a
+	 * {@link org.springframework.amqp.support.converter.SimpleMessageConverter}
+	 * to convert the payload of the message.
+	 * <p>Consider configuring a {@link MessagingMessageConverter} with a different
+	 * {@link MessagingMessageConverter#setPayloadConverter(MessageConverter) payload converter}
+	 * for more advanced scenario.
+	 * @see MessagingMessageConverter
+	 */
+	public void setAmqpMessageConverter(MessageConverter amqpMessageConverter) {
+		this.amqpMessageConverter = amqpMessageConverter;
+	}
+
+	/**
+	 * Return the {@link MessageConverter} to use to convert a {@link org.springframework.messaging.Message}
+	 * from the messaging to and from a {@link org.springframework.amqp.core.Message}.
+	 */
+	public MessageConverter getAmqpMessageConverter() {
+		return this.amqpMessageConverter;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		Assert.notNull(getRabbitTemplate(), "Property 'rabbitTemplate' is required");
+		Assert.notNull(getAmqpMessageConverter(), "Property 'amqpMessageConverter' is required");
+	}
+
+	@Override
+	public void send(String exchange, String routingKey, Message<?> message) throws MessagingException {
+		doSend(exchange, routingKey, message);
+	}
+
+	@Override
+	public void convertAndSend(String exchange, String routingKey, Object payload) throws MessagingException {
+		convertAndSend(exchange, routingKey, payload, (Map<String, Object>) null);
+	}
+
+	@Override
+	public void convertAndSend(String exchange, String routingKey, Object payload,
+			Map<String, Object> headers) throws MessagingException {
+
+		convertAndSend(exchange, routingKey, payload, headers, null);
+	}
+
+	@Override
+	public void convertAndSend(String exchange, String routingKey, Object payload,
+			MessagePostProcessor postProcessor) throws MessagingException {
+
+		convertAndSend(exchange, routingKey, payload, null, postProcessor);
+	}
+
+	@Override
+	public void convertAndSend(String exchange, String routingKey, Object payload,
+			Map<String, Object> headers, MessagePostProcessor postProcessor) throws MessagingException {
+
+		Message<?> message = doConvert(payload, headers, postProcessor);
+		send(exchange, routingKey, message);
+	}
+
+	@Override
+	public Message<?> sendAndReceive(String exchange, String routingKey, Message<?> requestMessage)
+			throws MessagingException {
+
+		return doSendAndReceive(exchange, routingKey, requestMessage);
+	}
+
+	@Override
+	public <T> T convertSendAndReceive(String exchange, String routingKey, Object request,
+			Class<T> targetClass) throws MessagingException {
+
+		return convertSendAndReceive(exchange, routingKey, request, null, targetClass);
+	}
+
+	@Override
+	public <T> T convertSendAndReceive(String exchange, String routingKey, Object request,
+			Map<String, Object> headers, Class<T> targetClass) throws MessagingException {
+
+		return convertSendAndReceive(exchange, routingKey, request, headers, targetClass, null);
+	}
+
+	@Override
+	public <T> T convertSendAndReceive(String exchange, String routingKey, Object request,
+			Class<T> targetClass, MessagePostProcessor requestPostProcessor) throws MessagingException {
+
+		return convertSendAndReceive(exchange, routingKey, request, null, targetClass, requestPostProcessor);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T convertSendAndReceive(String exchange, String routingKey, Object request, Map<String, Object> headers,
+			Class<T> targetClass, MessagePostProcessor requestPostProcessor) throws MessagingException {
+
+		Message<?> requestMessage = doConvert(request, headers, requestPostProcessor);
+		Message<?> replyMessage = sendAndReceive(exchange, routingKey, requestMessage);
+		return (replyMessage != null ? (T) getMessageConverter().fromMessage(replyMessage, targetClass) : null);
+	}
+
+	@Override
+	protected void doSend(String destination, Message<?> message) {
+		try {
+			this.rabbitTemplate.send(destination, createMessage(message));
+		}
+		catch (RuntimeException ex) {
+			throw convertAmqpException(ex);
+		}
+	}
+
+	protected void doSend(String exchange, String routingKey, Message<?> message) {
+		try {
+			this.rabbitTemplate.send(exchange, routingKey, createMessage(message));
+		}
+		catch (RuntimeException ex) {
+			throw convertAmqpException(ex);
+		}
+	}
+
+
+	@Override
+	protected Message<?> doReceive(String destination) {
+		try {
+			org.springframework.amqp.core.Message amqpMessage = this.rabbitTemplate.receive(destination);
+			return convertAmqpMessage(amqpMessage);
+		}
+		catch (RuntimeException ex) {
+			throw convertAmqpException(ex);
+		}
+	}
+
+
+	@Override
+	protected Message<?> doSendAndReceive(String destination, Message<?> requestMessage) {
+		try {
+			org.springframework.amqp.core.Message amqpMessage = this.rabbitTemplate.sendAndReceive(
+					destination, createMessage(requestMessage));
+			return convertAmqpMessage(amqpMessage);
+		}
+		catch (RuntimeException ex) {
+			throw convertAmqpException(ex);
+		}
+	}
+
+	protected Message<?> doSendAndReceive(String exchange, String routingKey, Message<?> requestMessage) {
+		try {
+			org.springframework.amqp.core.Message amqpMessage = this.rabbitTemplate.sendAndReceive(
+					exchange, routingKey, createMessage(requestMessage));
+			return convertAmqpMessage(amqpMessage);
+		}
+		catch (RuntimeException ex) {
+			throw convertAmqpException(ex);
+		}
+	}
+
+	private org.springframework.amqp.core.Message createMessage(Message<?> message) {
+		try {
+			return getAmqpMessageConverter().toMessage(message, new MessageProperties());
+		}
+		catch (org.springframework.amqp.support.converter.MessageConversionException ex) {
+			throw new MessageConversionException("Could not convert '" + message + "'", ex);
+		}
+	}
+
+	protected Message<?> convertAmqpMessage(org.springframework.amqp.core.Message message) {
+		if (message == null) {
+			return null;
+		}
+		try {
+			return (Message<?>) getAmqpMessageConverter().fromMessage(message);
+		}
+		catch (Exception ex) {
+			throw new MessageConversionException("Could not convert '" + message + "'", ex);
+		}
+	}
+
+	@SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+	protected MessagingException convertAmqpException(RuntimeException ex) {
+		if (ex instanceof MessagingException) {
+			return (MessagingException) ex;
+		}
+		if (ex instanceof org.springframework.amqp.support.converter.MessageConversionException) {
+			return new MessageConversionException(ex.getMessage(), ex);
+		}
+		// Fallback
+		return new MessagingException(ex.getMessage(), ex);
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplateTests.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.core;
+
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hamcrest.core.StringContains;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.test.MessageTestUtils;
+import org.springframework.amqp.support.converter.MessageConversionException;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.GenericMessageConverter;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.junit.Assert.*;
+import static org.mockito.BDDMockito.*;
+
+/**
+ * @author Stephane Nicoll
+ */
+public class RabbitMessagingTemplateTests {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Captor
+	private ArgumentCaptor<org.springframework.amqp.core.Message> amqpMessage;
+
+	@Mock
+	private RabbitTemplate rabbitTemplate;
+
+	private RabbitMessagingTemplate messagingTemplate;
+
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		messagingTemplate = new RabbitMessagingTemplate(rabbitTemplate);
+	}
+
+	@Test
+	public void validateRabbitTemplate() {
+		assertSame(this.rabbitTemplate, messagingTemplate.getRabbitTemplate());
+	}
+
+	@Test
+	public void send() {
+		Message<String> message = createTextMessage();
+
+		messagingTemplate.send("myQueue", message);
+		verify(rabbitTemplate).send(eq("myQueue"), this.amqpMessage.capture());
+		assertTextMessage(this.amqpMessage.getValue());
+	}
+
+	@Test
+	public void sendExchange() {
+		Message<String> message = createTextMessage();
+
+		messagingTemplate.send("myExchange", "myQueue", message);
+		verify(rabbitTemplate).send(eq("myExchange"), eq("myQueue"), this.amqpMessage.capture());
+		assertTextMessage(this.amqpMessage.getValue());
+	}
+
+	@Test
+	public void sendDefaultDestination() {
+		messagingTemplate.setDefaultDestination("default");
+		Message<String> message = createTextMessage();
+
+		messagingTemplate.send(message);
+		verify(rabbitTemplate).send(eq("default"), this.amqpMessage.capture());
+		assertTextMessage(this.amqpMessage.getValue());
+	}
+
+	@Test
+	public void sendNoDefaultSet() {
+		Message<String> message = createTextMessage();
+
+		thrown.expect(IllegalStateException.class);
+		messagingTemplate.send(message);
+	}
+
+	@Test
+	public void sendPropertyInjection() {
+		RabbitMessagingTemplate t = new RabbitMessagingTemplate();
+		t.setRabbitTemplate(rabbitTemplate);
+		t.setDefaultDestination("myQueue");
+		t.afterPropertiesSet();
+		Message<String> message = createTextMessage();
+
+		t.send(message);
+		verify(rabbitTemplate).send(eq("myQueue"), this.amqpMessage.capture());
+		assertTextMessage(this.amqpMessage.getValue());
+	}
+
+	@Test
+	public void convertAndSendPayload() {
+		messagingTemplate.convertAndSend("myQueue", "my Payload");
+		verify(rabbitTemplate).send(eq("myQueue"), amqpMessage.capture());
+		assertEquals("my Payload", MessageTestUtils.extractText(amqpMessage.getValue()));
+	}
+
+	@Test
+	public void convertAndSendPayloadExchange() {
+		messagingTemplate.convertAndSend("myExchange", "myQueue", "my Payload");
+		verify(rabbitTemplate).send(eq("myExchange"), eq("myQueue"), amqpMessage.capture());
+		assertEquals("my Payload", MessageTestUtils.extractText(amqpMessage.getValue()));
+	}
+
+	@Test
+	public void convertAndSendDefaultDestination() {
+		messagingTemplate.setDefaultDestination("default");
+
+		messagingTemplate.convertAndSend("my Payload");
+		verify(rabbitTemplate).send(eq("default"), amqpMessage.capture());
+		assertEquals("my Payload", MessageTestUtils.extractText(amqpMessage.getValue()));
+	}
+
+	@Test
+	public void convertAndSendNoDefaultSet() {
+		thrown.expect(IllegalStateException.class);
+		messagingTemplate.convertAndSend("my Payload");
+	}
+
+	@Test
+	public void convertAndSendCustomAmqpMessageConverter() {
+		messagingTemplate.setAmqpMessageConverter(new SimpleMessageConverter() {
+
+			@Override
+			protected org.springframework.amqp.core.Message createMessage(Object object,
+					MessageProperties messageProperties) throws MessageConversionException {
+				throw new MessageConversionException("Test exception");
+			}
+		});
+
+		thrown.expect(org.springframework.messaging.converter.MessageConversionException.class);
+		thrown.expectMessage(new StringContains("Test exception"));
+		messagingTemplate.convertAndSend("myQueue", "msg to convert");
+	}
+
+	@Test
+	public void convertAndSendPayloadAndHeaders() {
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put("foo", "bar");
+
+		messagingTemplate.convertAndSend("myQueue", (Object) "Hello", headers);
+		verify(rabbitTemplate).send(eq("myQueue"), amqpMessage.capture());
+		assertTextMessage(amqpMessage.getValue());
+	}
+
+	@Test
+	public void convertAndSendPayloadAndHeadersExchange() {
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put("foo", "bar");
+
+		messagingTemplate.convertAndSend("myExchange", "myQueue", "Hello", headers);
+		verify(rabbitTemplate).send(eq("myExchange"), eq("myQueue"), amqpMessage.capture());
+		assertTextMessage(amqpMessage.getValue());
+	}
+
+	@Test
+	public void receive() {
+		org.springframework.amqp.core.Message amqpMessage = createAmqpTextMessage();
+		given(rabbitTemplate.receive("myQueue")).willReturn(amqpMessage);
+
+		Message<?> message = messagingTemplate.receive("myQueue");
+		verify(rabbitTemplate).receive("myQueue");
+		assertTextMessage(message);
+	}
+
+	@Test
+	public void receiveDefaultDestination() {
+		messagingTemplate.setDefaultDestination("default");
+
+		org.springframework.amqp.core.Message amqpMessage = createAmqpTextMessage();
+		given(rabbitTemplate.receive("default")).willReturn(amqpMessage);
+
+		Message<?> message = messagingTemplate.receive();
+		verify(rabbitTemplate).receive("default");
+		assertTextMessage(message);
+	}
+
+	@Test
+	public void receiveNoDefaultSet() {
+		thrown.expect(IllegalStateException.class);
+		messagingTemplate.receive();
+	}
+
+	@Test
+	public void receiveAndConvert() {
+		org.springframework.amqp.core.Message amqpMessage = createAmqpTextMessage("my Payload");
+		given(rabbitTemplate.receive("myQueue")).willReturn(amqpMessage);
+
+
+		String payload = messagingTemplate.receiveAndConvert("myQueue", String.class);
+		assertEquals("my Payload", payload);
+		verify(rabbitTemplate).receive("myQueue");
+	}
+
+	@Test
+	public void receiveAndConvertDefaultDestination() {
+		messagingTemplate.setDefaultDestination("default");
+
+		org.springframework.amqp.core.Message amqpMessage = createAmqpTextMessage("my Payload");
+		given(rabbitTemplate.receive("default")).willReturn(amqpMessage);
+
+
+		String payload = messagingTemplate.receiveAndConvert(String.class);
+		assertEquals("my Payload", payload);
+		verify(rabbitTemplate).receive("default");
+	}
+
+	@Test
+	public void receiveAndConvertWithConversion() {
+		org.springframework.amqp.core.Message amqpMessage = createAmqpTextMessage("123");
+		given(rabbitTemplate.receive("myQueue")).willReturn(amqpMessage);
+
+		messagingTemplate.setMessageConverter(new GenericMessageConverter());
+
+		Integer payload = messagingTemplate.receiveAndConvert("myQueue", Integer.class);
+		assertEquals(Integer.valueOf(123), payload);
+		verify(rabbitTemplate).receive("myQueue");
+	}
+
+	@Test
+	public void receiveAndConvertNoConverter() {
+		org.springframework.amqp.core.Message amqpMessage = createAmqpTextMessage("Hello");
+		given(rabbitTemplate.receive("myQueue")).willReturn(amqpMessage);
+
+		thrown.expect(org.springframework.messaging.converter.MessageConversionException.class);
+		messagingTemplate.receiveAndConvert("myQueue", Writer.class);
+	}
+
+	@Test
+	public void receiveAndConvertNoInput() {
+		given(rabbitTemplate.receive("myQueue")).willReturn(null);
+
+		assertNull(messagingTemplate.receiveAndConvert("myQueue", String.class));
+	}
+
+	@Test
+	public void sendAndReceive() {
+		Message<String> request = createTextMessage();
+		org.springframework.amqp.core.Message reply = createAmqpTextMessage();
+		given(rabbitTemplate.sendAndReceive(eq("myQueue"), anyAmqpMessage())).willReturn(reply);
+
+		Message<?> actual = messagingTemplate.sendAndReceive("myQueue", request);
+		verify(rabbitTemplate, times(1)).sendAndReceive(eq("myQueue"),
+				anyAmqpMessage());
+		assertTextMessage(actual);
+	}
+
+	@Test
+	public void sendAndReceiveExchange() {
+		Message<String> request = createTextMessage();
+		org.springframework.amqp.core.Message reply = createAmqpTextMessage();
+		given(rabbitTemplate.sendAndReceive(eq("myExchange"), eq("myQueue"), anyAmqpMessage())).willReturn(reply);
+
+		Message<?> actual = messagingTemplate.sendAndReceive("myExchange", "myQueue", request);
+		verify(rabbitTemplate, times(1)).sendAndReceive(eq("myExchange"), eq("myQueue"),
+				anyAmqpMessage());
+		assertTextMessage(actual);
+	}
+
+	@Test
+	public void sendAndReceiveDefaultDestination() {
+		messagingTemplate.setDefaultDestination("default");
+
+		Message<String> request = createTextMessage();
+		org.springframework.amqp.core.Message reply = createAmqpTextMessage();
+		given(rabbitTemplate.sendAndReceive(eq("default"), anyAmqpMessage())).willReturn(reply);
+
+		Message<?> actual = messagingTemplate.sendAndReceive(request);
+		verify(rabbitTemplate, times(1)).sendAndReceive(eq("default"),
+				anyAmqpMessage());
+		assertTextMessage(actual);
+	}
+
+	@Test
+	public void sendAndReceiveNoDefaultSet() {
+		Message<String> message = createTextMessage();
+
+		thrown.expect(IllegalStateException.class);
+		messagingTemplate.sendAndReceive(message);
+	}
+
+	@Test
+	public void convertSendAndReceivePayload() {
+		org.springframework.amqp.core.Message replyMessage = createAmqpTextMessage("My reply");
+		given(rabbitTemplate.sendAndReceive(eq("myQueue"), anyAmqpMessage())).willReturn(replyMessage);
+
+		String reply = messagingTemplate.convertSendAndReceive("myQueue", "my Payload", String.class);
+		verify(rabbitTemplate, times(1)).sendAndReceive(eq("myQueue"), anyAmqpMessage());
+		assertEquals("My reply", reply);
+	}
+
+	@Test
+	public void convertSendAndReceivePayloadExchange() {
+		org.springframework.amqp.core.Message replyMessage = createAmqpTextMessage("My reply");
+		given(rabbitTemplate.sendAndReceive(eq("myExchange"), eq("myQueue"), anyAmqpMessage())).willReturn(replyMessage);
+
+		String reply = messagingTemplate.convertSendAndReceive("myExchange", "myQueue", "my Payload", String.class);
+		verify(rabbitTemplate, times(1)).sendAndReceive(eq("myExchange"), eq("myQueue"), anyAmqpMessage());
+		assertEquals("My reply", reply);
+	}
+
+	@Test
+	public void convertSendAndReceiveDefaultDestination() {
+		messagingTemplate.setDefaultDestination("default");
+
+		org.springframework.amqp.core.Message replyMessage = createAmqpTextMessage("My reply");
+		given(rabbitTemplate.sendAndReceive(eq("default"), anyAmqpMessage())).willReturn(replyMessage);
+
+		String reply = messagingTemplate.convertSendAndReceive("my Payload", String.class);
+		verify(rabbitTemplate, times(1)).sendAndReceive(eq("default"), anyAmqpMessage());
+		assertEquals("My reply", reply);
+	}
+
+	@Test
+	public void convertSendAndReceiveNoDefaultSet() {
+		thrown.expect(IllegalStateException.class);
+		messagingTemplate.convertSendAndReceive("my Payload", String.class);
+	}
+
+	@Test
+	public void convertMessageConversionExceptionOnSend() {
+		Message<String> message = createTextMessage();
+		MessageConverter messageConverter = mock(MessageConverter.class);
+		willThrow(org.springframework.amqp.support.converter.MessageConversionException.class)
+				.given(messageConverter).toMessage(eq(message), anyMessageProperties());
+		messagingTemplate.setAmqpMessageConverter(messageConverter);
+
+		thrown.expect(org.springframework.messaging.converter.MessageConversionException.class);
+		messagingTemplate.send("myQueue", message);
+	}
+
+	@Test
+	public void convertMessageConversionExceptionOnReceive() {
+		org.springframework.amqp.core.Message message = createAmqpTextMessage();
+		MessageConverter messageConverter = mock(MessageConverter.class);
+		willThrow(org.springframework.amqp.support.converter.MessageConversionException.class)
+				.given(messageConverter).fromMessage(message);
+		messagingTemplate.setAmqpMessageConverter(messageConverter);
+		given(rabbitTemplate.receive("myQueue")).willReturn(message);
+
+		thrown.expect(org.springframework.messaging.converter.MessageConversionException.class);
+		messagingTemplate.receive("myQueue");
+	}
+
+	private Message<String> createTextMessage(String payload) {
+		return MessageBuilder
+				.withPayload(payload).setHeader("foo", "bar").build();
+	}
+
+	private Message<String> createTextMessage() {
+		return createTextMessage("Hello");
+	}
+
+
+	private org.springframework.amqp.core.Message createAmqpTextMessage(String payload) {
+		MessageProperties properties = new MessageProperties();
+		properties.setHeader("foo", "bar");
+		return MessageTestUtils.createTextMessage(payload, properties);
+
+	}
+
+	private org.springframework.amqp.core.Message createAmqpTextMessage() {
+		return createAmqpTextMessage("Hello");
+	}
+
+	private void assertTextMessage(org.springframework.amqp.core.Message amqpMessage) {
+		assertEquals("Wrong body message", "Hello", MessageTestUtils.extractText(amqpMessage));
+		assertEquals("Invalid foo property", "bar", amqpMessage.getMessageProperties().getHeaders().get("foo"));
+	}
+
+	private void assertTextMessage(Message<?> message) {
+		assertNotNull("message should not be null", message);
+		assertEquals("Wrong payload", "Hello", message.getPayload());
+		assertEquals("Invalid foo property", "bar", message.getHeaders().get("foo"));
+	}
+
+
+	private static org.springframework.amqp.core.Message anyAmqpMessage() {return any(org.springframework.amqp.core.Message.class);}
+
+	private static MessageProperties anyMessageProperties() {return any(MessageProperties.class);}
+
+}


### PR DESCRIPTION
This commit provides a Rabbit implementation of standard messaging interfaces available in the spring framework. These are `MessageSendingOperations` for sending standard Messages, `MessageReceivingOperations` to receive a protocol specific content and return the standard `Message` counter part and `MessageRequestReplyOperations` to send a message a wait for a reply.
