### PR TITLE
AMQP-472: Namespace for Declaration Retries

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
@@ -85,6 +85,11 @@ public class RabbitNamespaceUtils {
 
 	private static final String AUTO_DECLARE = "auto-declare";
 
+	private static final String DECLARATION_RETRIES = "declaration-retries";
+
+	private static final String FAILED_DECLARATION_RETRY_INTERVAL = "failed-declaration-retry-interval";
+
+	private static final String MISSING_QUEUE_RETRY_INTERVAL = "missing-queue-retry-interval";
 
 	public static BeanDefinition parseContainer(Element containerEle, ParserContext parserContext) {
 		RootBeanDefinition containerDef = new RootBeanDefinition(SimpleMessageListenerContainer.class);
@@ -212,6 +217,21 @@ public class RabbitNamespaceUtils {
 		String autoDeclare = containerEle.getAttribute(AUTO_DECLARE);
 		if (StringUtils.hasText(autoDeclare)) {
 			containerDef.getPropertyValues().add("autoDeclare", new TypedStringValue(autoDeclare));
+		}
+
+		String declarationRetries = containerEle.getAttribute(DECLARATION_RETRIES);
+		if (StringUtils.hasText(declarationRetries)) {
+			containerDef.getPropertyValues().add("declarationRetries", new TypedStringValue(declarationRetries));
+		}
+
+		String failedDeclarationRetryInterval = containerEle.getAttribute(FAILED_DECLARATION_RETRY_INTERVAL);
+		if (StringUtils.hasText(failedDeclarationRetryInterval)) {
+			containerDef.getPropertyValues().add("failedDeclarationRetryInterval", new TypedStringValue(failedDeclarationRetryInterval));
+		}
+
+		String retryDeclarationInterval = containerEle.getAttribute(MISSING_QUEUE_RETRY_INTERVAL);
+		if (StringUtils.hasText(retryDeclarationInterval)) {
+			containerDef.getPropertyValues().add("retryDeclarationInterval", new TypedStringValue(retryDeclarationInterval));
 		}
 
 		return containerDef;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -198,7 +198,7 @@ public abstract class RabbitUtils {
 					&& ((AMQP.Channel.Close) shutdownReason).getMethodId() == 10); // declare
 	}
 
-	protected static Object determineShutdownReason(ShutdownSignalException sig) {
+	public static Object determineShutdownReason(ShutdownSignalException sig) {
 		if (shutDownSignalReasonMethod == null) {
 			return false;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -244,7 +244,8 @@ public class BlockingQueueConsumer {
 	/**
 	 * Set the number of retries after passive queue declaration fails.
 	 * @param declarationRetries The number of retries, default 3.
-	 * @see #setFailedDeclarationRetryInterval(int)
+	 * @see #setFailedDeclarationRetryInterval(long)
+	 * @since 1.3.9
 	 */
 	public void setDeclarationRetries(int declarationRetries) {
 		this.declarationRetries = declarationRetries;
@@ -254,6 +255,7 @@ public class BlockingQueueConsumer {
 	 * Set the interval between passive queue declaration attempts in milliseconds.
 	 * @param failedDeclarationRetryInterval the interval, default 5000.
 	 * @see #setDeclarationRetries(int)
+	 * @since 1.3.9
 	 */
 	public void setFailedDeclarationRetryInterval(long failedDeclarationRetryInterval) {
 		this.failedDeclarationRetryInterval = failedDeclarationRetryInterval;
@@ -263,6 +265,7 @@ public class BlockingQueueConsumer {
 	 * When consuming multiple queues, set the interval between declaration attempts when only
 	 * a subset of the queues were available (milliseconds).
 	 * @param retryDeclarationInterval the interval, default 60000.
+	 * @since 1.3.9
 	 */
 	public void setRetryDeclarationInterval(long retryDeclarationInterval) {
 		this.retryDeclarationInterval = retryDeclarationInterval;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -53,7 +53,6 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.ShutdownSignalException;
@@ -86,8 +85,6 @@ public class BlockingQueueConsumer {
 	private final boolean transactional;
 
 	private Channel channel;
-
-	private Connection connection;
 
 	private RabbitResourceHolder resourceHolder;
 
@@ -425,7 +422,6 @@ public class BlockingQueueConsumer {
 		try {
 			this.resourceHolder = ConnectionFactoryUtils.getTransactionalResourceHolder(connectionFactory, transactional);
 			this.channel = resourceHolder.getChannel();
-			this.connection = this.channel.getConnection();
 		}
 		catch (AmqpAuthenticationException e) {
 			throw new FatalListenerStartupException("Authentication failure", e);
@@ -522,7 +518,7 @@ public class BlockingQueueConsumer {
 				if (logger.isWarnEnabled()) {
 					logger.warn("Failed to declare queue:" + queueName);
 				}
-				if (!this.connection.isOpen()) {
+				if (!this.channel.isOpen()) {
 					throw new AmqpIOException(e);
 				}
 				if (failures == null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -555,7 +555,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	/**
 	 * Set the number of retries after passive queue declaration fails.
 	 * @param declarationRetries The number of retries, default 3.
-	 * @see #setFailedDeclarationRetryInterval(int)
+	 * @see #setFailedDeclarationRetryInterval(long)
+	 * @since 1.3.9
 	 */
 	public void setDeclarationRetries(int declarationRetries) {
 		this.declarationRetries = declarationRetries;
@@ -565,6 +566,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 * Set the interval between passive queue declaration attempts in milliseconds.
 	 * @param failedDeclarationRetryInterval the interval, default 5000.
 	 * @see #setDeclarationRetries(int)
+	 * @since 1.3.9
 	 */
 	public void setFailedDeclarationRetryInterval(long failedDeclarationRetryInterval) {
 		this.failedDeclarationRetryInterval = failedDeclarationRetryInterval;
@@ -574,6 +576,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 * When consuming multiple queues, set the interval between declaration attempts when only
 	 * a subset of the queues were available (milliseconds).
 	 * @param retryDeclarationInterval the interval, default 60000.
+	 * @since 1.3.9
 	 */
 	public void setRetryDeclarationInterval(long retryDeclarationInterval) {
 		this.retryDeclarationInterval = retryDeclarationInterval;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -170,6 +170,12 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	private ContainerDelegate proxy = delegate;
 
+	private Integer declarationRetries;
+
+	private Long failedDeclarationRetryInterval;
+
+	private Long retryDeclarationInterval;
+
 	/**
 	 * Default constructor for convenient dependency injection via setters.
 	 */
@@ -547,6 +553,33 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
+	 * Set the number of retries after passive queue declaration fails.
+	 * @param declarationRetries The number of retries, default 3.
+	 * @see #setFailedDeclarationRetryInterval(int)
+	 */
+	public void setDeclarationRetries(int declarationRetries) {
+		this.declarationRetries = declarationRetries;
+	}
+
+	/**
+	 * Set the interval between passive queue declaration attempts in milliseconds.
+	 * @param failedDeclarationRetryInterval the interval, default 5000.
+	 * @see #setDeclarationRetries(int)
+	 */
+	public void setFailedDeclarationRetryInterval(long failedDeclarationRetryInterval) {
+		this.failedDeclarationRetryInterval = failedDeclarationRetryInterval;
+	}
+
+	/**
+	 * When consuming multiple queues, set the interval between declaration attempts when only
+	 * a subset of the queues were available (milliseconds).
+	 * @param retryDeclarationInterval the interval, default 60000.
+	 */
+	public void setRetryDeclarationInterval(long retryDeclarationInterval) {
+		this.retryDeclarationInterval = retryDeclarationInterval;
+	}
+
+	/**
 	 * Avoid the possibility of not configuring the CachingConnectionFactory in sync with the number of concurrent
 	 * consumers.
 	 */
@@ -852,6 +885,15 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		consumer = new BlockingQueueConsumer(getConnectionFactory(), this.messagePropertiesConverter, cancellationLock,
 				getAcknowledgeMode(), isChannelTransacted(), actualPrefetchCount, this.defaultRequeueRejected,
 				this.consumerArgs, this.exclusive, queues);
+		if (this.declarationRetries != null) {
+			consumer.setDeclarationRetries(this.declarationRetries);
+		}
+		if (this.failedDeclarationRetryInterval != null) {
+			consumer.setFailedDeclarationRetryInterval(this.failedDeclarationRetryInterval);
+		}
+		if (this.retryDeclarationInterval != null) {
+			consumer.setRetryDeclarationInterval(this.retryDeclarationInterval);
+		}
 		return consumer;
 	}
 

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
@@ -706,6 +706,33 @@
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="declaration-retries" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The number of times to attempt passive queue declarations during consumer initialization (or when attempting
+	to declare additional queues when only a subset were available during initialization). Default: 3.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="failed-declaration-retry-interval" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The interval, in milliseconds, between passive queue declaration attempts during consumer initialization
+	(or when attempting to declare additional queues when only a subset were available during initialization).
+	Default: 5000.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="missing-queue-retry-interval" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The interval, in milliseconds, between passive queue declaration attempts when multiple queues are being
+	used and only a subset of those queues were available during initialization. When this interval expires,
+	any missing queues will be attempted to be declared, according to the 'declaration-retries' and
+	'failed-declaration-retry-interval' settings. Default: 60000.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="auto-declare" default="true">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
@@ -93,6 +93,9 @@ public class ListenerContainerParserTests {
 		assertFalse(TestUtils.getPropertyValue(container, "exclusive", Boolean.class));
 		assertFalse(TestUtils.getPropertyValue(container, "missingQueuesFatal", Boolean.class));
 		assertTrue(TestUtils.getPropertyValue(container, "autoDeclare", Boolean.class));
+		assertEquals(5, TestUtils.getPropertyValue(container, "declarationRetries"));
+		assertEquals(1000L, TestUtils.getPropertyValue(container, "failedDeclarationRetryInterval"));
+		assertEquals(30000L, TestUtils.getPropertyValue(container, "retryDeclarationInterval"));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -113,6 +113,9 @@ public class BlockingQueueConsumerTests {
 
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		when(connection.createChannel(Mockito.anyBoolean())).thenReturn(channel);
+		com.rabbitmq.client.Connection rabbitConnection = mock(com.rabbitmq.client.Connection.class);
+		when(rabbitConnection.isOpen()).thenReturn(true);
+		when(channel.getConnection()).thenReturn(rabbitConnection);
 		when(channel.queueDeclarePassive(Mockito.anyString()))
 				.then(new Answer<Object>() {
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -390,6 +390,7 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		container.setMissingQueuesFatal(false);
 		container.setDeclarationRetries(1);
 		container.setFailedDeclarationRetryInterval(100);
+		container.setRetryDeclarationInterval(30000);
 		container.afterPropertiesSet();
 		container.start();
 
@@ -397,6 +398,13 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		this.template.convertAndSend(queue.getName(), "foo");
 
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+		// verify properties propagated to consumer
+		BlockingQueueConsumer consumer = (BlockingQueueConsumer) TestUtils
+				.getPropertyValue(container, "consumers", Map.class).keySet().iterator().next();
+		assertEquals(1, TestUtils.getPropertyValue(consumer, "declarationRetries"));
+		assertEquals(100L, TestUtils.getPropertyValue(consumer, "failedDeclarationRetryInterval"));
+		assertEquals(30000L, TestUtils.getPropertyValue(consumer, "retryDeclarationInterval"));
 
 		container.stop();
 	}

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -13,7 +13,8 @@
 
 	<rabbit:listener-container id="container1" connection-factory="connectionFactory" acknowledge="manual" concurrency="5"
 			max-concurrency="6" receive-timeout="9876" recovery-interval="5555" missing-queues-fatal="false"
-			min-start-interval="1234" min-stop-interval="2345" min-consecutive-active="12" min-consecutive-idle="34">
+			min-start-interval="1234" min-stop-interval="2345" min-consecutive-active="12" min-consecutive-idle="34"
+			declaration-retries="5" failed-declaration-retry-interval="1000" missing-queue-retry-interval="30000">
 		<rabbit:listener queue-names="foo, #{bar.name}" ref="testBean" method="handle" priority="10" />
 	</rabbit:listener-container>
 

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -2742,14 +2742,14 @@ public RabbitTransactionManager rabbitTransactionManager() {
               <para>When set to <code>true</code> (default), if none of the configured
               queues are available on the broker, it is considered fatal. This causes
               the application context to fail to initialize during startup; also, when the queues
-              are deleted while the container is running, the consumers make 3 attempts
+              are deleted while the container is running, by default, the consumers make 3 retries
               to connect to the queues (at 5 second intervals) and stop the container
               if these attempts fail.</para>
               <para>This was not configurable in previous versions.</para>
-              <para>When set to <code>false</code>, after making the 3 attempts, the container
+              <para>When set to <code>false</code>, after making the 3 retries, the container
               will go into recovery mode, as with other problems, such as the broker being
               down. The container will attempt to recover according to the <code>recoveryInterval</code>
-              property. During each recovery attempt, each consumer will again try 3 times
+              property. During each recovery attempt, each consumer will again try 4 times
               to passively declare the queues at 5 second intervals. This process will
               continue indefinitely.</para>
               <para>You can also use a properties bean to set the property
@@ -2759,10 +2759,13 @@ public RabbitTransactionManager rabbitTransactionManager() {
 </util:properties>]]></programlisting>
               <para>This global property will not be applied to any containers that have an explicit
               <code>missingQueuesFatal</code> property set.</para>
+              <para>The default retry properties (3 retries at 5 second intervals)
+              can be overridden using the properties below.</para>
               </entry>
             </row>
 			  <row>
-				  <entry><literallayout>autoDeclare (auto-declare)</literallayout></entry>
+				  <entry><literallayout>autoDeclare
+(auto-declare)</literallayout></entry>
 
 				  <entry><para>Starting with <emphasis>version 1.4</emphasis>,
 					  <classname>SimpleMessageListenerContainer</classname> has this new
@@ -2777,6 +2780,56 @@ public RabbitTransactionManager rabbitTransactionManager() {
 					</para>
 				  </entry>
 			  </row>
+			<row>
+				<entry><literallayout>declarationRetries
+(declaration-retries)</literallayout></entry>
+
+				<entry><para>Starting with <emphasis>versions 1.4.3, 1.3.9</emphasis>,
+					<classname>SimpleMessageListenerContainer</classname> has this new
+					property. The namespace attribute is available in <emphasis>version 1.5.</emphasis></para>
+					<para>
+						The number of retry attempts when passive queue declaration fails. Passive queue
+						declaration occurs when the consumer starts or, when consuming from multiple queues,
+						when not all queues were available during initialization. When none of the configured
+						queues can be passively declared (for any reason) after the retries are exhausted,
+						the container behavior is controlled by the 'missingQueuesFatal` property above.
+						Default: 3 retries (4 attempts).
+					</para>
+				</entry>
+			</row>
+			<row>
+				<entry><literallayout>failedDeclarationRetryInterval
+(failed-declaration-retry-interval)</literallayout></entry>
+
+				<entry><para>Starting with <emphasis>versions 1.4.3, 1.3.9</emphasis>,
+					<classname>SimpleMessageListenerContainer</classname> has this new
+					property. The namespace attribute is available in <emphasis>version 1.5.</emphasis></para>
+					<para>
+						The interval between passive queue declaration retry attempts. Passive queue
+						declaration occurs when the consumer starts or, when consuming from multiple queues,
+						when not all queues were available during initialization. Default: 5000
+						(5 seconds).
+					</para>
+				</entry>
+			</row>
+			<row>
+				<entry><literallayout>retryDeclarationInterval
+(missing-queue-retry-interval)</literallayout></entry>
+
+				<entry><para>Starting with <emphasis>versions 1.4.3, 1.3.9</emphasis>,
+					<classname>SimpleMessageListenerContainer</classname> has this new
+					property. The namespace attribute is available in <emphasis>version 1.5.</emphasis></para>
+					<para>
+						If a subset of the configured queues are available during consumer initialization,
+						the consumer starts consuming from those queues. The consumer will attempt to
+						passively declare the missing queues using this interval. When this interval elapses,
+						the 'declarationRetries' and 'failedDeclarationRetryInterval' will again be used.
+						If there are still missing queues, the consumer will again wait for this
+						interval before trying again. This process will continue indefinitely until
+						all queues are available. Default: 60000 (1 minute).
+					</para>
+				</entry>
+			</row>
           </tbody>
         </tgroup>
       </table></para>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -14,6 +14,26 @@
 				treated the same a null, and the host/port will be used.
 			</para>
 		</section>
+		<section>
+			<title>Properties to Control Container Queue Declaration Behavior</title>
+			<para>
+				When the listener container consumers start, they attempt to passively
+				declare the queues to ensure they are available on the broker.
+				Previously, if these declarations failed, for example because the queues
+				didn't exist, or when an HA queue was being moved, the retry logic
+				was fixed at 3 retry attempts at 5 second intervals. If the queue(s) still
+				do not exist, the behavior is controlled by the
+				<code>missingQueuesFatal</code> property (default true). Also, for containers
+				configured to listen from multiple queues, if only a subset of queues are
+				available, the consumer retried the missing queues on a fixed interval
+				of 60 seconds.
+			</para>
+			<para>
+				These 3 properties (<code>declarationRetries, failedDeclarationRetryInterval,
+				retryDeclarationInterval</code>) are now configurable. See
+				<xref linkend="containerAttributes" /> for more information.
+			</para>
+		</section>
 	</section>
 	<section>
 		<title>Changes in 1.4 Since 1.3</title>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-472

Add namespace support for consumer queue declaration retry properties.


__master only - depends on #257 - will need rebase if polish is needed there__.