### PR TITLE
[BackPort] AMQP-463: Fix Publisher Confirms with JRockit

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -654,8 +654,9 @@ public class PublisherCallbackChannelImpl implements PublisherCallbackChannel, C
 						Iterator<Entry<Long, PendingConfirm>> iterator = confirms.entrySet().iterator();
 						while (iterator.hasNext()) {
 							Entry<Long, PendingConfirm> entry = iterator.next();
+							PendingConfirm value = entry.getValue();
 							iterator.remove();
-							doHandleConfirm(ack, involvedListener, entry.getValue());
+							doHandleConfirm(ack, involvedListener, value);
 						}
 					}
 				}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminDeclarationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminDeclarationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,7 +278,7 @@ public class RabbitAdminDeclarationTests {
 		verify(Config.channel2, times(0)).queueDeclare("foo", true, false, false, null);
 		verify(Config.channel2, times(0)).exchangeDeclare("bar", "direct", true, false, new HashMap<String, Object>());
 		verify(Config.channel2, times(0)).queueBind("foo", "bar", "foo", null);
-		context.destroy();
+		context.close();
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-463

JRockit throws an `IllegalArgumentException` if a
`TreeMap$Entry` is used after removal via the `Iterator`.

The `PublishSubscribeChannelImpl` uses this technique.

Obtain the entry value before removing the entry.

Add a test to reproduce the problem with the JRockit JVM.

Currently sends 10k messages across 100 threads; also tested
with 1m messages across 100 threads with no lost confirms.

Conflicts:
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
Resolved.