### PR TITLE
AMQP-434 Make MessageConv.Ex. an AmqpException

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessageConversionException.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessageConversionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -26,9 +26,10 @@ import org.springframework.amqp.AmqpException;
  *
  * @author Mark Fisher
  * @author Dave Syer
+ * @author Gary Russell
  */
 @SuppressWarnings("serial")
-public class MessageConversionException extends RuntimeException {
+public class MessageConversionException extends AmqpException {
 
 	public MessageConversionException(String message, Throwable cause) {
 		super(message, cause);

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -120,6 +120,26 @@
 				See <xref linkend="template-retry"/>.
 			</para>
 		</section>
+		<section>
+			<title>MessageConversionException</title>
+			<para>
+				This exception is now a subclass of <classname>AmqpException</classname>; if you have code like
+				the following:
+			</para>
+				<programlisting language="java"><![CDATA[try {
+    template.convertAndSend("foo", "bar", "baz");
+}
+catch (AmqpException e) {
+	...
+}
+catch (MessageConversionException e) {
+	...
+}]]></programlisting>
+			<para>
+				The second catch block will no longer be reachable and needs to be moved above the catch-all
+				<classname>AmqpException</classname> catch block.
+			</para>
+		</section>
 	</section>
 
 	<section>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-434

`RabbitOperations` throw `AmqpException` but some can also
throw `MessageConversionException`.

Add this exception into the `AmqpException` hierarchy to
remove any confusion.
