### PR TITLE
AMQP-504: Update to RabbitMQ 3.5.3 Client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ subprojects { subproject ->
 		log4jVersion = '1.2.17'
 		logbackVersion = '1.1.2'
 		mockitoVersion = '1.9.5'
-		rabbitmqVersion = project.hasProperty('rabbitmqVersion') ? project.rabbitmqVersion : '3.5.1'
+		rabbitmqVersion = project.hasProperty('rabbitmqVersion') ? project.rabbitmqVersion : '3.5.3'
 		rabbitmqHttpClientVersion = '1.0.0.M1'
 
 		springVersion = project.hasProperty('springVersion') ? project.springVersion : '4.1.6.RELEASE'
@@ -216,9 +216,6 @@ project('spring-rabbit') {
 
 		compile ("ch.qos.logback:logback-classic:$logbackVersion", optional)
 	}
-
-	// suppress deprecation warnings (@SuppressWarnings("deprecation") is not enough for javac)
-	compileJava.options.compilerArgs = ["${xLintArg},-deprecation"]
 
 }
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -18,6 +18,7 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -221,6 +222,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 			return connection;
 		}
 		catch (IOException e) {
+			throw RabbitExceptionTranslator.convertRabbitAccessException(e);
+		}
+		catch (TimeoutException e) {
 			throw RabbitExceptionTranslator.convertRabbitAccessException(e);
 		}
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.springframework.amqp.AmqpException;
@@ -363,6 +364,11 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 						catch (IOException e) {
 							if (logger.isDebugEnabled()) {
 								logger.debug("Unexpected Exception closing channel " + e.getMessage());
+							}
+						}
+						catch (TimeoutException e) {
+							if (logger.isWarnEnabled()) {
+								logger.warn("TimeoutException closing channel " + e.getMessage());
 							}
 						}
 						channel = null;
@@ -749,6 +755,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 								}
 								catch (IOException e) {}
 								catch (AlreadyClosedException e) {}
+								catch (TimeoutException e) {}
 							}
 						}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
@@ -424,6 +425,9 @@ public class BlockingQueueConsumer {
 								channel.close();
 							}
 							catch (IOException e) {
+								//Ignore it
+							}
+							catch (TimeoutException e) {
 								//Ignore it
 							}
 						}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -192,7 +192,7 @@ public class PublisherCallbackChannelImpl
 		return this.delegate.getConnection();
 	}
 
