### PR TITLE
AMQP-416: Deprecate id on <listener-container/>

### DIFF
--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
@@ -512,7 +512,11 @@
 		<xsd:attribute name="id" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	Optional bean id for the container.
+	Deprecated - the top level container 'id' is no longer used when naming the child
+	'listener' beans - the 'id' there alone is now used instead. Also, the 'id'
+	attribute was ignored in a rabbit template 'reply-listener' where the bean name
+	is always 'templateId.replyListener'. This attribute will be removed in a future
+	release.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -765,7 +769,8 @@
 		<xsd:attribute name="id" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	The unique identifier for this listener.
+	The unique identifier for this listener. Normal bean name overrides will apply - a
+	listener that is parsed later with the same id will override this bean.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
@@ -142,26 +142,30 @@ public class ListenerContainerParserTests {
 
 	@Test
 	public void testNamedListeners() throws Exception {
-		beanFactory.getBean("containerWithNamedListeners$testListener1", SimpleMessageListenerContainer.class);
-		beanFactory.getBean("containerWithNamedListeners$testListener2", SimpleMessageListenerContainer.class);
+		beanFactory.getBean("testListener1", SimpleMessageListenerContainer.class);
+		beanFactory.getBean("testListener2", SimpleMessageListenerContainer.class);
 	}
 
 	@Test
 	public void testAnonListeners() throws Exception {
-		beanFactory.getBean("containerWithAnonListener", SimpleMessageListenerContainer.class);
-		beanFactory.getBean("containerWithAnonListeners.0", SimpleMessageListenerContainer.class);
-		beanFactory.getBean("containerWithAnonListeners$namedListener", SimpleMessageListenerContainer.class);
-		beanFactory.getBean("containerWithAnonListeners.2", SimpleMessageListenerContainer.class);
+		beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#0",
+				SimpleMessageListenerContainer.class);
+		beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#1",
+				SimpleMessageListenerContainer.class);
+		beanFactory.getBean("namedListener", SimpleMessageListenerContainer.class);
+		beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#2",
+				SimpleMessageListenerContainer.class);
 	}
 
 	@Test
 	public void testAnonEverything() throws Exception {
 		SimpleMessageListenerContainer container = beanFactory.getBean(
-				"org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#0.0",
+				"org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#3",
 				SimpleMessageListenerContainer.class);
 		assertEquals("ex1", ReflectionTestUtils.getField(ReflectionTestUtils.getField(container, "messageListener"),
 				"responseExchange"));
-		container = beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#0.1",
+		container = beanFactory.getBean(
+				"org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#4",
 				SimpleMessageListenerContainer.class);
 		assertEquals("ex2", ReflectionTestUtils.getField(ReflectionTestUtils.getField(container, "messageListener"),
 				"responseExchange"));
@@ -169,15 +173,8 @@ public class ListenerContainerParserTests {
 
 	@Test
 	public void testAnonParent() throws Exception {
-		beanFactory.getBean(
-				"org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#1$anonParentL1",
-				SimpleMessageListenerContainer.class);
-		beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#1$anonParentL2",
-				SimpleMessageListenerContainer.class);
-		beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#2$anonParentL1",
-				SimpleMessageListenerContainer.class);
-		beanFactory.getBean("org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer#2$anonParentL2",
-				SimpleMessageListenerContainer.class);
+		beanFactory.getBean("anonParentL1", SimpleMessageListenerContainer.class);
+		beanFactory.getBean("anonParentL2", SimpleMessageListenerContainer.class);
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2013 the original author or authors.
+ * Copyright 2010-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.config.ListenerContainerParserTests.TestBean;
@@ -58,7 +59,7 @@ public final class ListenerContainerPlaceholderParserTests {
 
 	@Test
 	public void testParseWithQueueNames() throws Exception {
-		SimpleMessageListenerContainer container = beanFactory.getBean("container1$testListener", SimpleMessageListenerContainer.class);
+		SimpleMessageListenerContainer container = beanFactory.getBean("testListener", SimpleMessageListenerContainer.class);
 		assertEquals(AcknowledgeMode.MANUAL, container.getAcknowledgeMode());
 		assertEquals(beanFactory.getBean(ConnectionFactory.class), container.getConnectionFactory());
 		assertEquals(MessageListenerAdapter.class, container.getMessageListener().getClass());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,8 +67,8 @@ public class ListenFromAutoDeleteQueueTests {
 	public void setup() {
 		this.context = new ClassPathXmlApplicationContext(this.getClass().getSimpleName() + "-context.xml",
 				this.getClass());
-		this.listenerContainer1 = context.getBean("container1$listener1", SimpleMessageListenerContainer.class);
-		this.listenerContainer2 = context.getBean("container2$listener2", SimpleMessageListenerContainer.class);
+		this.listenerContainer1 = context.getBean("container1", SimpleMessageListenerContainer.class);
+		this.listenerContainer2 = context.getBean("container2", SimpleMessageListenerContainer.class);
 	}
 
 	@After

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -11,33 +11,33 @@
 
 	<rabbit:queue id="bar" />
 
-	<rabbit:listener-container id="container1" connection-factory="connectionFactory" acknowledge="manual" concurrency="5"
+	<rabbit:listener-container connection-factory="connectionFactory" acknowledge="manual" concurrency="5"
 			max-concurrency="6" receive-timeout="9876" recovery-interval="5555" missing-queues-fatal="false"
 			min-start-interval="1234" min-stop-interval="2345" min-consecutive-active="12" min-consecutive-idle="34"
 			declaration-retries="5" failed-declaration-retry-interval="1000" missing-queue-retry-interval="30000"
 			consumer-tag-strategy="tagger">
-		<rabbit:listener queue-names="foo, #{bar.name}" ref="testBean" method="handle" priority="10" />
+		<rabbit:listener id="container1" queue-names="foo, #{bar.name}" ref="testBean" method="handle" priority="10" />
 	</rabbit:listener-container>
 
-	<rabbit:listener-container id="container2" connection-factory="connectionFactory" acknowledge="manual" concurrency="5"
+	<rabbit:listener-container connection-factory="connectionFactory" acknowledge="manual" concurrency="5"
 			auto-declare="false">
-		<rabbit:listener queues="foo, bar" ref="testBean" method="handle"/>
+		<rabbit:listener id="container2" queues="foo, bar" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 
-	<rabbit:listener-container id="container3" connection-factory="connectionFactory" advice-chain="adviceChain">
-		<rabbit:listener queues="foo" exclusive="true" ref="testBean" method="handle"/>
+	<rabbit:listener-container connection-factory="connectionFactory" advice-chain="adviceChain">
+		<rabbit:listener id="container3" queues="foo" exclusive="true" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 
-	<rabbit:listener-container id="container4" connection-factory="connectionFactory">
-		<rabbit:listener queues="foo" ref="testBean" method="handle"/>
+	<rabbit:listener-container connection-factory="connectionFactory">
+		<rabbit:listener id="container4" queues="foo" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 
-	<rabbit:listener-container id="container5" connection-factory="connectionFactory" requeue-rejected="false">
-		<rabbit:listener queues="foo" ref="testBean" method="handle"/>
+	<rabbit:listener-container connection-factory="connectionFactory" requeue-rejected="false">
+		<rabbit:listener id="container5" queues="foo" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 
-	<rabbit:listener-container id="container6" connection-factory="connectionFactory" channel-transacted="true" transaction-size="5" >
-		<rabbit:listener queues="foo" ref="testBean" method="handle"/>
+	<rabbit:listener-container connection-factory="connectionFactory" channel-transacted="true" transaction-size="5" >
+		<rabbit:listener id="container6" queues="foo" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 
 	<rabbit:listener-container id="containerWithNamedListeners" connection-factory="connectionFactory">

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
@@ -18,8 +18,8 @@
 		</rabbit:bindings>
 	</rabbit:direct-exchange>
 
-	<rabbit:listener-container id="container1" concurrency="2">
-		<rabbit:listener id="listener1" ref="foo" queues="anon" />
+	<rabbit:listener-container concurrency="2">
+		<rabbit:listener id="container1" ref="foo" queues="anon" />
 	</rabbit:listener-container>
 
 	<!-- With Conditional Declarations -->
@@ -32,8 +32,8 @@
 		</rabbit:bindings>
 	</rabbit:direct-exchange>
 
-	<rabbit:listener-container id="container2" auto-startup="false">
-		<rabbit:listener id="listener2" ref="foo" queues="otherAnon" admin="containerAdmin" />
+	<rabbit:listener-container auto-startup="false">
+		<rabbit:listener id="container2" ref="foo" queues="otherAnon" admin="containerAdmin" />
 	</rabbit:listener-container>
 
 	<rabbit:queue id="xExpires" name="xExpires">
@@ -42,12 +42,12 @@
 		</rabbit:queue-arguments>
 	</rabbit:queue>
 
-	<rabbit:listener-container id="container3" concurrency="2">
-		<rabbit:listener ref="foo" queues="xExpires"/>
+	<rabbit:listener-container concurrency="2">
+		<rabbit:listener id="container3" ref="foo" queues="xExpires"/>
 	</rabbit:listener-container>
 
-	<rabbit:listener-container id="container4" auto-declare="false">
-		<rabbit:listener ref="foo" queues="anon2"/>
+	<rabbit:listener-container auto-declare="false">
+		<rabbit:listener id="container4" ref="foo" queues="anon2"/>
 	</rabbit:listener-container>
 
 	<rabbit:admin connection-factory="rabbitConnectionFactory" />

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -46,6 +46,13 @@ See <<request-reply>> for more information.
 (Also available in _1.4.4_ as setter on the `RabbitTemplate`).
 
 
+===== Listener Container Bean Names (XML)
+
+The `id` attribute on the `<listener-container/>` element is deprecated and ignored.
+Starting with this release, the `id` on the `<listener/>` child element us used alone to name the listener container bean.
+Normal Spring bean name overrides are applied; if a later `<listener/>` is parsed with the same `id` as an existing beam, the new definition will override the existing one.
+Previously, bean names were composed from the ids of the `<listener-container/>` and `<listener/>` elements.
+
 ==== Changes in 1.4 Since 1.3
 
 ===== @RabbitListener Annotation


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-416

Use `<listener/>` id attribute alone.