### PR TITLE
AMQP-482: Make LongString Limit Configurable

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -40,6 +40,28 @@ import com.rabbitmq.client.LongString;
  * @since 1.0
  */
 public class DefaultMessagePropertiesConverter implements MessagePropertiesConverter {
+
+	private static final int DEFAULT_LONG_STRING_LIMIT = 1024;
+
+	private final int longStringLimit;
+
+
+	/**
+	 * Construct an instance where {@link LongString}s will be returned as a
+	 * {@link java.io.DataInputStream} when longer than 1024 bytes.
+	 */
+	public DefaultMessagePropertiesConverter() {
+		this(DEFAULT_LONG_STRING_LIMIT);
+	}
+
+	/**
+	 * Construct an instance where {@link LongString}s will be returned as a
+	 * {@link java.io.DataInputStream} when longer than this limit.
+	 * @param longStringLimit the limit.
+	 */
+	public DefaultMessagePropertiesConverter(int longStringLimit) {
+		this.longStringLimit = longStringLimit;
+	}
 
 	public MessageProperties toMessageProperties(final BasicProperties source, final Envelope envelope,
 			final String charset) {
@@ -163,11 +185,11 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
 
 	/**
 	 * Converts a LongString value to either a String or DataInputStream based on a length-driven threshold. If the
-	 * length is 1024 bytes or less, a String will be returned, otherwise a DataInputStream is returned.
+	 * length is {@link #longStringLimit} bytes or less, a String will be returned, otherwise a DataInputStream is returned.
 	 */
 	private Object convertLongString(LongString longString, String charset) {
 		try {
-			if (longString.length() <= 1024) {
+			if (longString.length() <= this.longStringLimit) {
 				return new String(longString.getBytes(), charset);
 			} else {
 				return longString.getStream();

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -1615,7 +1615,19 @@ Object receiveAndConvert(String queueName) throws AmqpException;]]></programlist
 </bean>]]></programlisting>
       </sect2>
   </section>
-
+  <section id="message-properties-converters">
+    <title>Message Propeties Converters</title>
+    The <interfacename>MessagePropertiesConverter</interfacename> strategy interface is used to convert
+    between the rabbit client <classname>BasicProperties</classname> and Spring AMQP
+    <classname>MessageProperties</classname>. The default implementation
+    (<classname>DefaultMessagePropertiesConverter</classname>) is usually sufficient for most purposes
+    but you can implement your own if needed. The default properties converter, by default, will
+    convert <classname>BasicProperties</classname> elements of type <classname>LongString</classname>
+    to <classname>String</classname>s when the size is not greater than 1024 bytes.
+    Larger <classname>LongString</classname>s
+    are returned as a <classname>DataInputStream</classname>. This limit can be overridden with
+    a constructor argument.
+  </section>
   <section id="request-reply">
     <title>Request/Reply Messaging</title>
 

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -41,6 +41,16 @@
 				<code>o.s.amqp.rabbit.core.support</code> to <code>o.s.amqp.rabbit.core</code>.
 			</para>
 		</section>
+		<section>
+			<title>DefaultMessagePropertiesConverter</title>
+			<para>
+				The <classname>DefaultMessagePropertiesConverter</classname> can now be configured to
+				determine the maximum length of a <classname>LongString</classname> that will be converted
+				to a <classname>String</classname> rather than a <classname>DataInputStream</classname>.
+				The converter has an alternative constructor that takes the value as a limit.
+				Previously, this limit was hard-coded at 1024 bytes. (Also available in 1.4.4).
+			</para>
+		</section>
 	</section>
 	<section>
 		<title>Changes in 1.4 Since 1.3</title>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-482

Make the threshold at which `LongString`s are converted as `DataInputStream`s configurable.

__cherry-pick to 1.4.x__