### PR TITLE
AMQP-438: Fix `MessagingMessageListenerAdapter`

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
@@ -40,7 +40,7 @@ import org.springframework.util.ErrorHandler;
  * @since 1.3.2
  *
  */
-public final class ConditionalRejectingErrorHandler implements ErrorHandler {
+public class ConditionalRejectingErrorHandler implements ErrorHandler {
 
 	protected static final Log logger = LogFactory.getLog(ConditionalRejectingErrorHandler.class);
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -44,6 +44,7 @@ import com.rabbitmq.client.Channel;
  *
  * @author Stephane Nicoll
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 1.4
  */
 public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageListener {
@@ -110,6 +111,11 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 			Message<?> message) {
 		try {
 			return this.handlerMethod.invoke(message, amqpMessage, channel);
+		}
+		catch (org.springframework.messaging.converter.MessageConversionException ex) {
+			throw new ListenerExecutionFailedException(createMessagingErrorMessage("Listener method could not " +
+					"be invoked with the incoming message"),
+					new MessageConversionException("Cannot handle message", ex));
 		}
 		catch (MessagingException ex) {
 			throw new ListenerExecutionFailedException(createMessagingErrorMessage("Listener method could not " +

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpointTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,6 @@ import org.mockito.ArgumentCaptor;
 
 import org.springframework.amqp.core.Address;
 import org.springframework.amqp.core.MessageProperties;
-import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
-import org.springframework.amqp.rabbit.listener.MethodRabbitListenerEndpoint;
-import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.amqp.rabbit.listener.adapter.ReplyFailureException;
 import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
@@ -73,6 +70,7 @@ import com.rabbitmq.client.Channel;
 
 /**
  * @author Stephane Nicoll
+ * @author Artem Bilan
  */
 public class MethodRabbitListenerEndpointTests {
 
@@ -378,7 +376,7 @@ public class MethodRabbitListenerEndpointTests {
 		Channel channel = mock(Channel.class);
 
 		thrown.expect(ListenerExecutionFailedException.class);
-		thrown.expectCause(Matchers.isA(org.springframework.messaging.converter.MessageConversionException.class));
+		thrown.expectCause(Matchers.isA(MessageConversionException.class));
 		thrown.expectMessage(getDefaultListenerMethod(Integer.class).toGenericString()); // ref to method
 		listener.onMessage(createTextMessage("test"), channel); // test is not a valid integer
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFaile
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.ReflectionUtils;
@@ -40,6 +39,7 @@ import com.rabbitmq.client.Channel;
 
 /**
  * @author Stephane Nicoll
+ * @author Artem Bilan
  */
 public class MessagingMessageListenerAdapterTests {
 
@@ -102,7 +102,10 @@ public class MessagingMessageListenerAdapterTests {
 			fail("Should have thrown an exception");
 		}
 		catch (ListenerExecutionFailedException ex) {
-			assertEquals(MessageConversionException.class, ex.getCause().getClass());
+			assertEquals(org.springframework.amqp.support.converter.MessageConversionException.class,
+					ex.getCause().getClass());
+			assertEquals(org.springframework.messaging.converter.MessageConversionException.class,
+					ex.getCause().getCause().getClass());
 		}
 		catch (Exception ex) {
 			fail("Should not have thrown another exception");


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-438

Since `DefaultExceptionStrategy` treats only `org.springframework.amqp.support.converter.MessageConversionException` as `fatal`
and assuming backward compatibility for SF < 4.1, add `catch (org.springframework.messaging.converter.MessageConversionException ex) {`
to the `MessagingMessageListenerAdapter` to wrap that exception to the `org.springframework.amqp.support.converter.MessageConversionException`.
Having that the `DefaultExceptionStrategy` works with `@RabbitListener` as it is with generic `<rabbit:listener>`.
