### PR TITLE
AMQP-450: Support Reply Routing via Exchange

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Dave Syer
  * @author Artem Bilan
+ * @author Gary Russell
  */
 public class Address {
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 the original author or authors.
+ * Copyright 2010-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -51,6 +51,8 @@ class TemplateParser extends AbstractSingleBeanDefinitionParser {
 
 	private static final String REPLY_QUEUE_ATTRIBUTE = "reply-queue";
 
+	private static final String REPLY_ADDRESS_ATTRIBUTE = "reply-address";
+
 	private static final String LISTENER_ELEMENT = "reply-listener";
 
 	private static final String MANDATORY_ATTRIBUTE = "mandatory";
@@ -101,7 +103,11 @@ class TemplateParser extends AbstractSingleBeanDefinitionParser {
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, REPLY_TIMEOUT_ATTRIBUTE);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, ENCODING_ATTRIBUTE);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, MESSAGE_CONVERTER_ATTRIBUTE);
-		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, REPLY_QUEUE_ATTRIBUTE);
+		String replyAddress = element.getAttribute(REPLY_ADDRESS_ATTRIBUTE);
+		if (!StringUtils.hasText(replyAddress)) {
+			NamespaceUtils.setReferenceIfAttributeDefined(builder, element, REPLY_QUEUE_ATTRIBUTE);
+		}
+		NamespaceUtils.setValueIfAttributeDefined(builder, element, REPLY_ADDRESS_ATTRIBUTE);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, RETURN_CALLBACK_ATTRIBUTE);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, CONFIRM_CALLBACK_ATTRIBUTE);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, CORRELATION_KEY);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -161,7 +161,7 @@ public class RabbitTemplate extends RabbitAccessor
 
 	private volatile String encoding = DEFAULT_ENCODING;
 
-	private volatile Queue replyQueue;
+	private volatile String replyAddress;
 
 	private volatile ConfirmCallback confirmCallback;
 
@@ -256,11 +256,25 @@ public class RabbitTemplate extends RabbitAccessor
 	 * A queue for replies; if not provided, a temporary exclusive, auto-delete queue will
 	 * be used for each reply, unless RabbitMQ supports 'amq.rabbitmq.reply-to' - see
 	 * http://www.rabbitmq.com/direct-reply-to.html
-	 *
+	 * @deprecated - use #setReplyAddress(String replyAddress)
 	 * @param replyQueue the replyQueue to set
 	 */
+	@Deprecated
 	public void setReplyQueue(Queue replyQueue) {
-		this.replyQueue = replyQueue;
+		setReplyAddress(replyQueue.getName());
+	}
+
+	/**
+	 * An address for replies; if not provided, a temporary exclusive, auto-delete queue will
+	 * be used for each reply, unless RabbitMQ supports 'amq.rabbitmq.reply-to' - see
+	 * http://www.rabbitmq.com/direct-reply-to.html
+	 * <p>The address can be a simple queue name (in which case the reply will be routed via the default
+	 * exchange), or with the form {@code exchange/routingKey} to route the reply using an explicit
+	 * exchange and routing key.
+	 * @param replyQueue the replyQueue to set
+	 */
+	public void setReplyAddress(String replyAddress) {
+		this.replyAddress = replyAddress;
 		this.evaluatedFastReplyTo = false;
 	}
 
@@ -502,7 +516,7 @@ public class RabbitTemplate extends RabbitAccessor
 
 	private void evaluateFastReplyTo() {
 		this.usingFastReplyTo = false;
-		if (this.replyQueue == null || Address.AMQ_RABBITMQ_REPLY_TO.equals(this.replyQueue.getName())) {
+		if (this.replyAddress == null || Address.AMQ_RABBITMQ_REPLY_TO.equals(this.replyAddress)) {
 			try {
 				execute(new ChannelCallback<Void>() {
 
@@ -515,7 +529,7 @@ public class RabbitTemplate extends RabbitAccessor
 				this.usingFastReplyTo = true;
 			}
 			catch (Exception e) {
-				if (replyQueue != null) {
+				if (this.replyAddress != null) {
 					logger.error("Broker does not support fast replies via 'amq.rabbitmq.reply-to', temporary "
 							+ "queues will be used:" + e.getMessage() + ".");
 				}
@@ -525,7 +539,7 @@ public class RabbitTemplate extends RabbitAccessor
 								+ "queues will be used:" + e.getMessage() + ".");
 					}
 				}
-				RabbitTemplate.this.replyQueue = null;
+				this.replyAddress = null;
 			}
 		}
 		this.evaluatedFastReplyTo = true;
@@ -902,7 +916,7 @@ public class RabbitTemplate extends RabbitAccessor
 				}
 			}
 		}
