### PR TITLE
AMQP-351 AMQP-379 Stop Container when Fatal Errors

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -598,7 +598,8 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 		Object listener = getMessageListener();
 		if (listener instanceof ChannelAwareMessageListener) {
 			doInvokeListener((ChannelAwareMessageListener) listener, channel, message);
-		} else if (listener instanceof MessageListener) {
+		}
+		else if (listener instanceof MessageListener) {
 			boolean bindChannel = isExposeListenerChannel() && isChannelLocallyTransacted(channel);
 			if (bindChannel) {
 				RabbitResourceHolder resourceHolder = new RabbitResourceHolder(channel, false);
@@ -615,11 +616,13 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 					TransactionSynchronizationManager.unbindResource(this.getConnectionFactory());
 				}
 			}
-		} else if (listener != null) {
-			throw new IllegalArgumentException("Only MessageListener and SessionAwareMessageListener supported: "
+		}
+		else if (listener != null) {
+			throw new FatalListenerExecutionException("Only MessageListener and SessionAwareMessageListener supported: "
 					+ listener);
-		} else {
-			throw new IllegalStateException("No message listener specified - see property 'messageListener'");
+		}
+		else {
+			throw new FatalListenerExecutionException("No message listener specified - see property 'messageListener'");
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1043,6 +1043,9 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					}
 					catch (ListenerExecutionFailedException ex) {
 						// Continue to process, otherwise re-throw
+						if (ex.getCause() instanceof NoSuchMethodException) {
+							throw new FatalListenerExecutionException("Invalid listener", ex);
+						}
 					}
 					catch (AmqpRejectAndDontRequeueException rejectEx) {
 						/*


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-351
JIRA: https://jira.spring.io/browse/AMQP-379

Stop the listener container if there is no listener
or if an incorrect POJO method is specified in the
`MessageListenerAdapter`.
