### PR TITLE
AMQP-498: Adjust Consumers With ChannelTransacted

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -803,7 +803,8 @@ public class BlockingQueueConsumer {
 				RabbitUtils.commitIfNecessary(channel);
 			}
 
-		} finally {
+		}
+		finally {
 			deliveryTags.clear();
 		}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1134,15 +1134,11 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					ConsumerChannelRegistry.registerConsumerChannel(consumer.getChannel(), getConnectionFactory());
 				}
 
-				// Always better to stop receiving as soon as possible if
-				// transactional
-				boolean continuable = false;
-				while (isActive(this.consumer) || this.consumer.hasDelivery() || continuable) {
+				while (isActive(this.consumer) || this.consumer.hasDelivery()) {
 					try {
-						// Will come back false when the queue is drained
-						continuable = receiveAndExecute(this.consumer) && !isChannelTransacted();
+						boolean receivedOk = receiveAndExecute(this.consumer); // At least one message received
 						if (SimpleMessageListenerContainer.this.maxConcurrentConsumers != null) {
-							if (continuable) {
+							if (receivedOk) {
 								if (isActive(this.consumer)) {
 									consecutiveIdles = 0;
 									if (consecutiveMessages++ > SimpleMessageListenerContainer.this.consecutiveActiveTrigger) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-498

In earlier versions, the while loop to drain the queue took an early exit
when the channel was transacted. (This was actually incorrect since message
delivery is not transactional, only acks).

AMQP-388 introduced a new OR condition on the loop: `consumer.hasDelivery()`.

This effectively made the `continuable` boolean in the OR condition irrelevant.
This boolean was true if messages were received and the channel was not transactional.

Another side effect was the `continuable` boolean was incorrectly used to adjust the consumers
if the workload demanded. Instead, that decision should have depended just on whether
messages were received; whether the channel is transacted is irrelevent.

Remove the `continuable` boolean; fix the while loop and use a new boolean `receivedOk` which
indicates whether messages were received and so whether we should consider increasing the
consumers.

Add a test to verify consumers are adjusted for transactional channels.