-		if (this.replyQueue == null || this.usingFastReplyTo) {
+		if (this.replyAddress == null || this.usingFastReplyTo) {
 			return doSendAndReceiveWithTemporary(exchange, routingKey, message);
 		}
 		else {
@@ -973,9 +987,9 @@ public class RabbitTemplate extends RabbitAccessor
 				if (StringUtils.hasLength(savedReplyTo) && logger.isDebugEnabled()) {
 					logger.debug("Replacing replyTo header:" + savedReplyTo
 							+ " in favor of template's configured reply-queue:"
-							+ RabbitTemplate.this.replyQueue.getName());
+							+ RabbitTemplate.this.replyAddress);
 				}
-				message.getMessageProperties().setReplyTo(RabbitTemplate.this.replyQueue.getName());
+				message.getMessageProperties().setReplyTo(RabbitTemplate.this.replyAddress);
 				String savedCorrelation = null;
 				if (RabbitTemplate.this.correlationKey == null) { // using standard correlationId property
 					byte[] correlationId = message.getMessageProperties().getCorrelationId();

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
@@ -994,7 +994,23 @@
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 	A reference to a <queue/> for replies; optional; if not supplied, methods expecting replies
-	will use a temporary, exclusive, auto-delete queue.
+	will use a temporary, exclusive, auto-delete queue or, if the RabbitMQ version is 3.4 or higher,
+	using the 'direct reply-to' mechanism. See also 'reply-address'.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.core.Queue" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-address" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reply addressing information; by default, replies will be routed to the default exchange
+	using the 'reply-queue' name as the routing key; an address with the form
+	'exchange/routingKey' means that replies will be published to the specified exchange
+	and routed using the specified routing key.
 					]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2014 the original author or authors.
+ * Copyright 2010-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -100,10 +100,10 @@ public final class TemplateParserTests {
 		assertNotNull(template);
 		DirectFieldAccessor dfa = new DirectFieldAccessor(template);
 		assertNull(dfa.getPropertyValue("correlationKey"));
-		Queue queue = (Queue) dfa.getPropertyValue("replyQueue");
-		assertNotNull(queue);
+		String replyQueue = (String) dfa.getPropertyValue("replyAddress");
+		assertNotNull(replyQueue);
 		Queue queueBean = beanFactory.getBean("reply.queue", Queue.class);
-		assertSame(queueBean, queue);
+		assertEquals(queueBean.getName(), replyQueue);
 		SimpleMessageListenerContainer container =
 				beanFactory.getBean("withReplyQ.replyListener", SimpleMessageListenerContainer.class);
 		assertNotNull(container);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/FixedReplyQueueDeadLetterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/FixedReplyQueueDeadLetterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ public class FixedReplyQueueDeadLetterTests {
 			RabbitTemplate template = new RabbitTemplate(rabbitConnectionFactory());
 			template.setExchange(ex().getName());
 			template.setRoutingKey("dlx.reply.test");
-			template.setReplyQueue(replyQueue());
+			template.setReplyAddress(replyQueue().getName());
 			template.setReplyTimeout(1);
 			return template;
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -996,7 +996,7 @@ public class RabbitTemplateIntegrationTests {
 	public void testSymmetricalReceiveAndReply() throws InterruptedException, UnsupportedEncodingException {
 		this.template.setQueue(ROUTE);
 		this.template.setRoutingKey(ROUTE);
-		this.template.setReplyQueue(REPLY_QUEUE);
+		this.template.setReplyAddress(REPLY_QUEUE.getName());
 		this.template.setReplyTimeout(10000);
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -1096,7 +1096,7 @@ public class RabbitTemplateIntegrationTests {
 
 	@Test
 	public void testSendAndReceiveFastExplicit() {
-		this.template.setReplyQueue(new Queue(Address.AMQ_RABBITMQ_REPLY_TO));
+		this.template.setReplyAddress(Address.AMQ_RABBITMQ_REPLY_TO);
 		sendAndReceiveFastGuts();
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2014 by the original author(s).
+ * Copyright (c) 2011-2015 by the original author(s).
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -17,21 +17,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
-import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.MDC;
-import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
@@ -18,6 +18,7 @@
 	<bean id="converter" class="org.springframework.amqp.support.converter.SerializerMessageConverter"/>
 
 	<rabbit:template id="withReplyQ" connection-factory="connectionFactory" reply-queue="replyQId"
+					 reply-address="reply.queue"
 					 correlation-key="correlationId">
 		<rabbit:reply-listener/>
 	</rabbit:template>

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1489,13 +1489,19 @@ All of the <<containerAttributes>> attributes allowed on a <listener-container/>
 [source,xml]
 ----
 <rabbit:template id="amqpTemplate"
-        connection-factory="connectionFactory" reply-queue="replies">
+        connection-factory="connectionFactory"
+        reply-queue="replies"
+        reply-address="replyEx/routeReply">
     <rabbit:reply-listener/>
 </rabbit:template>
 
 ----
 
 While the container and template share a connection factory, they do not share a channel and therefore requests and replies are not performed within the same transaction (if transactional).
+
+NOTE: Prior to _version 1.5_, the `reply-address` attribute was not available, replies were always routed using the default exchange and the `reply-queue` name as the routing key.
+This is still the default but you can now specify the new `reply-address` attribute.
+The `reply-address` can contain an address with the form `<exchange>/<routingKey>` and the reply will be routed to the specified *exchange* and routed to a queue bound with the *routing key*.
 
 [[direct-reply-to]]
 ===== RabbitMQ Direct reply-to


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-450

Support reply routing using an exchange/routing key as well as
the simple queue name via the default exchange.