### PR TITLE
AMQP-427: Add `BackOff` for listener container

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
@@ -81,6 +81,8 @@ public class RabbitNamespaceUtils {
 
 	private static final String RECOVERY_INTERVAL = "recovery-interval";
 
+	private static final String RECOVERY_BACK_OFF = "recovery-back-off";
+
 	private static final String MISSING_QUEUES_FATAL = "missing-queues-fatal";
 
 	private static final String AUTO_DECLARE = "auto-declare";
@@ -207,8 +209,17 @@ public class RabbitNamespaceUtils {
 		}
 
 		String recoveryInterval = containerEle.getAttribute(RECOVERY_INTERVAL);
+		String recoveryBackOff = containerEle.getAttribute(RECOVERY_BACK_OFF);
 		if (StringUtils.hasText(recoveryInterval)) {
+			if (StringUtils.hasText(recoveryBackOff)) {
+				parserContext.getReaderContext()
+						.error("'" + RECOVERY_INTERVAL + "' and '" + RECOVERY_BACK_OFF + "' are mutually exclusive",
+						containerEle);
+			}
 			containerDef.getPropertyValues().add("recoveryInterval", new TypedStringValue(recoveryInterval));
+		}
+		if (StringUtils.hasText(recoveryBackOff)) {
+			containerDef.getPropertyValues().add("recoveryBackOff", new RuntimeBeanReference(recoveryBackOff));
 		}
 
 		String missingQueuesFatal = containerEle.getAttribute(MISSING_QUEUES_FATAL);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -24,6 +24,8 @@ import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.support.ConsumerTagStrategy;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.FixedBackOff;
 
 /**
  * A {@link RabbitListenerContainerFactory} implementation to build a regular
@@ -34,6 +36,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  *
  * @author Stephane Nicoll
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 1.4
  */
 public class SimpleRabbitListenerContainerFactory
@@ -65,7 +68,7 @@ public class SimpleRabbitListenerContainerFactory
 
 	private Advice[] adviceChain;
 
-	private Long recoveryInterval;
+	private BackOff recoveryBackOff;
 
 	private Boolean missingQueuesFatal;
 
@@ -180,7 +183,16 @@ public class SimpleRabbitListenerContainerFactory
 	 * @see SimpleMessageListenerContainer#setRecoveryInterval
 	 */
 	public void setRecoveryInterval(Long recoveryInterval) {
-		this.recoveryInterval = recoveryInterval;
+		this.recoveryBackOff = new FixedBackOff(recoveryInterval, FixedBackOff.UNLIMITED_ATTEMPTS);
+	}
+
+	/**
+	 * @param recoveryBackOff The BackOff to recover.
+	 * @since 1.5
+	 * @see SimpleMessageListenerContainer#setRecoveryBackOff(BackOff)
+	 */
+	public void setRecoveryBackOff(BackOff recoveryBackOff) {
+		this.recoveryBackOff = recoveryBackOff;
 	}
 
 	/**
@@ -247,8 +259,8 @@ public class SimpleRabbitListenerContainerFactory
 		if (this.adviceChain != null) {
 			instance.setAdviceChain(this.adviceChain);
 		}
-		if (this.recoveryInterval != null) {
-			instance.setRecoveryInterval(this.recoveryInterval);
+		if (this.recoveryBackOff != null) {
+			instance.setRecoveryBackOff(this.recoveryBackOff);
 		}
 		if (this.missingQueuesFatal != null) {
 			instance.setMissingQueuesFatal(this.missingQueuesFatal);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -49,6 +49,7 @@ import org.springframework.amqp.rabbit.listener.exception.FatalListenerStartupEx
 import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
 import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
 import org.springframework.amqp.support.ConsumerTagStrategy;
+import org.springframework.util.backoff.BackOffExecution;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
@@ -124,6 +125,8 @@ public class BlockingQueueConsumer {
 	private long lastRetryDeclaration;
 
 	private ConsumerTagStrategy tagStrategy;
+
+	private BackOffExecution backOffExecution;
 
 	/**
 	 * Create a consumer. The consumer must not attempt to use
@@ -278,6 +281,19 @@ public class BlockingQueueConsumer {
 	 */
 	public void setTagStrategy(ConsumerTagStrategy tagStrategy) {
 		this.tagStrategy = tagStrategy;
+	}
+
+	/**
+	 * Set the {@link BackOffExecution} to use for the recovery in the {@code SimpleMessageListenerContainer}.
+	 * @param backOffExecution the backOffExecution.
+	 * @since 1.5
+	 */
+	public void setBackOffExecution(BackOffExecution backOffExecution) {
+		this.backOffExecution = backOffExecution;
+	}
+
+	public BackOffExecution getBackOffExecution() {
+		return backOffExecution;
 	}
 
 	protected void basicCancel() {

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
@@ -705,7 +705,7 @@
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 	The BackOff bean reference for recovery interval between attempts to start a consumer
-	if it fails to start with a non-fatal error. Default 5000.
+	if it fails to start with a non-fatal error. Default FixedBackOff with unlimited retries every 5 seconds.
 	See also 'missing-queues-fatal'. Fatal errors include authentication problems.
 	Mutually exclusive with 'recovery-interval'.
 				]]></xsd:documentation>

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
@@ -697,7 +697,23 @@
 				<xsd:documentation><![CDATA[
 	The time in milliseconds between attempts to start a consumer if it fails to start with a non-fatal error. Default 5000.
 	See also 'missing-queues-fatal'. Fatal errors include authentication problems.
+	Mutually exclusive with 'recovery-back-off'.
 				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="recovery-back-off" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The BackOff bean reference for recovery interval between attempts to start a consumer
+	if it fails to start with a non-fatal error. Default 5000.
+	See also 'missing-queues-fatal'. Fatal errors include authentication problems.
+	Mutually exclusive with 'recovery-interval'.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.util.backoff.BackOff" />
+					</tool:annotation>
+				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="missing-queues-fatal" type="xsd:string">

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
@@ -51,6 +51,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class ListenerContainerParserTests {
 
@@ -90,7 +91,7 @@ public class ListenerContainerParserTests {
 		Object xPriority = consumerArgs.get("x-priority");
 		assertNotNull(xPriority);
 		assertEquals(10, xPriority);
-		assertEquals(Long.valueOf(5555), TestUtils.getPropertyValue(container, "recoveryInterval", Long.class));
+		assertEquals(Long.valueOf(5555), TestUtils.getPropertyValue(container, "recoveryBackOff.interval", Long.class));
 		assertFalse(TestUtils.getPropertyValue(container, "exclusive", Boolean.class));
 		assertFalse(TestUtils.getPropertyValue(container, "missingQueuesFatal", Boolean.class));
 		assertTrue(TestUtils.getPropertyValue(container, "autoDeclare", Boolean.class));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,10 @@
 
 package org.springframework.amqp.rabbit.config;
 
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.Executor;
 
@@ -35,12 +39,12 @@ import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.ErrorHandler;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.ExponentialBackOff;
 
 /**
  * @author Stephane Nicoll
+ * @author Artem Bilan
  */
 public class RabbitListenerContainerFactoryTests {
 
@@ -91,7 +95,8 @@ public class RabbitListenerContainerFactoryTests {
 		this.factory.setReceiveTimeout(1500L);
 		this.factory.setDefaultRequeueRejected(false);
 		this.factory.setAdviceChain(advice);
-		this.factory.setRecoveryInterval(3000L);
+		BackOff recoveryBackOff = new ExponentialBackOff();
+		this.factory.setRecoveryBackOff(recoveryBackOff);
 		this.factory.setMissingQueuesFatal(true);
 
 		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
@@ -117,7 +122,7 @@ public class RabbitListenerContainerFactoryTests {
 		Advice[] actualAdviceChain = (Advice[]) fieldAccessor.getPropertyValue("adviceChain");
 		assertEquals("Wrong number of advice", 1, actualAdviceChain.length);
 		assertSame("Wrong advice", advice, actualAdviceChain[0]);
-		assertEquals(3000L, fieldAccessor.getPropertyValue("recoveryInterval"));
+		assertSame(recoveryBackOff, fieldAccessor.getPropertyValue("recoveryBackOff"));
 		assertEquals(true, fieldAccessor.getPropertyValue("missingQueuesFatal"));
 		assertEquals(messageListener, container.getMessageListener());
 		assertEquals("myQueue", container.getQueueNames()[0]);

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -46,10 +46,21 @@
 	</rabbit:listener-container>
 
 <!-- Invalid -->
-<!-- 	<rabbit:listener-container id="containerWithNamedListenersSame" connection-factory="connectionFactory"> -->
-<!-- 		<rabbit:listener id="testListener3" queues="foo" ref="testBean" method="handle"/> -->
-<!-- 		<rabbit:listener id="testListener3" queues="bar" ref="testBean" method="handle"/> -->
-<!-- 	</rabbit:listener-container> -->
+
+	<!--<rabbit:listener-container id="containerWithNamedListenersSame" connection-factory="connectionFactory">
+ 		<rabbit:listener id="testListener3" queues="foo" ref="testBean" method="handle"/>
+ 		<rabbit:listener id="testListener3" queues="bar" ref="testBean" method="handle"/>
+ 	</rabbit:listener-container>-->
+
+	<!--<bean id="backOff" class="org.springframework.util.backoff.FixedBackOff"/>
+
+	<rabbit:listener-container connection-factory="connectionFactory"
+							   recovery-interval="100"
+							   recovery-back-off="backOff">
+		<rabbit:listener queues="foo" ref="testBean" method="handle"/>
+	</rabbit:listener-container>-->
+<!-- Invalid -->
+
 
 	<rabbit:listener-container id="containerWithAnonListener" connection-factory="connectionFactory">
 		<rabbit:listener queues="foo" ref="testBean" method="handle"/>

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2453,13 +2453,21 @@ Default 'true'.
 
 | Determines the time in milliseconds between attempts to start a consumer if it fails to start for non-fatal reasons.
 Default '5000'.
+Mutually exclusive with `recoveryBackOff`.
 
+| recoveryBackOff
+(recovery-back-off)
+
+| Specifies the `BackOff` for intervals between attempts to start a consumer if it fails to start for non-fatal reasons.
+Default is `FixedBackOff` with unlimited retries every 5 seconds.
+Mutually exclusive with `recoveryInterval`.
 | exclusive
 (exclusive)
 
 | Determines whether the single consumer in this container has exclusive access to the queue(s).
 The concurrency of the container must be 1 when this is true.
-If another consumer has exclusive access, the container will attempt to recover the consumer, according to the `recovery-interval`.
+If another consumer has exclusive access, the container will attempt to recover the consumer, according to the
+`recovery-interval` or `recovery-back-off`.
 When using the namespace, this attribute appears on the <rabbit:listener/> element along with the queue names.
 Default 'false'.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -75,6 +75,11 @@ The `@RabbitListener` annotation can now be applied at the class level.
 Together with the new `@RabbitHandler` method annotation, this allows the handler method to be selected based on payload
 type. See <<annotation-method-selection>> for more information.
 
+===== SimpleMessageListenerContainer: BackOff support
+
+The `SimpleMessageListenerContainer` can now be supplied with the `BackOff` for `consumer` startup recovery.
+See <<containerAttributes>> for more information.
+
 ==== Changes in 1.4 Since 1.3
 
 ===== @RabbitListener Annotation


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-427

To have more control over `recoveryInterval` add `BackOff` injection support
 for the `SimpleMessageListenerContainer`.
When the `backOffExecution` reaches `BackOffExecution.STOP`, stop the container for further recovery to prevent infinity logs pollution.