### PR TITLE
AMQP-496: Prevent AMQP threads dead lock

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -36,7 +36,12 @@ import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpTimeoutException;
 import org.springframework.amqp.rabbit.support.PublisherCallbackChannel;
 import org.springframework.amqp.rabbit.support.PublisherCallbackChannelImpl;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -72,7 +77,10 @@ import com.rabbitmq.client.ShutdownSignalException;
  * @author Gary Russell
  * @author Artem Bilan
  */
-public class CachingConnectionFactory extends AbstractConnectionFactory implements InitializingBean, ShutdownListener {
+public class CachingConnectionFactory extends AbstractConnectionFactory
+		implements InitializingBean, ShutdownListener, ApplicationContextAware, ApplicationListener<ContextClosedEvent> {
+
+	private ApplicationContext applicationContext;
 
 	public enum CacheMode {
 		/**
@@ -118,6 +126,8 @@ public class CachingConnectionFactory extends AbstractConnectionFactory implemen
 	private volatile boolean publisherReturns;
 
 	private volatile boolean initialized;
+
+	private volatile boolean stopped;
 
 	/** Synchronization monitor for the shared Connection */
 	private final Object connectionMonitor = new Object();
@@ -282,6 +292,18 @@ public class CachingConnectionFactory extends AbstractConnectionFactory implemen
 		}
 	}
 
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public void onApplicationEvent(ContextClosedEvent event) {
+		if (this.applicationContext == event.getApplicationContext()) {
+			this.stopped = true;
+		}
+	}
+
 	private Channel getChannel(ChannelCachingConnectionProxy connection, boolean transactional) {
 		if (this.channelCheckoutTimeout > 0) {
 			Semaphore checkoutPermits = this.checkoutPermits.get(connection);
@@ -438,6 +460,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory implemen
 
 	@Override
 	public final Connection createConnection() throws AmqpException {
+		Assert.state(!this.stopped, "The ConnectionFactory isn't active any more for obtaining connection.");
 		synchronized (this.connectionMonitor) {
 			if (this.cacheMode == CacheMode.CHANNEL) {
 				if (this.connection == null) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-496

The long living message listener performs `channel.basicAck` (`channel.txCommit()`)
to late after stopping container and connectionFactory.
It may cause unexpected dead locks in the underlying AMQP thread.

Since this `late commit` does not make any sense already,
because `consumer` has been canceled already by the `container.stop()`,
just add a `if (this.cancelled.get()) {` check and return immediately from `BlockingQueueConsumer#commitIfNecessary`
to prevent undesired connections to the Broker.

