### PR TITLE
AMQP-457: ListenerContainer Provide Consumer Queue

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -99,6 +99,12 @@ public class MessageProperties implements Serializable {
 
 	private volatile Integer messageCount;
 
+	// Not included in hashCode()
+
+	private volatile String consumerTag;
+
+	private volatile String consumerQueue;
+
 	public void setHeader(String key, Object value) {
 		this.headers.put(key, value);
 	}
@@ -217,7 +223,7 @@ public class MessageProperties implements Serializable {
 	}
 
 	protected final boolean isContentLengthSet() {
-		return contentLengthSet;
+		return this.contentLengthSet;
 	}
 
 	public void setDeliveryMode(MessageDeliveryMode deliveryMode) {
@@ -288,7 +294,7 @@ public class MessageProperties implements Serializable {
 	}
 
 	protected final boolean isDeliveryTagSet() {
-		return deliveryTagSet;
+		return this.deliveryTagSet;
 	}
 
 	public void setMessageCount(Integer messageCount) {
@@ -299,6 +305,21 @@ public class MessageProperties implements Serializable {
 		return this.messageCount;
 	}
 
+	public String getConsumerTag() {
+		return this.consumerTag;
+	}
+
+	public void setConsumerTag(String consumerTag) {
+		this.consumerTag = consumerTag;
+	}
+
+	public String getConsumerQueue() {
+		return this.consumerQueue;
+	}
+
+	public void setConsumerQueue(String consumerQueue) {
+		this.consumerQueue = consumerQueue;
+	}
 
 	@Override
 	public int hashCode() {

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
@@ -92,4 +92,14 @@ public abstract class AmqpHeaders {
 
 	public static final String CHANNEL = PREFIX + "channel";
 
+	/**
+	 * The tag of the listener container consumer that received the message.
+	 */
+	public static final String CONSUMER_TAG = PREFIX + "consumerTag";
+
+	/**
+	 * The queue from which the listener container consumer received the message.
+	 */
+	public static final String CONSUMER_QUEUE = PREFIX + "consumerQueue";
+
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpMessageHeaderAccessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpMessageHeaderAccessor.java
@@ -31,6 +31,7 @@ import org.springframework.util.MimeType;
  * implementation giving access to AMQP-specific headers.
  *
  * @author Stephane Nicoll
+ * @author Gary Russell
  * @since 1.4
  */
 public class AmqpMessageHeaderAccessor extends NativeMessageHeaderAccessor {
@@ -137,6 +138,7 @@ public class AmqpMessageHeaderAccessor extends NativeMessageHeaderAccessor {
 		return (String) getHeader(AmqpHeaders.REPLY_TO);
 	}
 
+	@Override
 	public Long getTimestamp() {
 		Date amqpTimestamp = (Date) getHeader(AmqpHeaders.TIMESTAMP);
 		if (amqpTimestamp != null) {
@@ -153,6 +155,14 @@ public class AmqpMessageHeaderAccessor extends NativeMessageHeaderAccessor {
 
 	public String getUserId() {
 		return (String) getHeader(AmqpHeaders.USER_ID);
+	}
+
+	public String getConsumerTag() {
+		return (String) getHeader(AmqpHeaders.CONSUMER_TAG);
+	}
+
+	public String getConsumerQueue() {
+		return (String) getHeader(AmqpHeaders.CONSUMER_QUEUE);
 	}
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/SimpleAmqpHeaderMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/SimpleAmqpHeaderMapper.java
@@ -233,6 +233,14 @@ public class SimpleAmqpHeaderMapper extends AbstractHeaderMapper<MessageProperti
 			if (StringUtils.hasText(userId)) {
 				headers.put(AmqpHeaders.USER_ID, userId);
 			}
+			String consumerTag = amqpMessageProperties.getConsumerTag();
+			if (StringUtils.hasText(consumerTag)) {
+				headers.put(AmqpHeaders.CONSUMER_TAG, consumerTag);
+			}
+			String consumerQueue = amqpMessageProperties.getConsumerQueue();
+			if (StringUtils.hasText(consumerQueue)) {
+				headers.put(AmqpHeaders.CONSUMER_QUEUE, consumerQueue);
+			}
 
 			// Map custom headers
 			for (Map.Entry<String, Object> entry : amqpMessageProperties.getHeaders().entrySet()) {

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/SimpleAmqpHeaderMapperTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/SimpleAmqpHeaderMapperTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.amqp.support;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,8 +31,6 @@ import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.support.converter.JsonMessageConverter;
 import org.springframework.messaging.MessageHeaders;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Mark Fisher
@@ -132,6 +133,8 @@ public class SimpleAmqpHeaderMapperTests {
 		amqpProperties.setTimestamp(testTimestamp);
 		amqpProperties.setType("test.type");
 		amqpProperties.setUserId("test.userId");
+		amqpProperties.setConsumerTag("consumer.tag");
+		amqpProperties.setConsumerQueue("consumer.queue");
 		amqpProperties.setHeader(AmqpHeaders.SPRING_REPLY_CORRELATION, "test.correlation");
 		amqpProperties.setHeader(AmqpHeaders.SPRING_REPLY_TO_STACK, "test.replyTo2");
 		Map<String, Object> headerMap = headerMapper.toHeaders(amqpProperties);
@@ -154,6 +157,8 @@ public class SimpleAmqpHeaderMapperTests {
 		assertEquals("test.userId", headerMap.get(AmqpHeaders.USER_ID));
 		assertEquals("test.correlation", headerMap.get(AmqpHeaders.SPRING_REPLY_CORRELATION));
 		assertEquals("test.replyTo2", headerMap.get(AmqpHeaders.SPRING_REPLY_TO_STACK));
+		assertEquals("consumer.tag", headerMap.get(AmqpHeaders.CONSUMER_TAG));
+		assertEquals("consumer.queue", headerMap.get(AmqpHeaders.CONSUMER_QUEUE));
 	}
 
 	@Test // INT-2090

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -120,10 +120,8 @@ public abstract class RabbitUtils {
 			return;
 		}
 		try {
-			synchronized(consumerTags) {
-				for (String consumerTag : consumerTags) {
-					channel.basicCancel(consumerTag);
-				}
+			for (String consumerTag : consumerTags) {
+				channel.basicCancel(consumerTag);
 			}
 			if (transactional) {
 				/*

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -16,7 +16,6 @@ package org.springframework.amqp.rabbit.listener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -108,7 +108,7 @@ public class BlockingQueueConsumer {
 
 	private final boolean defaultRequeuRejected;
 
-	private final Collection<String> consumerTags = Collections.synchronizedSet(new HashSet<String>());
+	private final Map<String, String> consumerTags = new ConcurrentHashMap<String, String>();
 
 	private final Set<String> missingQueues = Collections.synchronizedSet(new HashSet<String>());
 
@@ -233,24 +233,23 @@ public class BlockingQueueConsumer {
 	}
 
 	protected void basicCancel() {
-		try {
-			synchronized (this.consumerTags) {
-				for (String consumerTag : this.consumerTags) {
-					this.channel.basicCancel(consumerTag);
+		for (String consumerTag : this.consumerTags.keySet()) {
+			try {
+				this.channel.basicCancel(consumerTag);
+			}
+			catch (IOException e) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Error performing 'basicCancel'", e);
 				}
-				this.consumerTags.clear();
+			}
+			catch (AlreadyClosedException e) {
+				if (logger.isTraceEnabled()) {
+					logger.trace(this.channel + " is already closed");
+				}
+				break;
 			}
 		}
-		catch (IOException e) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("Error performing 'basicCancel'", e);
-			}
-		}
-		catch (AlreadyClosedException e) {
-			if (logger.isTraceEnabled()) {
-				logger.trace(this.channel + " is already closed");
-			}
-		}
+		this.consumerTags.clear();
 		this.cancelled.set(true);
 	}
 
@@ -286,6 +285,8 @@ public class BlockingQueueConsumer {
 		MessageProperties messageProperties = this.messagePropertiesConverter.toMessageProperties(
 				delivery.getProperties(), envelope, "UTF-8");
 		messageProperties.setMessageCount(0);
+		messageProperties.setConsumerTag(delivery.getConsumerTag());
+		messageProperties.setConsumerQueue(this.consumerTags.get(delivery.getConsumerTag()));
 		Message message = new Message(body, messageProperties);
 		if (logger.isDebugEnabled()) {
 			logger.debug("Received message: " + message);
@@ -458,10 +459,16 @@ public class BlockingQueueConsumer {
 	}
 
 	private void consumeFromQueue(String queue) throws IOException {
-		this.channel.basicConsume(queue, this.acknowledgeMode.isAutoAck(), "", false, this.exclusive,
+		String consumerTag = this.channel.basicConsume(queue, this.acknowledgeMode.isAutoAck(), "", false, this.exclusive,
 				this.consumerArgs, this.consumer);
-		if (logger.isDebugEnabled()) {
-			logger.debug("Started on queue '" + queue + "': " + this);
+		if (consumerTag != null) {
+			this.consumerTags.put(consumerTag, queue);
+			if (logger.isDebugEnabled()) {
+				logger.debug("Started on queue '" + queue + "' with tag " + consumerTag + ": " + this);
+			}
+		}
+		else {
+			logger.error("Null consumer tag received for queue " + queue);
 		}
 	}
 
@@ -491,7 +498,7 @@ public class BlockingQueueConsumer {
 		if (consumer != null && consumer.getChannel() != null && this.consumerTags.size() > 0
 				&& !this.cancelReceived.get()) {
 			try {
-				RabbitUtils.closeMessageConsumer(this.consumer.getChannel(), this.consumerTags, this.transactional);
+				RabbitUtils.closeMessageConsumer(this.consumer.getChannel(), this.consumerTags.keySet(), this.transactional);
 			}
 			catch (Exception e) {
 				if (logger.isDebugEnabled()) {
@@ -517,9 +524,6 @@ public class BlockingQueueConsumer {
 		@Override
 		public void handleConsumeOk(String consumerTag) {
 			super.handleConsumeOk(consumerTag);
-			synchronized(BlockingQueueConsumer.this.consumerTags) {
-				BlockingQueueConsumer.this.consumerTags.add(consumerTag);
-			}
 			if (logger.isDebugEnabled()) {
 				logger.debug("ConsumeOK : " + BlockingQueueConsumer.this);
 			}
@@ -546,9 +550,7 @@ public class BlockingQueueConsumer {
 			if (logger.isWarnEnabled()) {
 				logger.warn("Cancel received for " + consumerTag + "; " + BlockingQueueConsumer.this);
 			}
-			synchronized (BlockingQueueConsumer.this.consumerTags) {
-				BlockingQueueConsumer.this.consumerTags.remove(consumerTag);
-			}
+			BlockingQueueConsumer.this.consumerTags.remove(consumerTag);
 			BlockingQueueConsumer.this.cancelReceived.set(true);
 		}
 
@@ -569,7 +571,7 @@ public class BlockingQueueConsumer {
 				logger.debug("Storing delivery for " + BlockingQueueConsumer.this);
 			}
 			try {
-				queue.put(new Delivery(envelope, properties, body));
+				queue.put(new Delivery(consumerTag, envelope, properties, body));
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
@@ -583,14 +585,23 @@ public class BlockingQueueConsumer {
 	 */
 	private static class Delivery {
 
+		private final String consumerTag;
+
 		private final Envelope envelope;
+
 		private final AMQP.BasicProperties properties;
+
 		private final byte[] body;
 
-		public Delivery(Envelope envelope, AMQP.BasicProperties properties, byte[] body) {
+		public Delivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) {
+			this.consumerTag = consumerTag;
 			this.envelope = envelope;
 			this.properties = properties;
 			this.body = body;
+		}
+
+		public String getConsumerTag() {
+			return consumerTag;
 		}
 
 		public Envelope getEnvelope() {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -16,14 +16,18 @@
 
 package org.springframework.amqp.rabbit.listener;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.rabbitmq.client.AMQP;
-import com.rabbitmq.client.Channel;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -35,6 +39,10 @@ import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
 import org.springframework.beans.DirectFieldAccessor;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
 
 /**
  * @author Gary Russell
@@ -96,6 +104,7 @@ public class BlockingQueueConsumerTests {
 		testRequeueOrNotDefaultNo(new MessageRejectedWhileStoppingException(), true);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testPrefetchIsSetOnFailedPassiveDeclaration() throws IOException {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
@@ -118,6 +127,8 @@ public class BlockingQueueConsumerTests {
 						}
 					}
 				});
+		when(channel.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
+						anyMap(), any(Consumer.class))).thenReturn("consumerTag");
 
 		BlockingQueueConsumer blockingQueueConsumer = new BlockingQueueConsumer(connectionFactory,
 				new DefaultMessagePropertiesConverter(), new ActiveObjectCounter<BlockingQueueConsumer>(),

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -106,7 +106,7 @@ public class ExternalTxManagerTests {
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
-				return null;
+				return "consumerTag";
 			}
 		}).when(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
@@ -213,7 +213,7 @@ public class ExternalTxManagerTests {
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
-				return null;
+				return "consumerTag";
 			}
 		}).when(listenerChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
@@ -322,7 +322,7 @@ public class ExternalTxManagerTests {
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
-				return null;
+				return "consumerTag";
 			}
 		}).when(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
@@ -424,7 +424,7 @@ public class ExternalTxManagerTests {
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
-				return null;
+				return "consumerTag";
 			}
 		}).when(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
@@ -527,7 +527,7 @@ public class ExternalTxManagerTests {
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
-				return null;
+				return "consumerTag";
 			}
 		}).when(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
@@ -101,7 +101,7 @@ public class LocallyTransactedTests {
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
-				return null;
+				return "consumerTag";
 			}
 		}).when(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
@@ -199,7 +199,7 @@ public class LocallyTransactedTests {
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
-				return null;
+				return "consumerTag";
 			}
 		}).when(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
@@ -299,7 +299,7 @@ public class LocallyTransactedTests {
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
-				return null;
+				return "consumerTag";
 			}
 		}).when(firstChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-457

If the listener container is configured to listen to multiple queues,
it would be useful for the listener to have access to which queue a
message was received from.

Instead of a collection of consumer tags, maintain a `Map` of consumer
tags to queue names and populate the message properties with the
tag and queue name.

In the spring-messaging header mapper, map the properties to headers
(inbound only).