### PR TITLE
AMQP-444: Multi-Method @RabbitListener

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitHandler.java
@@ -26,13 +26,13 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 
 /**
  * Annotation that marks a method to be the target of a Rabbit message
- * listener within a class that is annotated with {@code @RabbitListener}.
+ * listener within a class that is annotated with {@link RabbitListener}.
  *
  * <p>See the {@link RabbitListener} for information about permitted method signatures
  * and available parameters.
  * <p><b>It is important to understand that when a message arrives, the method selection
  * depends on the payload type. The type is matched with a single non-annotated parameter,
- * or one that is annotated with {@code Payload}.
+ * or one that is annotated with {@code @Payload}.
  * There must be no ambiguity - the system
  * must be able to select exactly one method based on the payload type.</b>
  *

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+
+/**
+ * Annotation that marks a method to be the target of a Rabbit message
+ * listener within a class that is annotated with {@code @RabbitListener}.
+ *
+ * <p>See the {@link RabbitListener} for information about permitted method signatures
+ * and available parameters.
+ * <p><b>It is important to understand that when a message arrives, the method selection
+ * depends on the payload type. The type is matched with a single non-annotated parameter,
+ * or one that is annotated with {@code Payload}.
+ * There must be no ambiguity - the system
+ * must be able to select exactly one method based on the payload type.</b>
+ *
+ * @author Gary Russell
+ * @since 1.5
+ * @see EnableRabbit
+ * @see RabbitListener
+ * @see RabbitListenerAnnotationBeanPostProcessor
+ */
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@MessageMapping
+@Documented
+public @interface RabbitHandler {
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.rabbit.listener.MethodRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.listener.MultiMethodRabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 
 /**
@@ -61,7 +65,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
  * for convenient access to all method arguments.</li>
  * </ul>
  *
- * <p>Annotated method may have a non {@code void} return type. When they do, the result of the
+ * <p>Annotated methods may have a non {@code void} return type. When they do, the result of the
  * method invocation is sent as a reply to the queue defined by the
  * {@link org.springframework.amqp.core.MessageProperties#getReplyTo() ReplyTo}  header of the
  * incoming message. When this value is not set, a default queue can be provided by
@@ -72,13 +76,23 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
  * {@link org.springframework.amqp.rabbit.core.RabbitAdmin},
  * the queue, exchange and binding will be automatically declared.
  *
+ * <p>When defined at the method level, a listener container is created for each method. The
+ * {@link MessageListener} is a {@link MessagingMessageListenerAdapter}, configured with a
+ * {@link MethodRabbitListenerEndpoint}.
+ *
+ * <p>When defined at the class level, a single message listener container is used to service
+ * all methods annotated with {@code @RabbitHandler}. Method signatures of such annotated
+ * methods must not cause any ambiguity such that a single method can be resolved for a
+ * particular inbound message. The {@link MessagingMessageListenerAdapter} is configured with
+ * a {@link MultiMethodRabbitListenerEndpoint}.
+ *
  * @author Stephane Nicoll
  * @author Gary Russell
  * @since 1.4
  * @see EnableRabbit
  * @see RabbitListenerAnnotationBeanPostProcessor
  */
-@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @MessageMapping
 @Documented

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DelegatingInvocableHandler.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.listener;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.springframework.amqp.AmqpException;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+
+
+/**
+ * Delegates to an {@link InvocableHandlerMethod} based on the message payload type.
+ * Matches a single, non-annotated parameter or one that is annotated with {@link Payload}.
+ * Matches must be unambiguous.
+ *
+ * @author Gary Russell
+ * @since 1.5
+ *
+ */
+public class DelegatingInvocableHandler {
+
+	private final List<InvocableHandlerMethod> handlers;
+
+	private final ConcurrentMap<Class<?>, InvocableHandlerMethod> cachedHandlers = new ConcurrentHashMap<Class<?>, InvocableHandlerMethod>();
+
+	private final Object bean;
+
+	/**
+	 * Construct an instance with the supplied handlers for the bean.
+	 * @param handlers the handlers.
+	 * @param bean the bean.
+	 */
+	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers, Object bean) {
+		this.handlers = new ArrayList<InvocableHandlerMethod>(handlers);
+		this.bean = bean;
+	}
+
+	/**
+	 * @return the bean
+	 */
+	public Object getBean() {
+		return bean;
+	}
+
+	/**
+	 * Invoke the method with the given message.
+	 * @param message the message.
+	 * @param providedArgs additional arguments.
+	 * @throws Exception raised if no suitable argument resolver can be found,
+	 * or the method raised an exception.
+	 * @return the result of the invocation.
+	 */
+	public Object invoke(Message<?> message, Object... providedArgs) throws Exception {
+		Class<? extends Object> payloadClass = message.getPayload().getClass();
+		InvocableHandlerMethod handler = getHandlerForPayload(payloadClass);
+		return handler.invoke(message, providedArgs);
+	}
+
+	/**
+	 * @param payloadClass the payload class.
+	 * @return the handler.
+	 */
+	protected InvocableHandlerMethod getHandlerForPayload(Class<? extends Object> payloadClass) {
+		InvocableHandlerMethod handler = this.cachedHandlers.get(payloadClass);
+		if (handler == null) {
+			handler = findHandlerForPayload(payloadClass);
+			if (handler == null) {
+				throw new AmqpException("No method found for " + payloadClass);
+			}
+			this.cachedHandlers.putIfAbsent(payloadClass, handler);
+		}
+		return handler;
+	}
+
+	protected InvocableHandlerMethod findHandlerForPayload(Class<? extends Object> payloadClass) {
+		InvocableHandlerMethod result = null;
+		for (InvocableHandlerMethod handler : this.handlers) {
+			if (matchHandlerMethod(payloadClass, handler)) {
+				if (result != null) {
+					throw new AmqpException("Ambiguous methods for payload type: " + payloadClass + ": " +
+							result.getMethod().getName() + " and " + handler.getMethod().getName());
+				}
+				result = handler;
+			}
+		}
+		return result;
+	}
+
+	protected boolean matchHandlerMethod(Class<? extends Object> payloadClass, InvocableHandlerMethod handler) {
+		Method method = handler.getMethod();
+		Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+		// Single param; no annotation or @Payload
+		if (parameterAnnotations.length == 1) {
+			MethodParameter methodParameter = new MethodParameter(method, 0);
+			if (methodParameter.getParameterAnnotations().length == 0 || methodParameter.hasParameterAnnotation(Payload.class)) {
+				if (methodParameter.getParameterType().isAssignableFrom(payloadClass)) {
+					return true;
+				}
+			}
+		}
+		boolean foundCandidate = false;
+		for (int i = 0; i < parameterAnnotations.length; i++) {
+			MethodParameter methodParameter = new MethodParameter(method, i);
+			if (methodParameter.getParameterAnnotations().length == 0 || methodParameter.hasParameterAnnotation(Payload.class)) {
+				if (methodParameter.getParameterType().isAssignableFrom(payloadClass)) {
+					if (foundCandidate) {
+						throw new AmqpException("Ambiguous payload parameter for " + method.toGenericString());
+					}
+					foundCandidate = true;
+				}
+			}
+		}
+		return foundCandidate;
+	}
+
+	/**
+	 * Return a string representation of the method that will be invoked for this payload.
+	 * @param payload the payload.
+	 * @return the method name.
+	 */
+	public String getMethodNameFor(Object payload) {
+		InvocableHandlerMethod handlerForPayload = getHandlerForPayload(payload.getClass());
+		return handlerForPayload == null ? "no match" : handlerForPayload.getMethod().toGenericString();
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MultiMethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MultiMethodRabbitListenerEndpoint.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.listener;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.amqp.rabbit.listener.adapter.HandlerAdapter;
+import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+
+/**
+ * @author Gary Russell
+ * @since 1.5
+ *
+ */
+public class MultiMethodRabbitListenerEndpoint extends MethodRabbitListenerEndpoint {
+
+	private final List<Method> methods;
+
+	private final Object bean;
+
+	public MultiMethodRabbitListenerEndpoint(List<Method> methods, Object bean) {
+		this.methods = methods;
+		this.bean = bean;
+	}
+
+	@Override
+	protected HandlerAdapter configureListenerAdapter(MessagingMessageListenerAdapter messageListener) {
+		List<InvocableHandlerMethod> invocableHandlerMethods = new ArrayList<InvocableHandlerMethod>();
+		for (Method method : this.methods) {
+			invocableHandlerMethods.add(getMessageHandlerMethodFactory()
+					.createInvocableHandlerMethod(getBean(), method));
+		}
+		return new HandlerAdapter(new DelegatingInvocableHandler(invocableHandlerMethods, this.bean));
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/HandlerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/HandlerAdapter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import org.springframework.amqp.rabbit.listener.DelegatingInvocableHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+
+/**
+ * A wrapper for either an {@link InvocableHandlerMethod} or
+ * {@link DelegatingInvocableHandler}. All methods delegate to the
+ * underlying handler.
+ *
+ * @author Gary Russell
+ * @since 1.5
+ *
+ */
+public class HandlerAdapter {
+
+	private final InvocableHandlerMethod invokerHandlerMethod;
+
+	private final DelegatingInvocableHandler delegatingHandler;
+
+	public HandlerAdapter(InvocableHandlerMethod invokerHandlerMethod) {
+		this.invokerHandlerMethod = invokerHandlerMethod;
+		this.delegatingHandler = null;
+	}
+
+	public HandlerAdapter(DelegatingInvocableHandler delegatingHandler) {
+		this.invokerHandlerMethod = null;
+		this.delegatingHandler = delegatingHandler;
+	}
+
+	public Object invoke(Message<?> message, Object... providedArgs) throws Exception {
+		if (this.invokerHandlerMethod != null) {
+			return this.invokerHandlerMethod.invoke(message, providedArgs);
+		}
+		else {
+			return this.delegatingHandler.invoke(message, providedArgs);
+		}
+	}
+
+	public String getMethodAsString(Object payload) {
+		if (this.invokerHandlerMethod != null) {
+			return this.invokerHandlerMethod.getMethod().toGenericString();
+		}
+		else {
+			return this.delegatingHandler.getMethodNameFor(payload);
+		}
+	}
+
+	public Object getBean() {
+		if (this.invokerHandlerMethod != null) {
+			return this.invokerHandlerMethod.getBean();
+		}
+		else {
+			return this.delegatingHandler.getBean();
+		}
+	}
+
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ import com.rabbitmq.client.Channel;
  */
 public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageListener {
 
-	private InvocableHandlerMethod handlerMethod;
+	private HandlerAdapter handlerMethod;
 
 	private final MessagingMessageConverterAdapter messagingMessageConverter = new MessagingMessageConverterAdapter();
 
@@ -59,7 +59,7 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	 * processing an incoming {@link org.springframework.amqp.core.Message}.
 	 * @param handlerMethod {@link InvocableHandlerMethod} instance.
 	 */
-	public void setHandlerMethod(InvocableHandlerMethod handlerMethod) {
+	public void setHandlerMethod(HandlerAdapter handlerMethod) {
 		this.handlerMethod = handlerMethod;
 	}
 
@@ -114,23 +114,23 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 		}
 		catch (org.springframework.messaging.converter.MessageConversionException ex) {
 			throw new ListenerExecutionFailedException(createMessagingErrorMessage("Listener method could not " +
-					"be invoked with the incoming message"),
+					"be invoked with the incoming message", message.getPayload()),
 					new MessageConversionException("Cannot handle message", ex));
 		}
 		catch (MessagingException ex) {
 			throw new ListenerExecutionFailedException(createMessagingErrorMessage("Listener method could not " +
-					"be invoked with the incoming message"), ex);
+					"be invoked with the incoming message", message.getPayload()), ex);
 		}
 		catch (Exception ex) {
 			throw new ListenerExecutionFailedException("Listener method '" +
-					this.handlerMethod.getMethod().toGenericString() + "' threw exception", ex);
+					this.handlerMethod.getMethodAsString(message.getPayload()) + "' threw exception", ex);
 		}
 	}
 
-	private String createMessagingErrorMessage(String description) {
+	private String createMessagingErrorMessage(String description, Object payload) {
 		return description + "\n"
 				+ "Endpoint handler details:\n"
-				+ "Method [" + this.handlerMethod.getMethod() + "]\n"
+				+ "Method [" + this.handlerMethod.getMethodAsString(payload) + "]\n"
 				+ "Bean [" + this.handlerMethod.getBean() + "]";
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -24,14 +24,13 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.MessagingMessageConverter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
-import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.util.Assert;
 
 import com.rabbitmq.client.Channel;
 
 /**
  * A {@link org.springframework.amqp.core.MessageListener MessageListener}
- * adapter that invokes a configurable {@link InvocableHandlerMethod}.
+ * adapter that invokes a configurable {@link HandlerAdapter}.
  *
  * <p>Wraps the incoming {@link org.springframework.amqp.core.Message
  * AMQP Message} to Spring's {@link Message} abstraction, copying the
@@ -55,9 +54,9 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 
 
 	/**
-	 * Set the {@link InvocableHandlerMethod} to use to invoke the method
+	 * Set the {@link HandlerAdapter} to use to invoke the method
 	 * processing an incoming {@link org.springframework.amqp.core.Message}.
-	 * @param handlerMethod {@link InvocableHandlerMethod} instance.
+	 * @param handlerMethod {@link HandlerAdapter} instance.
 	 */
 	public void setHandlerMethod(HandlerAdapter handlerMethod) {
 		this.handlerMethod = handlerMethod;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.springframework.amqp.rabbit.listener.adapter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
-import static org.mockito.BDDMockito.mock;
+import static org.mockito.Mockito.mock;
 import static org.springframework.amqp.rabbit.test.MessageTestUtils.createTextMessage;
 
 import java.lang.reflect.Method;
@@ -119,7 +119,7 @@ public class MessagingMessageListenerAdapterTests {
 
 	protected MessagingMessageListenerAdapter createInstance(Method m) {
 		MessagingMessageListenerAdapter adapter = new MessagingMessageListenerAdapter();
-		adapter.setHandlerMethod(factory.createInvocableHandlerMethod(sample, m));
+		adapter.setHandlerMethod(new HandlerAdapter(factory.createInvocableHandlerMethod(sample, m)));
 		return adapter;
 	}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1000,7 +1000,9 @@ Batched messages are automatically de-batched by listener containers (using the 
 See <<template-batching>> for more information about batching.
 
 [[async-annotation-driven]]
-===== Annotation-driven listener endpoints
+===== Annotation-driven Listener Endpoints
+
+====== Introduction
 
 Starting with _version 1.4_, the easiest way to receive a message asynchronously is to use the annotated listener endpoint infrastructure.
 In a nutshell, it allows you to expose a method of a managed bean as a Rabbit listener endpoint.
@@ -1271,6 +1273,41 @@ The valid values are:
 Also `@SendTo` can be used without a `value` attribute.
 This case is equal to an empty sendTo pattern.
 `@SendTo` is only used if the inbound message does not have a `replyToAddress` property.
+
+[[annotation-method-selection]]
+====== Multi-Method Listeners
+
+Starting with _version 1.5_, the `@RabbitListener` annotation can now be specified at the class level.
+Together with the new `@RabbitHandler` annotation, this allows a single listener to invoke different methods, based on the payload type of the incoming message.
+This is best described using an example:
+
+[source, java]
+----
+@RabbitListener(queues = "someQueue"
+public class MultiListenerBean {
+
+	@RabbitHandler
+	public String bar(Bar bar) {
+		return "BAR: " + bar.field;
+	}
+
+	@RabbitHandler
+	public String baz(Baz baz) {
+		return "BAZ: " + baz.field;
+	}
+
+	@RabbitHandler
+	public String qux(@Header("amqp_receivedRoutingKey") String rk, @Payload Qux qux) {
+		return "QUX: " + qux.field + ": " + rk;
+	}
+
+}
+----
+
+In this case, the individual `@RabbitHandler` methods are invoked if the converted payload is a `Bar`, `Baz` or `Qux`.
+It is important to understand that the system must be able to identify a unique method based on the payload type.
+The type is checked for assignability to a single parameter that has no annotations, or is annotated with the `@Payload` annotation.
+Notice that the same method signatures apply as discussed in the method-level `@RabbitListener` described above.
 
 ===== Threading and Asynchronous Consumers
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1283,7 +1283,7 @@ This is best described using an example:
 
 [source, java]
 ----
-@RabbitListener(queues = "someQueue"
+@RabbitListener(queues = "someQueue")
 public class MultiListenerBean {
 
 	@RabbitHandler

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -45,6 +45,10 @@ The `reply-address` attribute has been added to the `<rabbit-template>` componen
 See <<request-reply>> for more information.
 (Also available in _1.4.4_ as setter on the `RabbitTemplate`).
 
+===== Class-Level @RabbitListener
+
+The `@RabbitListener` annotation can now be applied at the class level.
+Together with the new `@RabbitHandler` method annotation, this allows the handler method to be selected based on payload type. See <<annotation-method-selection>> for more information.
 
 ==== Changes in 1.4 Since 1.3
 


### PR DESCRIPTION
Enable class-level `@RabbitHandler` annotations, allowing for selection
of indidividual `@RabbitListener` methods based on `Message<?>` payload
type. Method selection must be unambiguous.

