### PR TITLE
AMQP-436 SMLC: Support Routing Connection Factory

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -27,7 +27,9 @@ import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.AbstractRoutingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactoryUtils;
 import org.springframework.amqp.rabbit.connection.RabbitAccessor;
 import org.springframework.amqp.rabbit.connection.RabbitResourceHolder;
@@ -350,6 +352,19 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	@Override
 	public final void setApplicationContext(ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public ConnectionFactory getConnectionFactory() {
+		ConnectionFactory connectionFactory = super.getConnectionFactory();
+		if (connectionFactory instanceof AbstractRoutingConnectionFactory) {
+			ConnectionFactory targetConnectionFactory = ((AbstractRoutingConnectionFactory) connectionFactory)
+					.getTargetConnectionFactory(this.queueNames.toString().replaceAll(" ", ""));
+			if (targetConnectionFactory != null) {
+				return targetConnectionFactory;
+			}
+		}
+		return connectionFactory;
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactoryTests.java
@@ -16,6 +16,8 @@ package org.springframework.amqp.rabbit.connection;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,6 +29,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 
 /**
  * @author Artem Bilan
@@ -144,4 +148,42 @@ public class RoutingConnectionFactoryTests {
 		Mockito.verify(targetConnectionFactory,
 				Mockito.times(2)).addConnectionListener(Mockito.any(ConnectionListener.class));
 	}
+
+	@Test
+	public void testAbstractRoutingConnectionFactoryWithListenerContainer() {
+		ConnectionFactory connectionFactory1 = mock(ConnectionFactory.class);
+		ConnectionFactory connectionFactory2 = mock(ConnectionFactory.class);
+		Map<Object, ConnectionFactory> factories = new HashMap<Object, ConnectionFactory>(2);
+		factories.put("[baz]", connectionFactory1);
+		factories.put("[foo,bar]", connectionFactory2);
+		ConnectionFactory defaultConnectionFactory = mock(ConnectionFactory.class);
+
+		SimpleRoutingConnectionFactory connectionFactory = new SimpleRoutingConnectionFactory();
+
+		connectionFactory.setDefaultTargetConnectionFactory(defaultConnectionFactory);
+		connectionFactory.setTargetConnectionFactories(factories);
+
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setQueueNames("foo, bar");
+		container.afterPropertiesSet();
+		container.start();
+		container.stop();
+		Mockito.verify(connectionFactory1, never()).createConnection();
+		Mockito.verify(connectionFactory2).createConnection();
+		Mockito.verify(defaultConnectionFactory, never()).createConnection();
+		container.setQueueNames("baz");
+		container.start();
+		container.stop();
+		Mockito.verify(connectionFactory1).createConnection();
+		Mockito.verify(connectionFactory2).createConnection();
+		Mockito.verify(defaultConnectionFactory, never()).createConnection();
+		container.setQueueNames("qux");
+		container.start();
+		container.stop();
+		Mockito.verify(connectionFactory1).createConnection();
+		Mockito.verify(connectionFactory2).createConnection();
+		Mockito.verify(defaultConnectionFactory).createConnection();
+	}
+
+
 }

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -469,6 +469,12 @@ trustStore.passPhrase=secret</programlisting>
 		  and <code>receive-connection-factory-selector-expression</code> attributes
 		  on the <code>&lt;rabbit:template&gt;</code> component.
 	  </para>
+	  <para>
+	    Also starting with <emphasis>version 1.4</emphasis>, you can configure a routing connection factory
+	    in a <classname>SimpleMessageListenerContainer</classname>. In that case, the list of queue names
+	    is used as the lookup key. For example, if you configure the container with
+	    <code>setQueueNames("foo, bar")</code>, the lookup key will be <code>"[foo,bar]"</code> (no spaces).
+	  </para>
     </section>
 
     <section id="cf-pub-conf-ret">

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -113,6 +113,13 @@
 			</para>
 		</section>
 		<section>
+			<para>
+				A <classname>SimpleMessageListenerContainer</classname> can be configured with a routing
+				connection factory to enable connection selection based on the queue names.
+				See <xref linkend="routing-connection-factory"/>.
+			</para>
+		</section>
+		<section>
 			<title>RabbitTemplate: RecoveryCallback option</title>
 			<para>
 				The <code>recoveryCallback</code> property has been added to be used in the


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-436

Use the list of queue names as the lookup key.
