### PR TITLE
AMQP-473: Add REST RabbitManagementTemplate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ subprojects { subproject ->
 		commonsIoVersion = '2.4'
 		erlangOtpVersion = '1.5.6'
 		hamcrestVersion = '1.3'
+		httpClientVersion = "4.3.6"
 		jacksonVersion = '1.9.13'
 		jackson2Version = '2.3.2'
 		junitVersion = '4.11'
@@ -175,6 +176,8 @@ project('spring-amqp') {
 	dependencies {
 
 		compile "org.springframework:spring-core:$springVersion"
+		compile "org.springframework:spring-web:$springVersion"
+		compile "org.apache.httpcomponents:httpclient:$httpClientVersion"
 		compile ("org.springframework:spring-messaging:$springVersion", optional)
 		compile ("org.springframework:spring-oxm:$springVersion", optional)
 		compile ("org.springframework:spring-context:$springVersion", optional)

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ project('spring-amqp') {
 	dependencies {
 
 		compile "org.springframework:spring-core:$springVersion"
-		compile "org.springframework:spring-web:$springVersion"
 		compile ("org.springframework:spring-messaging:$springVersion", optional)
 		compile ("org.springframework:spring-oxm:$springVersion", optional)
 		compile ("org.springframework:spring-context:$springVersion", optional)
@@ -212,6 +211,7 @@ project('spring-rabbit') {
 		compile "com.rabbitmq:amqp-client:$rabbitmqVersion"
 
 		compile ("org.springframework:spring-aop:$springVersion", optional)
+		compile ("org.springframework:spring-web:$springVersion", optional)
 		compile ("org.apache.httpcomponents:httpclient:$httpClientVersion", optional)
 		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-messaging:$springVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,6 @@ project('spring-amqp') {
 
 		compile "org.springframework:spring-core:$springVersion"
 		compile "org.springframework:spring-web:$springVersion"
-		compile "org.apache.httpcomponents:httpclient:$httpClientVersion"
 		compile ("org.springframework:spring-messaging:$springVersion", optional)
 		compile ("org.springframework:spring-oxm:$springVersion", optional)
 		compile ("org.springframework:spring-context:$springVersion", optional)
@@ -213,6 +212,7 @@ project('spring-rabbit') {
 		compile "com.rabbitmq:amqp-client:$rabbitmqVersion"
 
 		compile ("org.springframework:spring-aop:$springVersion", optional)
+		compile ("org.apache.httpcomponents:httpclient:$httpClientVersion", optional)
 		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-messaging:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractDeclarable.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractDeclarable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.springframework.util.Assert;
 
@@ -34,6 +35,12 @@ public abstract class AbstractDeclarable implements Declarable {
 	private volatile boolean shouldDeclare = true;
 
 	private volatile Collection<Object> declaringAdmins = new ArrayList<Object>();
+
+	private final Map<String, Object> properties;
+
+	public AbstractDeclarable(Map<String, Object> properties) {
+		this.properties = properties;
+	}
 
 	@Override
 	public boolean shouldDeclare() {
@@ -75,4 +82,14 @@ public abstract class AbstractDeclarable implements Declarable {
 		}
 		this.declaringAdmins = declaringAdmins;
 	}
+
+	/**
+	 * Get additional properties returned by the broker over the REST API.
+	 * @return the properties.
+	 * @since 1.5
+	 */
+	public Map<String, Object> getProperties() {
+		return properties;
+	}
+
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,12 @@ public abstract class AbstractExchange extends AbstractDeclarable implements Exc
 	 * @param arguments the arguments used to declare the exchange
 	 */
 	public AbstractExchange(String name, boolean durable, boolean autoDelete, Map<String, Object> arguments) {
-		super();
+		this(name, durable, autoDelete, arguments, null);
+	}
+
+	public AbstractExchange(String name, boolean durable, boolean autoDelete, Map<String, Object> arguments,
+			Map<String, Object> properties) {
+		super(properties);
 		this.name = name;
 		this.durable = durable;
 		this.autoDelete = autoDelete;
@@ -77,16 +82,20 @@ public abstract class AbstractExchange extends AbstractDeclarable implements Exc
 		}
 	}
 
+	@Override
 	public abstract String getType();
 
+	@Override
 	public String getName() {
 		return name;
 	}
 
+	@Override
 	public boolean isDurable() {
 		return durable;
 	}
 
+	@Override
 	public boolean isAutoDelete() {
 		return autoDelete;
 	}
@@ -98,6 +107,7 @@ public abstract class AbstractExchange extends AbstractDeclarable implements Exc
 	 * Return the collection of arbitrary arguments to use when declaring an exchange.
 	 * @return the collection of arbitrary arguments to use when declaring an exchange.
 	 */
+	@Override
 	public Map<String, Object> getArguments() {
 		return arguments;
 	}

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Binding.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -45,6 +45,12 @@ public class Binding extends AbstractDeclarable {
 
 	public Binding(String destination, DestinationType destinationType, String exchange, String routingKey,
 			Map<String, Object> arguments) {
+		this(destination, destinationType, exchange, routingKey, arguments, null);
+	}
+
+	public Binding(String destination, DestinationType destinationType, String exchange, String routingKey,
+			Map<String, Object> arguments, Map<String, Object> properties) {
+		super(properties);
 		this.destination = destination;
 		this.destinationType = destinationType;
 		this.exchange = exchange;
@@ -78,7 +84,9 @@ public class Binding extends AbstractDeclarable {
 
 	@Override
 	public String toString() {
-		return "Binding [destination=" + destination + ", exchange=" + exchange + ", routingKey=" + routingKey + "]";
+		return "Binding [destination=" + destination
+				+ ", destinationType=" + destinationType
+				+ ", exchange=" + exchange + ", routingKey=" + routingKey + "]";
 	}
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/DirectExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/DirectExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,11 @@ public class DirectExchange extends AbstractExchange {
 
 	public DirectExchange(String name, boolean durable, boolean autoDelete, Map<String,Object> arguments) {
 		super(name, durable, autoDelete, arguments);
+	}
+
+	public DirectExchange(String name, boolean durable, boolean autoDelete, Map<String, Object> arguments,
+			Map<String, Object> properties) {
+		super(name, durable, autoDelete, arguments, properties);
 	}
 
 	@Override

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/FanoutExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/FanoutExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ public class FanoutExchange extends AbstractExchange {
 
 	public FanoutExchange(String name, boolean durable, boolean autoDelete, Map<String,Object> arguments) {
 		super(name, durable, autoDelete, arguments);
+	}
+
+	public FanoutExchange(String name, boolean durable, boolean autoDelete, Map<String, Object> arguments,
+			Map<String, Object> properties) {
+		super(name, durable, autoDelete, arguments, properties);
 	}
 
 	@Override

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/HeadersExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/HeadersExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,11 @@ public class HeadersExchange extends AbstractExchange {
 
 	public HeadersExchange(String name, boolean durable, boolean autoDelete, Map<String,Object> arguments) {
 		super(name, durable, autoDelete, arguments);
+	}
+
+	public HeadersExchange(String name, boolean durable, boolean autoDelete, Map<String, Object> arguments,
+			Map<String, Object> properties) {
+		super(name, durable, autoDelete, arguments, properties);
 	}
 
 	@Override

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Queue.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Queue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -77,6 +77,23 @@ public class Queue extends AbstractDeclarable {
 	 * @param arguments the arguments used to declare the queue
 	 */
 	public Queue(String name, boolean durable, boolean exclusive, boolean autoDelete, Map<String, Object> arguments) {
+		this(name, durable, exclusive, autoDelete, arguments, null);
+	}
+
+	/**
+	 * Construct a new queue, given a name, durability flag, and auto-delete flag, and arguments.
+	 * @param name the name of the queue - must not be null; set to "" to have the broker generate the name.
+	 * @param durable true if we are declaring a durable queue (the queue will survive a server restart)
+	 * @param exclusive true if we are declaring an exclusive queue (the queue will only be used by the declarer's
+	 * connection)
+	 * @param autoDelete true if the server should delete the queue when it is no longer in use
+	 * @param arguments the arguments used to declare the queue
+	 * @param properties addition properties returned over REST by the broker
+	 *
+	 */
+	public Queue(String name, boolean durable, boolean exclusive, boolean autoDelete, Map<String, Object> arguments,
+			Map<String, Object> properties) {
+		super(properties);
 		Assert.notNull(name, "'name' cannot be null");
 		this.name = name;
 		this.durable = durable;

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Queue.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Queue.java
@@ -89,7 +89,7 @@ public class Queue extends AbstractDeclarable {
 	 * @param autoDelete true if the server should delete the queue when it is no longer in use
 	 * @param arguments the arguments used to declare the queue
 	 * @param properties addition properties returned over REST by the broker
-	 *
+	 * @since 1.5
 	 */
 	public Queue(String name, boolean durable, boolean exclusive, boolean autoDelete, Map<String, Object> arguments,
 			Map<String, Object> properties) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/TopicExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/TopicExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ public class TopicExchange extends AbstractExchange {
 
 	public TopicExchange(String name, boolean durable, boolean autoDelete, Map<String,Object> arguments) {
 		super(name, durable, autoDelete, arguments);
+	}
+
+	public TopicExchange(String name, boolean durable, boolean autoDelete, Map<String, Object> arguments,
+			Map<String, Object> properties) {
+		super(name, durable, autoDelete, arguments, properties);
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplate.java
@@ -330,10 +330,7 @@ public class RabbitManagementTemplate {
 	public static Queue queueMapToQueue(Map<String, Object> map) {
 		String name = (String) map.get("name");
 		boolean durable = (Boolean) map.get("durable");
-		Boolean exclusive = (Boolean) map.get("exclusive");
-		if (exclusive == null) {
-			exclusive = false;
-		}
+		boolean exclusive = map.get("owner_pid_details") != null;
 		boolean autoDelete = (Boolean) map.get("auto_delete");
 		@SuppressWarnings("unchecked")
 		Map<String, Object> arguments = (Map<String, Object>) map.get("arguments");

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplate.java
@@ -49,13 +49,18 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
+ * Use this class to interract with the RabbitMQ management plugin over its REST
+ * API. It does NOT support messaging over that API or declaring/removing queues, exchanges
+ * or bindings. Use {@link RabbitAdmin} for declaring/removing entities and the
+ * {@link RabbitTemplate} or a message listener container for messaging.
+ *
  * @author Gary Russell
  * @since 1.5
- *
  */
 public class RabbitManagementTemplate {
 
@@ -63,17 +68,27 @@ public class RabbitManagementTemplate {
 
 	private final String baseUri;
 
+	/**
+	 * Create a template with the default base URI and credentials.
+	 */
 	public RabbitManagementTemplate() {
 		this("http://localhost:15672/api/", "guest", "guest");
 	}
 
+	/**
+	 * Create a template with the supplied base URI and credentials.
+	 * @param baseUri the uri with the form {@code http[s]://<host>:<port>/api/};
+	 * default {@code http://localhost:15672/api/}.
+	 * @param user the user.
+	 * @param password the password.
+	 */
 	public RabbitManagementTemplate(String baseUri, String user, String password) {
 		CredentialsProvider credsProvider = new BasicCredentialsProvider();
 		credsProvider.setCredentials(
 				new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT),
 				new UsernamePasswordCredentials(user, password));
 		HttpClient httpClient = HttpClients.custom().setDefaultCredentialsProvider(credsProvider).build();
-		// Set up pre-emptive basic Auth because it seems the rabbit plugin doesn't support challenge/response for PUT
+		// Set up pre-emptive basic Auth because the rabbit plugin doesn't currently support challenge/response for PUT
 		// Create AuthCache instance
 		AuthCache authCache = new BasicAuthCache();
 		// Generate BASIC scheme object and add it to the local; from the apache docs...
@@ -104,29 +119,56 @@ public class RabbitManagementTemplate {
 		this.baseUri = baseUri;
 	}
 
-	public Map<String, Object> aliveness() {
+	/**
+	 * Invoke the {@code /aliveness/<vhost>} method with the default '/' vhost.
+	 * @return A map of keys.values; currently &#123;status: ok&#125; for success.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public Map<String, Object> aliveness() throws HttpClientErrorException {
 		return aliveness("/");
 	}
 
+	/**
+	 * Invoke the {@code /aliveness/<vhost>}.
+	 * @param vhost the vhost.
+	 * @return A map of keys/values; currently &#123;status: ok&#125; for success.
+	 * @throws HttpClientErrorException the exception.
+	 */
 	@SuppressWarnings("unchecked")
-	public Map<String, Object> aliveness(String vhost) {
+	public Map<String, Object> aliveness(String vhost) throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("aliveness-test", "{vhost}")
 				.buildAndExpand(vhost).encode().toUri();
 		return this.restTemplate.getForObject(uri, Map.class);
 	}
 
+	/**
+	 * Invoke the {@code /overview} method.
+	 * @return A map of keys/values.
+	 * @throws HttpClientErrorException the exception.
+	 */
 	@SuppressWarnings("unchecked")
-	public Map<String, Object> overview() {
+	public Map<String, Object> overview() throws HttpClientErrorException {
 		return this.restTemplate.getForObject(baseUri + "overview", Map.class);
 	}
 
-	public List<Policy> policies() {
+	/**
+	 * Invoke the {@code /policies} method.
+	 * @return A list of all {@link Policy}s.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Policy> policies() throws HttpClientErrorException {
 		@SuppressWarnings("unchecked")
 		List<Map<String, Object>> policies = this.restTemplate.getForObject(this.baseUri + "policies", List.class);
 		return policyMapsToPolicies(policies);
 	}
 
-	public List<Policy> policies(String vhost) {
+	/**
+	 * Invoke the {@code /policies/<vhost>} method.
+	 * @param vhost the vhost.
+	 * @return A list of all {@link Policy}s for the vhost.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Policy> policies(String vhost) throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("policies", "{vhost}")
 				.buildAndExpand(vhost).encode().toUri();
 		@SuppressWarnings("unchecked")
@@ -134,33 +176,62 @@ public class RabbitManagementTemplate {
 		return policyMapsToPolicies(policies);
 	}
 
-	public void addPolicy(Policy policy) {
+	/**
+	 * Add a new {@link Policy}.
+	 * @param policy the policy.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public void addPolicy(Policy policy) throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("policies", "{vhost}", "{name}")
 				.buildAndExpand(policy.getVhost(), policy.getName()).encode().toUri();
 		this.restTemplate.put(uri, policy);
 	}
 
-	public void removePolicy(String vhost, String name) {
+	/**
+	 * Remove a {@link Policy} from the vhost.
+	 * @param vhost the vhost.
+	 * @param name the policy name.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public void removePolicy(String vhost, String name) throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("policies", "{vhost}", "{name}")
 				.buildAndExpand(vhost, name).encode().toUri();
 		this.restTemplate.delete(uri);
 	}
 
-	public List<Exchange> exchanges() {
+	/**
+	 * Invoke the {@code /exchanges} method.
+	 * @return A list of all {@link Exchange}s.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Exchange> exchanges() throws HttpClientErrorException {
 		@SuppressWarnings("unchecked")
 		List<Map<String, Object>> exchangeMaps = this.restTemplate.getForObject(baseUri + "exchanges", List.class);
 		return exchangeMapsToExchanges(exchangeMaps);
 	}
 
+	/**
+	 * Invoke the {@code /exchanges/<vhost>} method.
+	 * @param vhost the vhost.
+	 * @return A list of all {@link Exchange}s for the vhost.
+	 * @throws HttpClientErrorException the exception.
+	 */
 	@SuppressWarnings("unchecked")
-	public List<Exchange> exchanges(String vhost) {
+	public List<Exchange> exchanges(String vhost) throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("exchanges", "{vhost}")
 				.buildAndExpand(vhost).encode().toUri();
 		List<Map<String, Object>> exchangeMaps = this.restTemplate.getForObject(uri, List.class);
 		return exchangeMapsToExchanges(exchangeMaps);
 	}
 
-	public Exchange exchange(String vhost, String exchange) {
+	/**
+	 * Invoke the {@code /exchanges/<vhost>/<exchange>} method.
+	 * @param vhost the vhost.
+	 * @param exchange the exchange name.
+	 * @return the exchange.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public Exchange exchange(String vhost, String exchange) throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("exchanges", "{vhost}", "{exchange}")
 				.buildAndExpand(vhost, exchange).encode().toUri();
 		@SuppressWarnings("unchecked")
@@ -168,13 +239,24 @@ public class RabbitManagementTemplate {
 		return exchangeMapToExchange(map);
 	}
 
-	public List<Queue> queues() {
+	/**
+	 * Invoke the {@code /queues} method.
+	 * @return A list of all {@link Queues}s.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Queue> queues() throws HttpClientErrorException {
 		@SuppressWarnings("unchecked")
 		List<Map<String, Object>> queueMaps = this.restTemplate.getForObject(baseUri + "queues", List.class);
 		return queueMapsToQueues(queueMaps);
 	}
 
-	public List<Queue> queues(String vhost) {
+	/**
+	 * Invoke the {@code /queues/<vhost>} method.
+	 * @param vhost the vhost.
+	 * @return A list of all {@link Queues}s for the vhost.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Queue> queues(String vhost) throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("queues", "{vhost}")
 				.buildAndExpand(vhost).encode().toUri();
 		@SuppressWarnings("unchecked")
@@ -182,7 +264,14 @@ public class RabbitManagementTemplate {
 		return queueMapsToQueues(queueMaps);
 	}
 
-	public Queue queue(String vhost, String queue) {
+	/**
+	 * Invoke the {@code /queue/<vhost>/<queue>} method.
+	 * @param vhost the vhost.
+	 * @param queue the queue name.
+	 * @return the queue.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public Queue queue(String vhost, String queue) throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("queues", "{vhost}", "{queue}")
 				.buildAndExpand(vhost, queue).encode().toUri();
 		@SuppressWarnings("unchecked")
@@ -190,13 +279,24 @@ public class RabbitManagementTemplate {
 		return queueMapToQueue(map);
 	}
 
-	public List<Binding> bindings() {
+	/**
+	 * Invoke the {@code /bindings} method.
+	 * @return A list of all {@link Binding}s.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Binding> bindings() throws HttpClientErrorException {
 		@SuppressWarnings("unchecked")
 		List<Map<String, Object>> bindingMaps = this.restTemplate.getForObject(baseUri + "bindings", List.class);
 		return bindingMapsToBindings(bindingMaps);
 	}
 
-	public List<Binding> bindings(String vhost) {
+	/**
+	 * Invoke the {@code /bindings/<vhost>} method.
+	 * @param vhost the vhost.
+	 * @return A list of all {@link Binding}s for the vhost.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Binding> bindings(String vhost) throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("bindings", "{vhost}")
 				.buildAndExpand(vhost).encode().toUri();
 		@SuppressWarnings("unchecked")
@@ -204,7 +304,16 @@ public class RabbitManagementTemplate {
 		return bindingMapsToBindings(bindingMaps);
 	}
 
-	public List<Binding> exchangeToQueueBindings(String vhost, String exchange, String queue) {
+	/**
+	 * Invoke the {@code /bindings/<vhost>/e/<exhange>/q/<queue>} method.
+	 * @param vhost the vhost.
+	 * @param exchange the exchange name.
+	 * @param queue the queue name.
+	 * @return a list of the {@link Binding}s from the exchange to the queue.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Binding> exchangeToQueueBindings(String vhost, String exchange, String queue)
+			throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri)
 				.pathSegment("bindings", "{vhost}", "e", "{exchange}", "q", "{queue}")
 				.buildAndExpand(vhost, exchange, queue).encode().toUri();
@@ -213,7 +322,16 @@ public class RabbitManagementTemplate {
 		return bindingMapsToBindings(list);
 	}
 
-	public List<Binding> exchangeToExchangeBindings(String vhost, String source, String dest) {
+	/**
+	 * Invoke the {@code /bindings/<vhost>/e/<exhange>/e/<destination>} method.
+	 * @param vhost the vhost.
+	 * @param source the source exchange name.
+	 * @param dest the destination exchange name.
+	 * @return a list of the {@link Binding}s from the source exchange to the destination exchange.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Binding> exchangeToExchangeBindings(String vhost, String source, String dest)
+			throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri)
 				.pathSegment("bindings", "{vhost}", "e", "{source}", "e", "{dest}")
 				.buildAndExpand(vhost, source, dest).encode().toUri();
@@ -222,15 +340,30 @@ public class RabbitManagementTemplate {
 		return bindingMapsToBindings(list);
 	}
 
-	public List<Binding> exchangeSourceBindings(String vhost, String exchange) {
+	/**
+	 * Invoke the {@code /bindings/<vhost>/<exhange>/source} method.
+	 * @param vhost the vhost.
+	 * @param exchange the source exchange name.
+	 * @return a list of all the {@link Binding}s for the source exchange.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Binding> exchangeSourceBindings(String vhost, String exchange) throws HttpClientErrorException {
 		return exchangeBindings(vhost, exchange, "source");
 	}
 
-	public List<Binding> exchangeDestBindings(String vhost, String exchange) {
+	/**
+	 * Invoke the {@code /bindings/<vhost>/<exhange>/destination} method.
+	 * @param vhost the vhost.
+	 * @param exchange the destination exchange name.
+	 * @return a list of all the {@link Binding}s where the exchange is the destination.
+	 * @throws HttpClientErrorException the exception.
+	 */
+	public List<Binding> exchangeDestBindings(String vhost, String exchange) throws HttpClientErrorException {
 		return exchangeBindings(vhost, exchange, "destination");
 	}
 
-	private List<Binding> exchangeBindings(String vhost, String exchange, String which) {
+	private List<Binding> exchangeBindings(String vhost, String exchange, String which)
+			throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri)
 				.pathSegment("exchanges", "{vhost}", "{exchange}", "bindings", which)
 				.buildAndExpand(vhost, exchange).encode().toUri();
@@ -243,31 +376,48 @@ public class RabbitManagementTemplate {
 	 * Use this to invoke any general GET operation. Useful when invoking methods not supported
 	 * by a specific method on this class.
 	 * @param returnType the return type, usually {@link List} or {@link Map}.
-	 * @param pathSegments the path segments/variable holders, e.g. {@code new String[] { "connections", "{name}" }.
+	 * @param pathSegments the path segments/variable place holders, e.g. {@code new String[] { "connections", "{name}" }.
 	 * @param uriVariables variables to insert into path place holders.
 	 * @return the result.
+	 * @throws HttpClientErrorException the exception.
 	 */
-	public <T> T executeGet(Class<T> returnType, String[] pathSegments, Object... uriVariables) {
+	public <T> T executeGet(Class<T> returnType, String[] pathSegments, Object... uriVariables)
+			throws HttpClientErrorException {
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment(pathSegments)
 				.buildAndExpand(uriVariables).encode().toUri();
 		return this.restTemplate.getForObject(uri, returnType);
 	}
 
-	public static List<Policy> policyMapsToPolicies(List<Map<String, Object>> policies) {
-		List<Policy> list = new ArrayList<Policy>(policies.size());
-		for (Map<String, Object> map : policies) {
+	/**
+	 * A helper method to convert a list of maps containing policy information to {@link Policy} objects.
+	 * @param policysMaps the list of maps.
+	 * @return the list of policies.
+	 */
+	public static List<Policy> policyMapsToPolicies(List<Map<String, Object>> policysMaps) {
+		List<Policy> list = new ArrayList<Policy>(policysMaps.size());
+		for (Map<String, Object> map : policysMaps) {
 			list.add(policyMapToPolicy(map));
 		}
 		return list;
 	}
 
+	/**
+	 * A helper method to convert a map containing policy information to a {@link Policy} object.
+	 * @param policyMap the map.
+	 * @return the {@link Policy}.
+	 */
 	@SuppressWarnings("unchecked")
-	public static Policy policyMapToPolicy(Map<String, Object> map) {
-		return new Policy((String) map.get("vhost"), (String) map.get("name"),
-				(String) map.get("pattern"), (String) map.get("apply_to"), (Integer) map.get("priority"),
-				(Map<String, Object>) map.get("definition"));
+	public static Policy policyMapToPolicy(Map<String, Object> policyMap) {
+		return new Policy((String) policyMap.get("vhost"), (String) policyMap.get("name"),
+				(String) policyMap.get("pattern"), (String) policyMap.get("apply_to"), (Integer) policyMap.get("priority"),
+				(Map<String, Object>) policyMap.get("definition"));
 	}
 
+	/**
+	 * A helper method to convert a list of maps containing exchange information to {@link Exchange} objects.
+	 * @param exchangeMaps the list of maps.
+	 * @return the list of {@link Exchange}s.
+	 */
 	public static List<Exchange> exchangeMapsToExchanges(List<Map<String, Object>> exchangeMaps) {
 		List<Exchange> exchanges = new ArrayList<Exchange>(exchangeMaps.size());
 		for (Map<String, Object> map : exchangeMaps) {
@@ -276,30 +426,35 @@ public class RabbitManagementTemplate {
 		return exchanges;
 	}
 
-	public static Exchange exchangeMapToExchange(Map<String, Object> map) {
+	/**
+	 * A helper method to convert a map containing policy information to a {@link Policy} object.
+	 * @param exchangeMap the map.
+	 * @return the {@link Exchange}.
+	 */
+	public static Exchange exchangeMapToExchange(Map<String, Object> exchangeMap) {
 		AbstractExchange exchange = null;
-		final String type = (String) map.get("type");
-		String name = (String) map.get("name");
-		boolean durable = (Boolean) map.get("durable");
-		boolean autoDelete = (Boolean) map.get("auto_delete");
+		final String type = (String) exchangeMap.get("type");
+		String name = (String) exchangeMap.get("name");
+		boolean durable = (Boolean) exchangeMap.get("durable");
+		boolean autoDelete = (Boolean) exchangeMap.get("auto_delete");
 		@SuppressWarnings("unchecked")
-		Map<String, Object> arguments = (Map<String, Object>) map.get("arguments");
-		map.remove("type");
-		map.remove("name");
-		map.remove("durable");
-		map.remove("auto_delete");
-		map.remove("arguments");
+		Map<String, Object> arguments = (Map<String, Object>) exchangeMap.get("arguments");
+		exchangeMap.remove("type");
+		exchangeMap.remove("name");
+		exchangeMap.remove("durable");
+		exchangeMap.remove("auto_delete");
+		exchangeMap.remove("arguments");
 		if (type.equals("direct")) {
-			exchange = new DirectExchange(name, durable, autoDelete, arguments, map);
+			exchange = new DirectExchange(name, durable, autoDelete, arguments, exchangeMap);
 		}
 		else if (type.equals("topic")) {
-			exchange = new TopicExchange(name, durable, autoDelete, arguments, map);
+			exchange = new TopicExchange(name, durable, autoDelete, arguments, exchangeMap);
 		}
 		else if (type.equals("fanout")) {
-			exchange = new FanoutExchange(name, durable, autoDelete, arguments, map);
+			exchange = new FanoutExchange(name, durable, autoDelete, arguments, exchangeMap);
 		}
 		else if (type.equals("headers")) {
-			exchange = new HeadersExchange(name, durable, autoDelete, arguments, map);
+			exchange = new HeadersExchange(name, durable, autoDelete, arguments, exchangeMap);
 		}
 		else {
 			class UnknownExchange extends AbstractExchange {
@@ -319,6 +474,11 @@ public class RabbitManagementTemplate {
 		return exchange;
 	}
 
+	/**
+	 * A helper method to convert a list of maps containing exchange information to {@link Queue} objects.
+	 * @param queueMaps the list of maps.
+	 * @return the list of {@link Queue}s.
+	 */
 	public static List<Queue> queueMapsToQueues(List<Map<String, Object>> queueMaps) {
 		List<Queue> queues = new ArrayList<Queue>(queueMaps.size());
 		for (Map<String, Object> map : queueMaps) {
@@ -327,6 +487,11 @@ public class RabbitManagementTemplate {
 		return queues;
 	}
 
+	/**
+	 * A helper method to convert a map containing policy information to a {@link Policy} object.
+	 * @param exchangeMap the map.
+	 * @return the {@link Exchange}.
+	 */
 	public static Queue queueMapToQueue(Map<String, Object> map) {
 		String name = (String) map.get("name");
 		boolean durable = (Boolean) map.get("durable");
@@ -341,9 +506,14 @@ public class RabbitManagementTemplate {
 		return new Queue(name, durable, exclusive, autoDelete, arguments, map);
 	}
 
-	public static List<Binding> bindingMapsToBindings(List<Map<String, Object>> list) {
-		List<Binding> bindings = new ArrayList<Binding>(list.size());
-		for (Map<String, Object> map : list) {
+	/**
+	 * A helper method to convert a list of maps containing binding information to {@link Binding} objects.
+	 * @param bindingMaps the list of maps.
+	 * @return the list of {@link Binding}s.
+	 */
+	public static List<Binding> bindingMapsToBindings(List<Map<String, Object>> bindingMaps) {
+		List<Binding> bindings = new ArrayList<Binding>(bindingMaps.size());
+		for (Map<String, Object> map : bindingMaps) {
 			@SuppressWarnings("unchecked")
 			Binding binding = new Binding((String) map.get("destination"),
 					Binding.DestinationType.valueOf(((String) map.get("destination_type")).toUpperCase()),

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplate.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.core;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HttpContext;
+
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.core.AbstractExchange;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.FanoutExchange;
+import org.springframework.amqp.core.HeadersExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.support.Policy;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Gary Russell
+ * @since 1.5
+ *
+ */
+public class RabbitManagementTemplate {
+
+	private final RestTemplate restTemplate;
+
+	private final String baseUri;
+
+	public RabbitManagementTemplate() {
+		this("http://localhost:15672/api/", "guest", "guest");
+	}
+
+	public RabbitManagementTemplate(String baseUri, String user, String password) {
+		CredentialsProvider credsProvider = new BasicCredentialsProvider();
+		credsProvider.setCredentials(
+				new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT),
+				new UsernamePasswordCredentials(user, password));
+		HttpClient httpClient = HttpClients.custom().setDefaultCredentialsProvider(credsProvider).build();
+		// Set up pre-emptive basic Auth because it seems the rabbit plugin doesn't support challenge/response for PUT
+		// Create AuthCache instance
+		AuthCache authCache = new BasicAuthCache();
+		// Generate BASIC scheme object and add it to the local; from the apache docs...
+		// auth cache
+		BasicScheme basicAuth = new BasicScheme();
+		URI uri;
+		try {
+			uri = new URI(baseUri);
+		}
+		catch (URISyntaxException e) {
+			throw new AmqpException("Invalid URI", e);
+		}
+		authCache.put(new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()), basicAuth);
+		// Add AuthCache to the execution context
+		final HttpClientContext localContext = HttpClientContext.create();
+		localContext.setAuthCache(authCache);
+		RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient) {
+
+			@Override
+			protected HttpContext createHttpContext(HttpMethod httpMethod, URI uri) {
+				return localContext;
+			}
+
+		});
+		this.restTemplate = restTemplate;
+		this.baseUri = baseUri;
+	}
+
+	public RabbitManagementTemplate(String baseUri, RestTemplate restTemplate) {
+		this.restTemplate = restTemplate;
+		this.baseUri = baseUri;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Map<String, Object> aliveness(String vhost) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("aliveness-test", "{vhost}")
+				.buildAndExpand(vhost).encode().toUri();
+		return this.restTemplate.getForObject(uri, Map.class);
+	}
+
+	@SuppressWarnings("unchecked")
+	public Map<String, Object> overview() {
+		return this.restTemplate.getForObject(baseUri + "overview", Map.class);
+	}
+
+	public List<Policy> policies() {
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> policies = this.restTemplate.getForObject(this.baseUri + "policies", List.class);
+		return policyMapsToPolicies(policies);
+	}
+
+	public List<Policy> policies(String vhost) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("policies", "{vhost}")
+				.buildAndExpand(vhost).encode().toUri();
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> policies = this.restTemplate.getForObject(uri, List.class);
+		return policyMapsToPolicies(policies);
+	}
+
+	public void addPolicy(Policy policy) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("policies", "{vhost}", "{name}")
+				.buildAndExpand(policy.getVhost(), policy.getName()).encode().toUri();
+		this.restTemplate.put(uri, policy);
+	}
+
+	public void removePolicy(String vhost, String name) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("policies", "{vhost}", "{name}")
+				.buildAndExpand(vhost, name).encode().toUri();
+		this.restTemplate.delete(uri);
+	}
+
+	public List<Exchange> exchanges() {
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> exchangeMaps = this.restTemplate.getForObject(baseUri + "exchanges", List.class);
+		return exchangeMapsToExchanges(exchangeMaps);
+	}
+
+	@SuppressWarnings("unchecked")
+	public List<Exchange> exchanges(String vhost) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("exchanges", "{vhost}")
+				.buildAndExpand(vhost).encode().toUri();
+		List<Map<String, Object>> exchangeMaps = this.restTemplate.getForObject(uri, List.class);
+		return exchangeMapsToExchanges(exchangeMaps);
+	}
+
+	public Exchange exchange(String vhost, String exchange) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("exchanges", "{vhost}", "{exchange}")
+				.buildAndExpand(vhost, exchange).encode().toUri();
+		@SuppressWarnings("unchecked")
+		Map<String, Object> map = this.restTemplate.getForObject(uri, Map.class);
+		return exchangeMapToExchange(map);
+	}
+
+	public List<Queue> queues() {
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> queueMaps = this.restTemplate.getForObject(baseUri + "queues", List.class);
+		return queueMapsToQueues(queueMaps);
+	}
+
+	public List<Queue> queues(String vhost) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("queues", "{vhost}")
+				.buildAndExpand(vhost).encode().toUri();
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> queueMaps = this.restTemplate.getForObject(uri, List.class);
+		return queueMapsToQueues(queueMaps);
+	}
+
+	public Queue queue(String vhost, String exchange) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("queues", "{vhost}", "{queue}")
+				.buildAndExpand(vhost, exchange).encode().toUri();
+		@SuppressWarnings("unchecked")
+		Map<String, Object> map = this.restTemplate.getForObject(uri, Map.class);
+		return queueMapToQueue(map);
+	}
+
+	public List<Binding> bindings() {
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> bindingMaps = this.restTemplate.getForObject(baseUri + "bindings", List.class);
+		return bindingMapsToBindings(bindingMaps);
+	}
+
+	public List<Binding> bindings(String vhost) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment("bindings", "{vhost}")
+				.buildAndExpand(vhost).encode().toUri();
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> bindingMaps = this.restTemplate.getForObject(uri, List.class);
+		return bindingMapsToBindings(bindingMaps);
+	}
+
+	public List<Binding> exchangeToQueueBindings(String vhost, String exchange, String queue) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri)
+				.pathSegment("bindings", "{vhost}", "e", "{exchange}", "q", "{queue}")
+				.buildAndExpand(vhost, exchange, queue).encode().toUri();
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> list = this.restTemplate.getForObject(uri, List.class);
+		return bindingMapsToBindings(list);
+	}
+
+	public List<Binding> exchangeToExchangeBindings(String vhost, String source, String dest) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri)
+				.pathSegment("bindings", "{vhost}", "e", "{source}", "e", "{dest}")
+				.buildAndExpand(vhost, source, dest).encode().toUri();
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> list = this.restTemplate.getForObject(uri, List.class);
+		return bindingMapsToBindings(list);
+	}
+
+	public List<Binding> exchangeSourceBindings(String vhost, String exchange) {
+		return exchangeBindings(vhost, exchange, "source");
+	}
+
+	public List<Binding> exchangeDestBindings(String vhost, String exchange) {
+		return exchangeBindings(vhost, exchange, "destination");
+	}
+
+	private List<Binding> exchangeBindings(String vhost, String exchange, String which) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri)
+				.pathSegment("exchanges", "{vhost}", "{exchange}", "bindings", which)
+				.buildAndExpand(vhost, exchange).encode().toUri();
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> list = this.restTemplate.getForObject(uri, List.class);
+		return bindingMapsToBindings(list);
+	}
+
+	/**
+	 * Use this to invoke any general GET operation. Useful when invoking methods not supported
+	 * by a specific method on this class.
+	 * @param returnType the return type, usually {@link List} or {@link Map}.
+	 * @param pathSegments the path segments/variable holders, e.g. {@code new String[] { "connections", "{name}" }.
+	 * @param uriVariables variables to insert into path place holders.
+	 * @return the result.
+	 */
+	public <T> T executeGet(Class<T> returnType, String[] pathSegments, Object... uriVariables) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri).pathSegment(pathSegments)
+				.buildAndExpand(uriVariables).encode().toUri();
+		return this.restTemplate.getForObject(uri, returnType);
+	}
+
+	public static List<Policy> policyMapsToPolicies(List<Map<String, Object>> policies) {
+		List<Policy> list = new ArrayList<Policy>(policies.size());
+		for (Map<String, Object> map : policies) {
+			list.add(policyMapToPolicy(map));
+		}
+		return list;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static Policy policyMapToPolicy(Map<String, Object> map) {
+		return new Policy((String) map.get("vhost"), (String) map.get("name"),
+				(String) map.get("pattern"), (String) map.get("apply_to"), (Integer) map.get("priority"),
+				(Map<String, Object>) map.get("definition"));
+	}
+
+	public static List<Exchange> exchangeMapsToExchanges(List<Map<String, Object>> exchangeMaps) {
+		List<Exchange> exchanges = new ArrayList<Exchange>(exchangeMaps.size());
+		for (Map<String, Object> map : exchangeMaps) {
+			exchanges.add(exchangeMapToExchange(map));
+		}
+		return exchanges;
+	}
+
+	public static Exchange exchangeMapToExchange(Map<String, Object> map) {
+		AbstractExchange exchange = null;
+		final String type = (String) map.get("type");
+		String name = (String) map.get("name");
+		boolean durable = (Boolean) map.get("durable");
+		boolean autoDelete = (Boolean) map.get("auto_delete");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> arguments = (Map<String, Object>) map.get("arguments");
+		map.remove("type");
+		map.remove("name");
+		map.remove("durable");
+		map.remove("auto_delete");
+		map.remove("arguments");
+		if (type.equals("direct")) {
+			exchange = new DirectExchange(name, durable, autoDelete, arguments, map);
+		}
+		else if (type.equals("topic")) {
+			exchange = new TopicExchange(name, durable, autoDelete, arguments, map);
+		}
+		else if (type.equals("fanout")) {
+			exchange = new FanoutExchange(name, durable, autoDelete, arguments, map);
+		}
+		else if (type.equals("headers")) {
+			exchange = new HeadersExchange(name, durable, autoDelete, arguments, map);
+		}
+		else {
+			class UnknownExchange extends AbstractExchange {
+
+				public UnknownExchange(String name, boolean durable, boolean autoDelete, Map<String, Object> arguments) {
+					super(name, durable, autoDelete, arguments);
+				}
+
+				@Override
+				public String getType() {
+					return type;
+				}
+
+			}
+			exchange = new UnknownExchange(name, durable, autoDelete, arguments);
+		}
+		return exchange;
+	}
+
+	public static List<Queue> queueMapsToQueues(List<Map<String, Object>> queueMaps) {
+		List<Queue> queues = new ArrayList<Queue>(queueMaps.size());
+		for (Map<String, Object> map : queueMaps) {
+			queues.add(queueMapToQueue(map));
+		}
+		return queues;
+	}
+
+	public static Queue queueMapToQueue(Map<String, Object> map) {
+		String name = (String) map.get("name");
+		boolean durable = (Boolean) map.get("durable");
+		boolean exclusive = false; // not returned (Boolean) map.get("exclusive");
+		boolean autoDelete = (Boolean) map.get("auto_delete");
+		@SuppressWarnings("unchecked")
+		Map<String, Object> arguments = (Map<String, Object>) map.get("arguments");
+		map.remove("name");
+		map.remove("durable");
+		map.remove("auto_delete");
+		map.remove("arguments");
+		return new Queue(name, durable, exclusive, autoDelete, arguments, map);
+	}
+
+	public static List<Binding> bindingMapsToBindings(List<Map<String, Object>> list) {
+		List<Binding> bindings = new ArrayList<Binding>(list.size());
+		for (Map<String, Object> map : list) {
+			@SuppressWarnings("unchecked")
+			Binding binding = new Binding((String) map.get("destination"),
+					Binding.DestinationType.valueOf(((String) map.get("destination_type")).toUpperCase()),
+					(String) map.get("source"),
+					(String) map.get("routing_key"),
+					(Map<String, Object>) map.get("arguments"),
+					map);
+			map.remove("destination");
+			map.remove("destination_type");
+			map.remove("source");
+			map.remove("routine_key");
+			map.remove("arguments");
+			bindings.add(binding);
+		}
+		return bindings;
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/Policy.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/Policy.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Represents a broker policy.
+ * Represents a broker policy; used with the REST API to add or list policies.
  *
  * @author Gary Russell
  * @since 1.5

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/Policy.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/Policy.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.support;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a broker policy.
+ *
+ * @author Gary Russell
+ * @since 1.5
+ *
+ */
+public class Policy {
+
+	private final String vhost;
+
+	private final String name;
+
+	private final String pattern;
+
+	private final String applyTo;
+
+	private final Integer priority;
+
+	private final Map<String, Object> definition;
+
+	public Policy(String vhost, String name, String pattern, String applyTo, Integer priority, Map<String, Object> definition) {
+		this.vhost = vhost;
+		this.name = name;
+		this.pattern = pattern;
+		this.applyTo = applyTo;
+		this.priority = priority;
+		this.definition = definition;
+	}
+
+	public String getVhost() {
+		return vhost;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getPattern() {
+		return pattern;
+	}
+
+	@JsonProperty("apply-to")
+	@JsonInclude(Include.NON_NULL)
+	public String getApplyTo() {
+		return applyTo;
+	}
+
+	@JsonInclude(Include.NON_NULL)
+	public Integer getPriority() {
+		return priority;
+	}
+
+	public Map<String, Object> getDefinition() {
+		return definition;
+	}
+
+	@Override
+	public String toString() {
+		return "Policy [vhost=" + vhost + ", name=" + name + ", pattern=" + pattern + ", applyTo=" + applyTo
+				+ ", priority=" + priority + ", definition=" + definition + "]";
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplateTests.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.core;
+
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.support.Policy;
+import org.springframework.amqp.rabbit.test.BrokerRunning;
+
+/**
+ * @author Gary Russell
+ * @since 1.5
+ *
+ */
+public class RabbitManagementTemplateTests {
+
+	private final CachingConnectionFactory connectionFactory = new CachingConnectionFactory("localhost");
+
+	private final RabbitManagementTemplate template = new RabbitManagementTemplate();
+
+	@ClassRule
+	public static BrokerRunning brokerRunning = BrokerRunning.isRunning();
+
+	@After
+	public void tearDown() {
+		connectionFactory.destroy();
+	}
+
+	@Test
+	public void testAliveness() {
+		Map<String, Object> aliveness = this.template.aliveness("/");
+		assertNotNull(aliveness.get("status"));
+		assertEquals("ok", aliveness.get("status"));
+	}
+
+	@Test
+	public void testOverview() {
+		Map<String, Object> map = this.template.overview();
+		assertTrue(map.containsKey("rabbitmq_version"));
+	}
+
+	@Test
+	public void testExchanges() {
+		List<Exchange> list = this.template.exchanges();
+		assertTrue(list.size() > 0);
+	}
+
+	@Test
+	public void testExchangesVhost() {
+		List<Exchange> list = this.template.exchanges("/");
+		assertTrue(list.size() > 0);
+	}
+
+	@Test
+	public void testBindings() {
+		List<Binding> list = this.template.bindings();
+		assertTrue(list.size() > 0);
+	}
+
+	@Test
+	public void testBindingsVhost() {
+		List<Binding> list = this.template.bindings("/");
+		assertTrue(list.size() > 0);
+	}
+
+	@Test
+	public void testQueues() {
+		List<Queue> list = this.template.queues();
+		assertTrue(list.size() > 0);
+	}
+
+	@Test
+	public void testQueuesVhost() {
+		List<Queue> list = this.template.queues("/");
+		assertTrue(list.size() > 0);
+	}
+
+	@Test
+	public void testBindingsDetail() {
+		RabbitAdmin admin = new RabbitAdmin(connectionFactory);
+		Map<String, Object> args = Collections.<String, Object>singletonMap("alternate-exchange", "");
+		Exchange exchange1 = new DirectExchange(UUID.randomUUID().toString(), false, true, args);
+		admin.declareExchange(exchange1);
+		Exchange exchange2 = new DirectExchange(UUID.randomUUID().toString(), false, true, args);
+		admin.declareExchange(exchange2);
+		Queue queue = admin.declareQueue();
+		Binding binding1 = BindingBuilder
+				.bind(queue)
+				.to(exchange1)
+				.with("foo")
+				.and(args);
+		admin.declareBinding(binding1);
+		Binding binding2 = BindingBuilder
+				.bind(exchange2)
+				.to((DirectExchange) exchange1)
+				.with("bar");
+		admin.declareBinding(binding2);
+
+		List<Binding> bindings = this.template.exchangeSourceBindings("/", exchange1.getName());
+		assertEquals(2, bindings.size());
+		assertEquals(exchange1.getName(), bindings.get(0).getExchange());
+		assertThat("foo", anyOf(equalTo(bindings.get(0).getRoutingKey()), equalTo(bindings.get(1).getRoutingKey())));
+		Binding qout = null;
+		Binding eout = null;
+		if (bindings.get(0).getRoutingKey().equals("foo")) {
+			qout = bindings.get(0);
+			eout = bindings.get(1);
+		}
+		else {
+			eout = bindings.get(0);
+			qout = bindings.get(1);
+		}
+		assertEquals(Binding.DestinationType.QUEUE, qout.getDestinationType());
+		assertEquals(queue.getName(), qout.getDestination());
+		assertNotNull(qout.getArguments());
+		assertEquals("", qout.getArguments().get("alternate-exchange"));
+		assertNotNull(qout.getProperties());
+		assertEquals("/", qout.getProperties().get("vhost"));
+
+		assertEquals(Binding.DestinationType.EXCHANGE, eout.getDestinationType());
+		assertEquals(exchange2.getName(), eout.getDestination());
+		assertNotNull(eout.getProperties());
+		assertEquals("/", eout.getProperties().get("vhost"));
+
+		bindings = this.template.exchangeDestBindings("/", exchange2.getName());
+		assertEquals(1, bindings.size());
+		eout = bindings.get(0);
+		assertEquals(Binding.DestinationType.EXCHANGE, eout.getDestinationType());
+		assertEquals(exchange1.getName(), eout.getExchange());
+		assertEquals(exchange2.getName(), eout.getDestination());
+
+		bindings = this.template.exchangeToQueueBindings("/", exchange1.getName(), queue.getName());
+		assertEquals(1, bindings.size());
+		qout = bindings.get(0);
+		assertEquals(Binding.DestinationType.QUEUE, qout.getDestinationType());
+		assertEquals(exchange1.getName(), qout.getExchange());
+		assertEquals(queue.getName(), qout.getDestination());
+
+		bindings = this.template.exchangeToExchangeBindings("/", exchange1.getName(), exchange2.getName());
+		assertEquals(1, bindings.size());
+		eout = bindings.get(0);
+		assertEquals(Binding.DestinationType.EXCHANGE, eout.getDestinationType());
+		assertEquals(exchange1.getName(), eout.getExchange());
+		assertEquals(exchange2.getName(), eout.getDestination());
+
+		admin.deleteExchange(exchange1.getName());
+		admin.deleteExchange(exchange2.getName());
+	}
+
+	@Test
+	public void testSpecificExchange() {
+		RabbitAdmin admin = new RabbitAdmin(connectionFactory);
+		Map<String, Object> args = Collections.<String, Object>singletonMap("alternate-exchange", "");
+		Exchange exchange = new DirectExchange(UUID.randomUUID().toString(), true, true, args);
+		admin.declareExchange(exchange);
+		Exchange exchangeOut = this.template.exchange("/", exchange.getName());
+		assertTrue(exchangeOut.isDurable());
+		assertTrue(exchangeOut.isAutoDelete());
+		assertEquals(exchange.getName(), exchangeOut.getName());
+		assertEquals(args, exchangeOut.getArguments());
+		admin.deleteExchange(exchange.getName());
+	}
+
+	@Test
+	public void testSpecificQueue() {
+		RabbitAdmin admin = new RabbitAdmin(connectionFactory);
+		Map<String, Object> args = Collections.<String, Object>singletonMap("foo", "bar");
+		Queue queue = new Queue(UUID.randomUUID().toString(), true, false, true, args);
+		admin.declareQueue(queue);
+		Queue queueOut = this.template.queue("/", queue.getName());
+		assertTrue(queueOut.isDurable());
+		assertTrue(queueOut.isAutoDelete());
+		assertEquals(queue.getName(), queueOut.getName());
+		assertEquals(args, queueOut.getArguments());
+		admin.deleteQueue(queue.getName());
+	}
+
+	@Test
+	public void testGenericGet() {
+		RabbitAdmin admin = new RabbitAdmin(connectionFactory);
+		Exchange exchange = new DirectExchange(UUID.randomUUID().toString(), false, true);
+		admin.declareExchange(exchange);
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> connections = this.template.executeGet(List.class, new String[] { "connections" });
+		assertTrue(connections.size() > 0);
+		admin.deleteExchange(exchange.getName());
+	}
+
+	@Test
+	public void testPolicies() {
+		String name = UUID.randomUUID().toString();
+		Policy policy = new Policy("/", name, "^foo.", null, 0,
+				Collections.<String, Object>singletonMap("message-ttl", 1000));
+		this.template.addPolicy(policy);
+		List<Policy> list = this.template.policies();
+		assertTrue(list.size() > 0);
+		Policy out = null;
+		for (Policy policyOut : list) {
+			if (policyOut.getName().equals(name)) {
+				out = policyOut;
+				break;
+			}
+		}
+		assertNotNull(out);
+
+		list = this.template.policies("/");
+		assertTrue(list.size() > 0);
+		out = null;
+		for (Policy policyOut : list) {
+			if (policyOut.getName().equals(name)) {
+				out = policyOut;
+				break;
+			}
+		}
+		assertNotNull(out);
+
+		this.template.removePolicy("/", name);
+		list = this.template.policies();
+		out = null;
+		for (Policy policyOut : list) {
+			if (policyOut.getName().equals(name)) {
+				out = policyOut;
+				break;
+			}
+		}
+	}
+
+}

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -2238,6 +2238,16 @@ public Binding binding() {
 	return binding;
 }]]></programlisting>
     </section>
+    <section id="rabbit-management-template">
+    	<title>Rabbit Management Interface</title>
+		<para>
+			Starting with <emphasis>version 1.5</emphasis> the <classname>RabbitManagementTemplate</classname>
+			is now available. This provides an abstraction over much of the <code>RabbitMQ</code> REST API.
+			It allows you to obtain information about exchanges, queues, bindings etc, as well as to
+			add/remove policies. Refer to the class javadocs for more information.
+		</para>
+
+    </section>
   </section>
 
   <section id="exception-handling">

--- a/src/reference/docbook/erlang.xml
+++ b/src/reference/docbook/erlang.xml
@@ -5,119 +5,14 @@
 
   <section id="erlang-introduction">
     <title>Introduction</title>
-
-    <para>There is an open source project called JInterface that provides a
-    way for Java applications to communicate with an Erlang process. The API
-    is very low level and rather tedious to use and throws checked exceptions.
-    The Spring Erlang module makes accessing functions in Erlang from Java
-    easy, often they can be one liners. </para>
+	<para>
+		Starting with <emphasis>version 1.5</emphasis>, the <code>spring-erlang</code> project
+		is no longer supported. You can continue to use the 1.4 version if you wish.
+	</para>
+	<para>
+		Instead, the <classname>RabbitManagementTemplate</classname>
+		has been introduced to provide a Java API over the RabbitMQ REST API.
+		See <xref linkend="rabbit-management-template" /> for more information.
+	</para>
   </section>
-
-  <section>
-    <title>Communicating with Erlang processes</title>
-
-<!--
-    <para>TODO</para>
-
-    <section>
-      <title>Connection Management</title>
-
-      <para>TODO</para>
-    </section>
--->
-
-    <section>
-      <title>Executing RPC</title>
-
-      <para>The interface ErlangOperations is the high level API for
-      interacting with an Erlang process.</para>
-
-      <programlisting language="java">public interface ErlangOperations {
-
-    &lt;T&gt; T execute(ConnectionCallback&lt;T&gt; action) throws OtpException;
-
-    OtpErlangObject executeErlangRpc(String module, String function, OtpErlangList args)
-            throws OtpException;
-
-    OtpErlangObject executeErlangRpc(String module, String function,
-        OtpErlangObject... args) throws OtpException;
-
-    OtpErlangObject executeRpc(String module, String function, Object... args)
-            throws OtpException;
-
-    Object executeAndConvertRpc(String module, String function,
-            ErlangConverter converterToUse, Object... args) throws OtpException;
-
-    // Sweet!
-    <emphasis role="bold">Object executeAndConvertRpc(String module, String function, Object... args)
-            throws OtpException;</emphasis>
-
-}</programlisting>
-
-      <para>The class that implements this interface is called
-      <classname>ErlangTemplate</classname>. There are a few convenience
-      methods, most notably <methodname>executeAndConvertRpc</methodname>, as
-      well as the <methodname>execute</methodname> method which gives you
-      access to the 'native' API of the JInterface project. For simple
-      functions, you can invoke <methodname>executeAndConvertRpc</methodname>
-      with the appropriate Erlang module name, function, and arguments in a
-      one-liner. For example, here is the implementation of the
-      RabbitBrokerAdmin method 'DeleteUser'</para>
-
-      <programlisting language="java"><![CDATA[@ManagedOperation
-public void deleteUser(String username) {
-    erlangTemplate.executeAndConvertRpc(
-        "rabbit_access_control", "delete_user", username.getBytes());
-}]]></programlisting>
-
-      <para>As the JInterface library uses specific classes such as
-      OtpErlangDouble and OtpErlangString to represent the primitive types in
-      Erlang RPC calls, there is a converter class that works in concert with
-      ErlangTemplate that knows how to translate from Java primitive types to
-      their Erlang class equivalents. You can also create custom converters
-      and register them with the ErlangTemplate to handle more complex data
-      format translations.</para>
-    </section>
-
-    <section>
-      <title>ErlangConverter</title>
-
-      <para>The ErlangConverter interface is shown below.</para>
-
-      <programlisting language="java"><![CDATA[public interface ErlangConverter {
-
-    /**
-     * Convert a Java object to a Erlang data type.
-     * @param object the object to convert
-     * @return the Erlang data type
-     * @throws ErlangConversionException in case of conversion failure
-     */
-    OtpErlangObject toErlang(Object object) throws ErlangConversionException;
-
-    /**
-     * Convert from a Erlang data type to a Java object.
-     * @param erlangObject the Erlang object to convert
-     * @return the converted Java object
-     * @throws ErlangConversionException in case of conversion failure
-     */
-    Object fromErlang(OtpErlangObject erlangObject) throws ErlangConversionException;
-
-    /**
-     * The return value from executing the Erlang RPC.
-     */
-    Object fromErlangRpc(String module, String function, OtpErlangObject erlangObject)
-        throws ErlangConversionException;
-}]]></programlisting>
-    </section>
-  </section>
-
-  <section>
-    <title>Exceptions</title>
-
-    <para>The JInterface checked exception hierarchy is translated into a
-    parallel runtime exception hierarchy when executing operations through
-    ErlangTemplate.</para>
-
-  </section>
-
 </chapter>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -6,6 +6,15 @@
 	<section>
 		<title>Changes in 1.5 Since 1.4</title>
 		<section>
+			<title>RabbitManagementTemplate Introduced</title>
+			<para>
+				This new component provides an abstraction over the RabbitMQ REST API,
+				allowing you to list queues, exchanges, bindings etc.
+				See <xref linkend="rabbit-management-template" /> for more information.
+			</para>
+			<para>
+				The <code>spring-erlang</code> sub-project is no longer supported.
+			</para>
 			<title>Empty Addresses Property in CachingConnectionFactory</title>
 			<para>
 				Previously, if the connection factory was configured with a host/port,


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-473

RabbitMQ ReST API - Initial PoC

ReST PoC Second Commit

- Improve URI encoding
- Add ctor with CredentialsProvider
- Convert to Binding
- Add properties field to Binding

Fix Encoding; Remove CredentialsProvider ctor

- See https://jira.spring.io/browse/SPR-12679
- No need for ctor - user can supply a RestTemplate

Add remaining First Class Support Paths

- Use preemptive basic auth
- Add remaining elements

__Replaces #259 __