### PR TITLE
AMQP-472: Recover From Conn. Close During Init

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -198,7 +198,7 @@ public abstract class RabbitUtils {
 					&& ((AMQP.Channel.Close) shutdownReason).getMethodId() == 10); // declare
 	}
 
-	protected static Object determineShutdownReason(ShutdownSignalException sig) {
+	public static Object determineShutdownReason(ShutdownSignalException sig) {
 		if (shutDownSignalReasonMethod == null) {
 			return false;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -244,7 +244,8 @@ public class BlockingQueueConsumer {
 	/**
 	 * Set the number of retries after passive queue declaration fails.
 	 * @param declarationRetries The number of retries, default 3.
-	 * @see #setFailedDeclarationRetryInterval(int)
+	 * @see #setFailedDeclarationRetryInterval(long)
+	 * @since 1.3.9
 	 */
 	public void setDeclarationRetries(int declarationRetries) {
 		this.declarationRetries = declarationRetries;
@@ -254,6 +255,7 @@ public class BlockingQueueConsumer {
 	 * Set the interval between passive queue declaration attempts in milliseconds.
 	 * @param failedDeclarationRetryInterval the interval, default 5000.
 	 * @see #setDeclarationRetries(int)
+	 * @since 1.3.9
 	 */
 	public void setFailedDeclarationRetryInterval(long failedDeclarationRetryInterval) {
 		this.failedDeclarationRetryInterval = failedDeclarationRetryInterval;
@@ -263,6 +265,7 @@ public class BlockingQueueConsumer {
 	 * When consuming multiple queues, set the interval between declaration attempts when only
 	 * a subset of the queues were available (milliseconds).
 	 * @param retryDeclarationInterval the interval, default 60000.
+	 * @since 1.3.9
 	 */
 	public void setRetryDeclarationInterval(long retryDeclarationInterval) {
 		this.retryDeclarationInterval = retryDeclarationInterval;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -53,7 +53,6 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.ShutdownSignalException;
@@ -86,8 +85,6 @@ public class BlockingQueueConsumer {
 	private final boolean transactional;
 
 	private Channel channel;
-
-	private Connection connection;
 
 	private RabbitResourceHolder resourceHolder;
 
@@ -425,7 +422,6 @@ public class BlockingQueueConsumer {
 		try {
 			this.resourceHolder = ConnectionFactoryUtils.getTransactionalResourceHolder(connectionFactory, transactional);
 			this.channel = resourceHolder.getChannel();
-			this.connection = this.channel.getConnection();
 		}
 		catch (AmqpAuthenticationException e) {
 			throw new FatalListenerStartupException("Authentication failure", e);
@@ -522,7 +518,7 @@ public class BlockingQueueConsumer {
 				if (logger.isWarnEnabled()) {
 					logger.warn("Failed to declare queue:" + queueName);
 				}
-				if (!this.connection.isOpen()) {
+				if (!this.channel.isOpen()) {
 					throw new AmqpIOException(e);
 				}
 				if (failures == null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -555,7 +555,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	/**
 	 * Set the number of retries after passive queue declaration fails.
 	 * @param declarationRetries The number of retries, default 3.
-	 * @see #setFailedDeclarationRetryInterval(int)
+	 * @see #setFailedDeclarationRetryInterval(long)
+	 * @since 1.3.9
 	 */
 	public void setDeclarationRetries(int declarationRetries) {
 		this.declarationRetries = declarationRetries;
@@ -565,6 +566,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 * Set the interval between passive queue declaration attempts in milliseconds.
 	 * @param failedDeclarationRetryInterval the interval, default 5000.
 	 * @see #setDeclarationRetries(int)
+	 * @since 1.3.9
 	 */
 	public void setFailedDeclarationRetryInterval(long failedDeclarationRetryInterval) {
 		this.failedDeclarationRetryInterval = failedDeclarationRetryInterval;
@@ -574,6 +576,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 * When consuming multiple queues, set the interval between declaration attempts when only
 	 * a subset of the queues were available (milliseconds).
 	 * @param retryDeclarationInterval the interval, default 60000.
+	 * @since 1.3.9
 	 */
 	public void setRetryDeclarationInterval(long retryDeclarationInterval) {
 		this.retryDeclarationInterval = retryDeclarationInterval;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -170,6 +170,12 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	private ContainerDelegate proxy = delegate;
 
+	private Integer declarationRetries;
+
+	private Long failedDeclarationRetryInterval;
+
+	private Long retryDeclarationInterval;
+
 	/**
 	 * Default constructor for convenient dependency injection via setters.
 	 */
@@ -547,6 +553,33 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
+	 * Set the number of retries after passive queue declaration fails.
+	 * @param declarationRetries The number of retries, default 3.
+	 * @see #setFailedDeclarationRetryInterval(int)
+	 */
+	public void setDeclarationRetries(int declarationRetries) {
+		this.declarationRetries = declarationRetries;
+	}
+
+	/**
+	 * Set the interval between passive queue declaration attempts in milliseconds.
+	 * @param failedDeclarationRetryInterval the interval, default 5000.
+	 * @see #setDeclarationRetries(int)
+	 */
+	public void setFailedDeclarationRetryInterval(long failedDeclarationRetryInterval) {
+		this.failedDeclarationRetryInterval = failedDeclarationRetryInterval;
+	}
+
+	/**
+	 * When consuming multiple queues, set the interval between declaration attempts when only
+	 * a subset of the queues were available (milliseconds).
+	 * @param retryDeclarationInterval the interval, default 60000.
+	 */
+	public void setRetryDeclarationInterval(long retryDeclarationInterval) {
+		this.retryDeclarationInterval = retryDeclarationInterval;
+	}
+
+	/**
 	 * Avoid the possibility of not configuring the CachingConnectionFactory in sync with the number of concurrent
 	 * consumers.
 	 */
@@ -852,6 +885,15 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		consumer = new BlockingQueueConsumer(getConnectionFactory(), this.messagePropertiesConverter, cancellationLock,
 				getAcknowledgeMode(), isChannelTransacted(), actualPrefetchCount, this.defaultRequeueRejected,
 				this.consumerArgs, this.exclusive, queues);
+		if (this.declarationRetries != null) {
+			consumer.setDeclarationRetries(this.declarationRetries);
+		}
+		if (this.failedDeclarationRetryInterval != null) {
+			consumer.setFailedDeclarationRetryInterval(this.failedDeclarationRetryInterval);
+		}
+		if (this.retryDeclarationInterval != null) {
+			consumer.setRetryDeclarationInterval(this.retryDeclarationInterval);
+		}
 		return consumer;
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -113,6 +113,9 @@ public class BlockingQueueConsumerTests {
 
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		when(connection.createChannel(Mockito.anyBoolean())).thenReturn(channel);
+		com.rabbitmq.client.Connection rabbitConnection = mock(com.rabbitmq.client.Connection.class);
+		when(rabbitConnection.isOpen()).thenReturn(true);
+		when(channel.getConnection()).thenReturn(rabbitConnection);
 		when(channel.queueDeclarePassive(Mockito.anyString()))
 				.then(new Answer<Object>() {
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-472

Previously, any `IOException` during passive queue declaration would enter
declaration retry and eventually throw a `QueuesNotAvailableException`. Whether
or not that is recoverable depends on the container's `missingQueuesFatal` property.

If the `IOException` is due to a connection close, we should not try to redeclare
and, further, recovery should be unconditional.

When a queue declaration fails, check if the connection is open and, if not, throw
an `AmqpIOException`, causing container recovery to begin. If the connection is open
continue retrying queue declaration as before.

In addition, expose the queue declaration retry properties on the `SimpleMessageListenerContainer`.

__cherry-pick to 1.4.x, 1.3.x; do not resolve JIRA - a second PR is required for namespace support for the new properties in 1.5.x__