### PR TITLE
AMQP-459: Add Channel Limit Option to CCF

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/AmqpTimeoutException.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/AmqpTimeoutException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp;
+
+/**
+ * Exception thrown when some time-bound operation fails to execute in the
+ * desired time.
+ *
+ * @author Gary Russell
+ * @since 1.4.2
+ *
+ */
+public class AmqpTimeoutException extends AmqpException {
+
+	private static final long serialVersionUID = -1981629885617675621L;
+
+	public AmqpTimeoutException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AmqpTimeoutException(String message) {
+		super(message);
+	}
+
+	public AmqpTimeoutException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -280,6 +280,25 @@
 	    would be most suitable.
 	  </para>
 	</important>
+    <para>
+        It is important to understand that the cache size is (by default) not a limit, but merely the number
+        of channels that can be cached. With a cache size of, say, 10, any number of channels can actually
+        be in use. If more than 10 channels are being used and they are all returned to the cache, 10 will
+        go in the cache; the remainder will be physically closed.
+    </para>
+    <para>
+        Starting with <emphasis>version 1.4.2</emphasis>, the <classname>CachingConnectionFactory</classname>
+        has a property <code>channelCheckoutTimeout</code>. When this property is greater than zero,
+        the <code>channelCacheSize</code> becomes a limit on the number of channels that can be created
+        on a connection. If the limit is reached, calling threads will block until a channel is available
+        or this timeout is reached, in which case a <classname>AmqpTimeoutException</classname> is thrown.
+    </para>
+    <caution>
+        Channels used within the framework (e.g. <classname>RabbitTemplate</classname>) will be reliably
+        returned to the cache. If you create channels outside of the framework, (e.g. by accessing
+        the connection(s) directly and invoking <code>createChannel()</code>), you must return them (by closing)
+        reliably, perhaps in a <code>finally</code> block, to avoid running out of channels.
+    </caution>
 
     <programlisting language="java"><![CDATA[CachingConnectionFactory connectionFactory = new CachingConnectionFactory("somehost");
 connectionFactory.setUsername("guest");


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-459

Add configuration such that the `channelCacheSize` can be
considered a limit of how many channels can be created and
a timeout when requesting a channel.