-	public void close(int closeCode, String closeMessage) throws IOException {
+	public void close(int closeCode, String closeMessage) throws IOException, TimeoutException {
 		this.delegate.close(closeCode, closeMessage);
 	}
 
@@ -225,7 +225,9 @@ public class PublisherCallbackChannelImpl
 	/**
 	 * Added to the 3.3.x client
 	 * @since 1.3.3
+	 * @deprecated in the 3.5.3 client
 	 */
+	@Deprecated
 	public boolean flowBlocked() {
 		if (this.flowBlockedMethod != null) {
 			return (Boolean) ReflectionUtils.invokeMethod(this.flowBlockedMethod, this.delegate);
@@ -241,14 +243,17 @@ public class PublisherCallbackChannelImpl
 		this.delegate.abort(closeCode, closeMessage);
 	}
 
+	@SuppressWarnings("deprecation")
 	public void addFlowListener(FlowListener listener) {
 		this.delegate.addFlowListener(listener);
 	}
 
+	@SuppressWarnings("deprecation")
 	public boolean removeFlowListener(FlowListener listener) {
 		return this.delegate.removeFlowListener(listener);
 	}
 
+	@SuppressWarnings("deprecation")
 	public void clearFlowListeners() {
 		this.delegate.clearFlowListeners();
 	}
@@ -618,7 +623,7 @@ public class PublisherCallbackChannelImpl
 // END PURE DELEGATE METHODS
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	public void close() throws IOException {
+	public void close() throws IOException, TimeoutException {
 		try {
 			this.delegate.close();
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/RabbitExceptionTranslator.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/RabbitExceptionTranslator.java
@@ -18,11 +18,13 @@ package org.springframework.amqp.rabbit.support;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
+import java.util.concurrent.TimeoutException;
 
 import org.springframework.amqp.AmqpAuthenticationException;
 import org.springframework.amqp.AmqpConnectException;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpIOException;
+import org.springframework.amqp.AmqpTimeoutException;
 import org.springframework.amqp.AmqpUnsupportedEncodingException;
 import org.springframework.amqp.UncategorizedAmqpException;
 import org.springframework.util.Assert;
@@ -61,6 +63,9 @@ public class RabbitExceptionTranslator {
 		}
 		if (ex instanceof IOException) {
 			return new AmqpIOException((IOException) ex);
+		}
+		if (ex instanceof TimeoutException) {
+			return new AmqpTimeoutException((IOException) ex);
 		}
 		// fallback
 		return new UncategorizedAmqpException(ex);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactoryTests.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,7 +33,7 @@ public abstract class AbstractConnectionFactoryTests {
 	protected abstract AbstractConnectionFactory createConnectionFactory(ConnectionFactory mockConnectionFactory);
 
 	@Test
-	public void testWithListener() throws IOException {
+	public void testWithListener() throws Exception {
 
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
@@ -79,7 +78,7 @@ public abstract class AbstractConnectionFactoryTests {
 	}
 
 	@Test
-	public void testWithListenerRegisteredAfterOpen() throws IOException {
+	public void testWithListenerRegisteredAfterOpen() throws Exception {
 
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -44,6 +44,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -75,7 +76,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void testWithConnectionFactoryDefaults() throws IOException {
+	public void testWithConnectionFactoryDefaults() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel = mock(Channel.class);
@@ -107,7 +108,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 	}
 	@Test
-	public void testWithConnectionFactoryCacheSize() throws IOException {
+	public void testWithConnectionFactoryCacheSize() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel1 = mock(Channel.class);
@@ -165,7 +166,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void testCacheSizeExceeded() throws IOException {
+	public void testCacheSizeExceeded() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel1 = mock(Channel.class);
@@ -221,7 +222,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void testCheckoutLimit() throws IOException {
+	public void testCheckoutLimit() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel1 = mock(Channel.class);
@@ -305,6 +306,8 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 				}
 				catch (IOException e) {
 				}
+				catch (TimeoutException e) {
+				}
 			}
 
 		}).start();
@@ -322,7 +325,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void testCacheSizeExceededAfterClose() throws IOException {
+	public void testCacheSizeExceededAfterClose() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel1 = mock(Channel.class);
@@ -369,7 +372,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void testTransactionalAndNonTransactionalChannelsSegregated() throws IOException {
+	public void testTransactionalAndNonTransactionalChannelsSegregated() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel1 = mock(Channel.class);
@@ -426,7 +429,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void testWithConnectionFactoryDestroy() throws IOException {
+	public void testWithConnectionFactoryDestroy() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 
@@ -496,7 +499,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void testWithChannelListener() throws IOException {
+	public void testWithChannelListener() throws Exception {
 
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
@@ -537,7 +540,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void testWithConnectionListener() throws IOException {
+	public void testWithConnectionListener() throws Exception {
 
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection1 = mock(com.rabbitmq.client.Connection.class);
@@ -1087,7 +1090,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void setAddressesEmpty() throws IOException {
+	public void setAddressesEmpty() throws Exception {
 		ConnectionFactory mock = mock(com.rabbitmq.client.ConnectionFactory.class);
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
 		ccf.setHost("abc");
@@ -1099,7 +1102,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void setAddressesOneHost() throws IOException {
+	public void setAddressesOneHost() throws Exception {
 		ConnectionFactory mock = mock(com.rabbitmq.client.ConnectionFactory.class);
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
 		ccf.setAddresses("mq1");
@@ -1109,7 +1112,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void setAddressesTwoHosts() throws IOException {
+	public void setAddressesTwoHosts() throws Exception {
 		ConnectionFactory mock = mock(com.rabbitmq.client.ConnectionFactory.class);
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
 		ccf.setAddresses("mq1,mq2");
@@ -1120,7 +1123,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	public void testChannelCloseIdempotency() throws IOException {
+	public void testChannelCloseIdempotency() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel = mock(Channel.class);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SingleConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SingleConnectionFactoryTests.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,7 +28,7 @@ public class SingleConnectionFactoryTests extends AbstractConnectionFactoryTests
 	}
 
 	@Test
-	public void testWithChannelListener() throws IOException {
+	public void testWithChannelListener() throws Exception {
 
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-504

`TimeoutException`, deprecations.

Also, the JDK `javac` now seems to honor `@SuppressWarnings("deprecation")` - remove the lint `-deprecation` option