### PR TITLE
AMQP-502: Fix Fanout @Binding Declaration

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -437,7 +437,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 					exchange = new FanoutExchange(exchangeName,
 							resolveExpressionAsBoolean(bindingExchange.durable()),
 							resolveExpressionAsBoolean(bindingExchange.autoDelete()));
-					actualBinding = new Binding(queueName, DestinationType.QUEUE, exchangeName, null, null);
+					actualBinding = new Binding(queueName, DestinationType.QUEUE, exchangeName, "", null);
 				}
 				else if (exchangeType.equals(ExchangeTypes.TOPIC)) {
 					exchange = new TopicExchange(exchangeName,

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -99,6 +99,11 @@ public class EnableRabbitIntegrationTests {
 	}
 
 	@Test
+	public void autoDeclareFanout() {
+		assertEquals("FOOFOO", rabbitTemplate.convertSendAndReceive("auto.exch.fanout", "", "foo"));
+	}
+
+	@Test
 	public void autoDeclareAnon() {
 		assertEquals("FOO", rabbitTemplate.convertSendAndReceive("auto.exch", "auto.anon.rk", "foo"));
 	}
@@ -189,6 +194,14 @@ public class EnableRabbitIntegrationTests {
 		)
 		public String handleWithDeclare(String foo) {
 			return foo.toUpperCase();
+		}
+
+		@RabbitListener(bindings = @QueueBinding(
+				value = @Queue(value = "auto.declare.fanout", autoDelete = "true"),
+				exchange = @Exchange(value = "auto.exch.fanout", autoDelete = "true", type="fanout"))
+		)
+		public String handleWithFanout(String foo) {
+			return foo.toUpperCase() + foo.toUpperCase();
 		}
 
 		@RabbitListener(bindings = {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-502

Queues are bound to fanout exchanges with no routing key.
The `RabbitListenerAnnotationBeanPostProcessor` incorrectly set the key to `null` instead of `""`.

Add a test for a fanout exchange.