### PR TITLE
[1.5.x] AMQP-447 Ignore empty string passsed to AbstractConnectionFactory.setAddresses()

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -26,6 +26,7 @@ import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import com.rabbitmq.client.Address;
 
@@ -106,9 +107,14 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	 * @param addresses list of addresses with form "host[:port],..."
 	 */
 	public void setAddresses(String addresses) {
-		Address[] addressArray = Address.parseAddresses(addresses);
-		if (addressArray.length > 0) {
-			this.addresses = addressArray;
+		if (StringUtils.hasText(addresses)) {
+			Address[] addressArray = Address.parseAddresses(addresses);
+			if (addressArray.length > 0) {
+				if (addressArray.length == 1) {
+					logger.warn("Cluster should have more than 1 host");
+				}
+				this.addresses = addressArray;
+			}
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -104,18 +104,19 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	/**
 	 * Set addresses for clustering.
+	 * This property overrides the host+port properties if not empty.
 	 * @param addresses list of addresses with form "host[:port],..."
 	 */
 	public void setAddresses(String addresses) {
 		if (StringUtils.hasText(addresses)) {
 			Address[] addressArray = Address.parseAddresses(addresses);
 			if (addressArray.length > 0) {
-				if (addressArray.length == 1) {
-					logger.warn("Cluster should have more than 1 host");
-				}
 				this.addresses = addressArray;
+				return;
 			}
 		}
+		logger.info("setAddresses() called with an empty value, will be using the host+port properties for connections");
+		this.addresses = null;
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -12,11 +12,13 @@
  */
 package org.springframework.amqp.rabbit.connection;
 
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -47,6 +49,7 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.Cache
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.GetResponse;
@@ -969,4 +972,32 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		assertSame(mockChannel, proxy.getTargetChannel());
 	}
 
+	private static Address[] parseAddresses(String stringAddresses) {
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mock(com.rabbitmq.client.ConnectionFactory.class));
+		ccf.setAddresses(stringAddresses);
+		return (Address[]) ReflectionTestUtils.getField(ccf, "addresses");
+	}
+
+	@Test
+	public void testParsingAddresses0() {
+		final Address[] addresses = parseAddresses("");
+		assertNull(addresses);
+	}
+
+	@Test
+	public void testParsingAddresses1() {
+		final Address[] addresses = parseAddresses("host1");
+		assertNotNull(addresses);
+		assertThat(addresses, arrayWithSize(1));
+		assertEquals("host1", addresses[0].getHost());
+	}
+
+	@Test
+	public void testParsingAddresses2() {
+		final Address[] addresses = parseAddresses("host1,host2");
+		assertNotNull(addresses);
+		assertThat(addresses, arrayWithSize(2));
+		assertEquals("host1", addresses[0].getHost());
+		assertEquals("host2", addresses[1].getHost());
+	}
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -12,20 +12,21 @@
  */
 package org.springframework.amqp.rabbit.connection;
 
-import static org.hamcrest.Matchers.arrayWithSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -972,32 +973,36 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		assertSame(mockChannel, proxy.getTargetChannel());
 	}
 
-	private static Address[] parseAddresses(String stringAddresses) {
-		CachingConnectionFactory ccf = new CachingConnectionFactory(mock(com.rabbitmq.client.ConnectionFactory.class));
-		ccf.setAddresses(stringAddresses);
-		return (Address[]) ReflectionTestUtils.getField(ccf, "addresses");
+	@Test
+	public void setAddressesEmpty() throws IOException {
+		ConnectionFactory mock = mock(com.rabbitmq.client.ConnectionFactory.class);
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
+		ccf.setHost("abc");
+		ccf.setAddresses("");
+		ccf.createConnection();
+		verify(mock).setHost("abc");
+		verify(mock).newConnection((ExecutorService) null);
+		verifyNoMoreInteractions(mock);
 	}
 
 	@Test
-	public void testParsingAddresses0() {
-		final Address[] addresses = parseAddresses("");
-		assertNull(addresses);
+	public void setAddressesOneHost() throws IOException {
+		ConnectionFactory mock = mock(com.rabbitmq.client.ConnectionFactory.class);
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
+		ccf.setAddresses("mq1");
+		ccf.createConnection();
+		verify(mock).newConnection(isNull(ExecutorService.class), aryEq(new Address[] { new Address("mq1") }));
+		verifyNoMoreInteractions(mock);
 	}
 
 	@Test
-	public void testParsingAddresses1() {
-		final Address[] addresses = parseAddresses("host1");
-		assertNotNull(addresses);
-		assertThat(addresses, arrayWithSize(1));
-		assertEquals("host1", addresses[0].getHost());
-	}
-
-	@Test
-	public void testParsingAddresses2() {
-		final Address[] addresses = parseAddresses("host1,host2");
-		assertNotNull(addresses);
-		assertThat(addresses, arrayWithSize(2));
-		assertEquals("host1", addresses[0].getHost());
-		assertEquals("host2", addresses[1].getHost());
+	public void setAddressesTwoHosts() throws IOException {
+		ConnectionFactory mock = mock(com.rabbitmq.client.ConnectionFactory.class);
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
+		ccf.setAddresses("mq1,mq2");
+		ccf.createConnection();
+		verify(mock).newConnection(isNull(ExecutorService.class),
+				aryEq(new Address[] { new Address("mq1"), new Address("mq2") }));
+		verifyNoMoreInteractions(mock);
 	}
 }


### PR DESCRIPTION
https://jira.spring.io/browse/AMQP-447

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement