### PR TITLE
AMQP-469 Introduce `Connection#sendAndReceiveRPC`

### DIFF
--- a/spring-erlang/src/main/java/org/springframework/erlang/connection/Connection.java
+++ b/spring-erlang/src/main/java/org/springframework/erlang/connection/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,15 +24,16 @@ import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangObject;
 
 /**
- * A simple interface that is used to wrap access to the OtpConnection class in order to support
- * caching of OptConnections via method interception.
+ * A simple interface that is used to wrap access to the {@code OtpConnection} class
+ * in order to support caching of {@code OtpConnection}s via method interception.
  *
- * Note:  The surface area of the API is all that is required to implement administrative functionality
- * for the Spring AMQP admin project.  To access the underlying OtpConnection, use the method getTargetConnection
- * on the interface ConnectionProxy that is implemented by DefaultConnection.
+ * Note:  The surface area of the API is all that is required to implement administrative
+ * functionality for the Spring AMQP admin project.
+ * To access the underlying {@code OtpConnection}, use the method {@code getTargetConnection}
+ * on the interface {@code ConnectionProxy} that is implemented by {@code DefaultConnection}.
  *
  * @author Mark Pollack
- *
+ * @author aArtem Bilan
  */
 public interface Connection {
 
@@ -44,27 +45,16 @@ public interface Connection {
     /**
      * Send an RPC request to the remote Erlang node. This convenience function
      * creates the following message and sends it to 'rex' on the remote node:
-     *
      * <pre class="code">
      * { self, { call, Mod, Fun, Args, user } }
      * </pre>
-     *
      * <p>
-     * Note that this method has unpredicatble results if the remote node is not
+     * Note that this method has unpredictable results if the remote node is not
      * an Erlang node.
-     * </p>
-     *
-     * @param mod
-     *                the name of the Erlang module containing the function to
-     *                be called.
-     * @param fun
-     *                the name of the function to call.
-     * @param args
-     *                a list of Erlang terms, to be used as arguments to the
-     *                function.
-     *
-     * @exception java.io.IOException
-     *                    if the connection is not active or a communication
+     * @param mod  the name of the Erlang module containing the function to  be called.
+     * @param fun  the name of the function to call.
+     * @param args a list of Erlang terms, to be used as arguments to the function.
+     * @exception java.io.IOException if the connection is not active or a communication
      *                    error occurs.
      */
 	void sendRPC(final String mod, final String fun, final OtpErlangList args) throws IOException;
@@ -73,27 +63,40 @@ public interface Connection {
      * Receive an RPC reply from the remote Erlang node. This convenience
      * function receives a message from the remote node, and expects it to have
      * the following format:
-     *
      * <pre class="code">
      * { rex, Term }
      * </pre>
-     *
      * @return the second element of the tuple if the received message is a
      *         two-tuple, otherwise null. No further error checking is
      *         performed.
-     *
-     * @exception java.io.IOException
-     *                    if the connection is not active or a communication
+     * @exception java.io.IOException if the connection is not active or a communication
      *                    error occurs.
-     *
-     * @exception OtpErlangExit
-     *                    if an exit signal is received from a process on the
+     * @exception OtpErlangExit if an exit signal is received from a process on the
      *                    peer node.
-     *
-     * @exception OtpAuthException
-     *                    if the remote node sends a message containing an
+     * @exception OtpAuthException if the remote node sends a message containing an
      *                    invalid cookie.
      */
 	OtpErlangObject receiveRPC() throws IOException, OtpErlangExit, OtpAuthException;
+
+	/**
+	 * Send an RPC request to the remote Erlang node and receive result.
+	 * The implementation must ensure {@code synchronized} mode of this method since
+	 * the underlying {@code OtpConnection} isn't thread-safe.
+	 * @param mod  the name of the Erlang module containing the function to  be called.
+	 * @param fun  the name of the function to call.
+	 * @param args a list of Erlang terms, to be used as arguments to the function.
+	 * @return the second element of the tuple if the received message is a
+	 *         two-tuple, otherwise null. No further error checking is
+	 *         performed.
+	 * @exception java.io.IOException if the connection is not active or a communication
+	 *                    error occurs.
+	 * @exception OtpErlangExit if an exit signal is received from a process on the
+	 *                    peer node.
+	 * @exception OtpAuthException if the remote node sends a message containing an
+	 *                    invalid cookie.
+	 * @since 1.5
+	 */
+	OtpErlangObject sendAndReceiveRPC(final String mod, final String fun, final OtpErlangList args)
+			throws IOException, OtpErlangExit, OtpAuthException;
 
 }

--- a/spring-erlang/src/main/java/org/springframework/erlang/connection/DefaultConnection.java
+++ b/spring-erlang/src/main/java/org/springframework/erlang/connection/DefaultConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.erlang.connection;
 
 import java.io.IOException;
@@ -24,9 +25,10 @@ import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangObject;
 
 /**
- * Basic implementation of {@link ConnectionProxy} that delegates to an underlying OtpConnection.
+ * Basic implementation of {@link ConnectionProxy} that delegates
+ * to an underlying {@link OtpConnection}.
  * @author Mark Pollack
- *
+ * @author Artem Bilan
  */
 public class DefaultConnection implements ConnectionProxy {
 
@@ -37,19 +39,26 @@ public class DefaultConnection implements ConnectionProxy {
 		this.otpConnection = otpConnection;
 	}
 
+	@Override
 	public void close() {
-		otpConnection.close();
+		this.otpConnection.close();
 	}
 
-	public void sendRPC(String mod, String fun, OtpErlangList args)
-			throws IOException {
-		otpConnection.sendRPC(mod, fun, args);
-
+	@Override
+	public void sendRPC(String mod, String fun, OtpErlangList args) throws IOException {
+		this.otpConnection.sendRPC(mod, fun, args);
 	}
 
-	public OtpErlangObject receiveRPC() throws IOException, OtpErlangExit,
-			OtpAuthException {
-		return otpConnection.receiveRPC();
+	@Override
+	public OtpErlangObject receiveRPC() throws IOException, OtpErlangExit, OtpAuthException {
+		return this.otpConnection.receiveRPC();
+	}
+
+	@Override
+	public synchronized OtpErlangObject sendAndReceiveRPC(String mod, String fun, OtpErlangList args)
+			throws IOException, OtpErlangExit, OtpAuthException {
+		sendRPC(mod, fun, args);
+		return receiveRPC();
 	}
 
 	public OtpConnection getTargetConnection() {

--- a/spring-erlang/src/main/java/org/springframework/erlang/core/ErlangTemplate.java
+++ b/spring-erlang/src/main/java/org/springframework/erlang/core/ErlangTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.ericsson.otp.erlang.*;
 
 /**
  * @author Mark Pollack
+ * @author Artem Bilan
  */
 public class ErlangTemplate extends ErlangAccessor implements ErlangOperations {
 
@@ -47,9 +48,7 @@ public class ErlangTemplate extends ErlangAccessor implements ErlangOperations {
 		return execute(new ConnectionCallback<OtpErlangObject>() {
 			public OtpErlangObject doInConnection(Connection connection) throws Exception {
 				logger.debug("Sending RPC for module [" + module + "] function [" + function + "] args [" + args);
-				connection.sendRPC(module, function, args);
-				//TODO consider dedicated response object.
-				OtpErlangObject response = connection.receiveRPC();
+				OtpErlangObject response = connection.sendAndReceiveRPC(module, function, args);
 				logger.debug("Response received = " + response.toString());
 				handleResponseError(module, function, response);
 				return response;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-469

Since `OtpConnection` isn't thread-safe between `sendRPC` and `receiveRPC`, add a new `sendAndReceiveRPC`
and make its implementation in the `DefaultConnection` as `synchronized`.

Modify `ErlangTemplate` to use that new operation.

Having that even with `SingleConnectionFactory` we don't meet race condition when one thread may receive result of another one.