### PR TITLE
AmqpHeaders: add `PUBLISH_CONFIRM_NACK_CAUSE`

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
@@ -24,7 +24,7 @@ import org.springframework.messaging.MessageHeaders;
  * Message} Headers.
  *
  * @author Mark Fisher
- * @since 2.0
+ * @since 1.4
  */
 public abstract class AmqpHeaders {
 
@@ -79,6 +79,8 @@ public abstract class AmqpHeaders {
 	public static final String SPRING_REPLY_TO_STACK = PREFIX + "springReplyToStack";
 
 	public static final String PUBLISH_CONFIRM = PREFIX + "publishConfirm";
+
+	public static final String PUBLISH_CONFIRM_NACK_CAUSE = PREFIX + "publishConfirmNackCause";
 
 	public static final String RETURN_REPLY_CODE = PREFIX + "returnReplyCode";
 


### PR DESCRIPTION
Since `AmqpHeaders` has been moved from SI, there is really a reason to deprecate that class in SI and use this one from AMQP.
To achieve that there is need to add one more recant `PUBLISH_CONFIRM_NACK_CAUSE` constant.
