### PR TITLE
Add setUri() method to ConnectionFactory classes

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -14,7 +14,10 @@ package org.springframework.amqp.rabbit.connection;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -55,7 +58,7 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	private volatile int closeTimeout = DEFAULT_CLOSE_TIMEOUT;
 
 	/**
-	 * Create a new SingleConnectionFactory for the given target ConnectionFactory.
+	 * Create a new AbstractConnectionFactory for the given target ConnectionFactory.
 	 * @param rabbitConnectionFactory the target ConnectionFactory
 	 */
 	public AbstractConnectionFactory(com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory) {
@@ -73,6 +76,16 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	public void setHost(String host) {
 		this.rabbitConnectionFactory.setHost(host);
+	}
+
+	public void setUri(URI uri) {
+		try {
+			this.rabbitConnectionFactory.setUri(uri);
+		} catch (URISyntaxException use) {
+			logger.info("setUri() was passed an invalid URI; it is ignored", use);
+		} catch (GeneralSecurityException gse) {
+			logger.info("setUri() was passed an invalid URI; it is ignored", gse);
+		}
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -18,6 +18,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -163,6 +164,15 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		}
 		setHost(hostname);
 		setPort(port);
+	}
+
+	/**
+	 * Create a new CachingConnectionFactory given a {@link URI}.
+	 * @param uri the amqp uri configuring the connection
+	 */
+	public CachingConnectionFactory(URI uri) {
+		super(new com.rabbitmq.client.ConnectionFactory());
+		setUri(uri);
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -31,8 +31,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.inOrder;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,6 +51,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
+import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -1119,6 +1122,22 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.createConnection();
 		verify(mock).newConnection(isNull(ExecutorService.class),
 				aryEq(new Address[] { new Address("mq1"), new Address("mq2") }));
+		verifyNoMoreInteractions(mock);
+	}
+
+	@Test
+	public void setUri() throws Exception {
+		URI uri = new URI("amqp://localhost:1234/%2f");
+
+		ConnectionFactory mock = mock(com.rabbitmq.client.ConnectionFactory.class);
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
+
+		ccf.setUri(uri);
+		ccf.createConnection();
+
+		InOrder order = inOrder(mock);
+		order.verify(mock).setUri(uri);
+		order.verify(mock).newConnection((ExecutorService)null);
 		verifyNoMoreInteractions(mock);
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SingleConnectionFactory.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SingleConnectionFactory.java
@@ -13,6 +13,7 @@
 
 package org.springframework.amqp.rabbit.connection;
 
+import java.net.URI;
 import java.util.List;
 
 import org.springframework.amqp.AmqpException;
@@ -72,6 +73,15 @@ public class SingleConnectionFactory extends AbstractConnectionFactory {
 		}
 		setHost(hostname);
 		setPort(port);
+	}
+
+	/**
+	 * Create a new SingleConnectionFactory given a {@link URI}.
+	 * @param uri the amqp uri configuring the connection
+	 */
+	public SingleConnectionFactory(URI uri) {
+		super(new com.rabbitmq.client.ConnectionFactory());
+		setUri(uri);
 	}
 
 	/**


### PR DESCRIPTION
Previously the setUri() method on rabbitmq.ConnectionFactory was not exposed
to the CachingConnectionFactory nor the SingleConnectionFactory. This change
adds this method to the AbstractConnectionFactory, which is then inherited by
the two implementation classes.

A constructor taking the URI is added to CachingConnectionFactory and also to
the SingleConnectionFactory to short-circuit the construction even further.