### PR TITLE
AMQP-493: Add Consumer Tag Naming Strategy

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/ConsumerTagStrategy.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/ConsumerTagStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.support;
+
+/**
+ * A strategy interface to determine the consumer tag to be used when issuing a
+ * {@code basicConsume} operation.
+ *
+ * @author Gary Russell
+ * @since 1.4.5
+ *
+ */
+public interface ConsumerTagStrategy {
+
+	/**
+	 * Create the consumer tag, optionally based on the queue name that the consumer
+	 * will listen to. Consumer tags must be unique.
+	 * @param queue The queue name that this consumer will listen to.
+	 * @return The consumer tag.
+	 */
+	String createConsumerTag(String queue);
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/ServerGeneratesConsumerTagStrategy.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/ServerGeneratesConsumerTagStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.support;
+
+/**
+ * The default strategy for consumer tags - causes the server to generate the tag
+ * when processing the {@code basicConsume} operation.
+ *
+ * @author Gary Russell
+ * @since 1.4.5
+ *
+ */
+public class ServerGeneratesConsumerTagStrategy implements ConsumerTagStrategy {
+
+	@Override
+	public String createConsumerTag(String queue) {
+		return "";
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,8 @@ public class RabbitNamespaceUtils {
 	private static final String FAILED_DECLARATION_RETRY_INTERVAL = "failed-declaration-retry-interval";
 
 	private static final String MISSING_QUEUE_RETRY_INTERVAL = "missing-queue-retry-interval";
+
+	private static final String CONSUMER_TAG_STRATEGY = "consumer-tag-strategy";
 
 	public static BeanDefinition parseContainer(Element containerEle, ParserContext parserContext) {
 		RootBeanDefinition containerDef = new RootBeanDefinition(SimpleMessageListenerContainer.class);
@@ -232,6 +234,12 @@ public class RabbitNamespaceUtils {
 		String retryDeclarationInterval = containerEle.getAttribute(MISSING_QUEUE_RETRY_INTERVAL);
 		if (StringUtils.hasText(retryDeclarationInterval)) {
 			containerDef.getPropertyValues().add("retryDeclarationInterval", new TypedStringValue(retryDeclarationInterval));
+		}
+
+		String consumerTagStrategy = containerEle.getAttribute(CONSUMER_TAG_STRATEGY);
+		if (StringUtils.hasText(consumerTagStrategy)) {
+			containerDef.getPropertyValues().add("consumerTagStrategy",
+					new RuntimeBeanReference(consumerTagStrategy));
 		}
 
 		return containerDef;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.aopalliance.aop.Advice;
 
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.support.ConsumerTagStrategy;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -32,6 +33,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * for those that are used to build such container definition manually.
  *
  * @author Stephane Nicoll
+ * @author Gary Russell
  * @since 1.4
  */
 public class SimpleRabbitListenerContainerFactory
@@ -66,6 +68,8 @@ public class SimpleRabbitListenerContainerFactory
 	private Long recoveryInterval;
 
 	private Boolean missingQueuesFatal;
+
+	private ConsumerTagStrategy consumerTagStrategy;
 
 	/**
 	 * @param taskExecutor the {@link Executor} to use.
@@ -187,6 +191,14 @@ public class SimpleRabbitListenerContainerFactory
 		this.missingQueuesFatal = missingQueuesFatal;
 	}
 
+	/**
+	 * @param consumerTagStrategy the consumerTagStrategy to set
+	 * @see SimpleMessageListenerContainer#setConsumerTagStrategy(ConsumerTagStrategy)
+	 */
+	public void setConsumerTagStrategy(ConsumerTagStrategy consumerTagStrategy) {
+		this.consumerTagStrategy = consumerTagStrategy;
+	}
+
 	@Override
 	protected SimpleMessageListenerContainer createContainerInstance() {
 		return new SimpleMessageListenerContainer();
@@ -240,6 +252,9 @@ public class SimpleRabbitListenerContainerFactory
 		}
 		if (this.missingQueuesFatal != null) {
 			instance.setMissingQueuesFatal(this.missingQueuesFatal);
+		}
+		if (this.consumerTagStrategy != null) {
+			instance.setConsumerTagStrategy(this.consumerTagStrategy);
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -52,6 +52,7 @@ import org.springframework.amqp.rabbit.listener.exception.FatalListenerStartupEx
 import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
 import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
 import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
+import org.springframework.amqp.support.ConsumerTagStrategy;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
@@ -157,6 +158,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	private volatile boolean missingQueuesFatalSet;
 
 	private volatile boolean autoDeclare = true;
+
+	private volatile ConsumerTagStrategy consumerTagStrategy;
 
 	public interface ContainerDelegate {
 		void invokeListener(Channel channel, Message message) throws Exception;
@@ -584,6 +587,16 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
+	 * Set the implementation of {@link ConsumerTagStrategy} to generate consumer tags.
+	 * By default, the RabbitMQ server generates consumer tags.
+	 * @param consumerTagStrategy the consumerTagStrategy to set.
+	 * @since 1.4.5
+	 */
+	public void setConsumerTagStrategy(ConsumerTagStrategy consumerTagStrategy) {
+		this.consumerTagStrategy = consumerTagStrategy;
+	}
+
+	/**
 	 * Avoid the possibility of not configuring the CachingConnectionFactory in sync with the number of concurrent
 	 * consumers.
 	 */
@@ -897,6 +910,9 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		}
 		if (this.retryDeclarationInterval != null) {
 			consumer.setRetryDeclarationInterval(this.retryDeclarationInterval);
+		}
+		if (this.consumerTagStrategy != null) {
+			consumer.setTagStrategy(this.consumerTagStrategy);
 		}
 		return consumer;
 	}

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
@@ -745,6 +745,20 @@
 				<xsd:union memberTypes="xsd:boolean xsd:string" />
 			</xsd:simpleType>
 		</xsd:attribute>
+		<xsd:attribute name="consumer-tag-strategy" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to an implementation of ConsumerTagStrategy - used to generate the consumer
+	tag for the container consumers - by default, the RabbitMQ server generates the consumer
+	tag.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.support.ConsumerTagStrategy" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="listenerType">

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 the original author or authors.
+ * Copyright 2010-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.amqp.support.ConsumerTagStrategy;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.aop.MethodBeforeAdvice;
 import org.springframework.beans.DirectFieldAccessor;
@@ -96,6 +97,7 @@ public class ListenerContainerParserTests {
 		assertEquals(5, TestUtils.getPropertyValue(container, "declarationRetries"));
 		assertEquals(1000L, TestUtils.getPropertyValue(container, "failedDeclarationRetryInterval"));
 		assertEquals(30000L, TestUtils.getPropertyValue(container, "retryDeclarationInterval"));
+		assertEquals(beanFactory.getBean("tagger"), TestUtils.getPropertyValue(container, "consumerTagStrategy"));
 	}
 
 	@Test
@@ -200,4 +202,14 @@ public class ListenerContainerParserTests {
 		public void before(Method method, Object[] args, Object target) throws Throwable {
 		}
 	}
+
+	public static class TestConsumerTagStrategy implements ConsumerTagStrategy {
+
+		@Override
+		public String createConsumerTag(String queue) {
+			return "foo";
+		}
+
+	}
+
 }

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -14,7 +14,8 @@
 	<rabbit:listener-container id="container1" connection-factory="connectionFactory" acknowledge="manual" concurrency="5"
 			max-concurrency="6" receive-timeout="9876" recovery-interval="5555" missing-queues-fatal="false"
 			min-start-interval="1234" min-stop-interval="2345" min-consecutive-active="12" min-consecutive-idle="34"
-			declaration-retries="5" failed-declaration-retry-interval="1000" missing-queue-retry-interval="30000">
+			declaration-retries="5" failed-declaration-retry-interval="1000" missing-queue-retry-interval="30000"
+			consumer-tag-strategy="tagger">
 		<rabbit:listener queue-names="foo, #{bar.name}" ref="testBean" method="handle" priority="10" />
 	</rabbit:listener-container>
 
@@ -88,5 +89,7 @@
 	<bean id="connectionFactory" class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory"/>
 
 	<bean id="testBean" class="org.springframework.amqp.rabbit.config.ListenerContainerParserTests$TestBean"/>
+
+	<bean id="tagger" class="org.springframework.amqp.rabbit.config.ListenerContainerParserTests$TestConsumerTagStrategy" />
 
 </beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-493

Allow the user to generate custom consumer tags instead of the default server-generated tag.

__cherry-pick to 1.4.x - namespace PR to follow - 1.5 only__