### PR TITLE
AMQP-506: Publisher Confirms Concurrency

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -514,16 +514,18 @@ public class RabbitTemplate extends RabbitAccessor
 			long threshold = System.currentTimeMillis() - age;
 			for (Entry<Object, SortedMap<Long, PendingConfirm>> channelPendingConfirmEntry : this.pendingConfirms.entrySet()) {
 				SortedMap<Long, PendingConfirm> channelPendingConfirms = channelPendingConfirmEntry.getValue();
-				Iterator<Entry<Long, PendingConfirm>> iterator = channelPendingConfirms.entrySet().iterator();
-				PendingConfirm pendingConfirm;
-				while (iterator.hasNext()) {
-					pendingConfirm = iterator.next().getValue();
-					if (pendingConfirm.getTimestamp() < threshold) {
-						unconfirmed.add(pendingConfirm.getCorrelationData());
-						iterator.remove();
-					}
-					else {
-						break;
+				synchronized(channelPendingConfirms) {
+					Iterator<Entry<Long, PendingConfirm>> iterator = channelPendingConfirms.entrySet().iterator();
+					PendingConfirm pendingConfirm;
+					while (iterator.hasNext()) {
+						pendingConfirm = iterator.next().getValue();
+						if (pendingConfirm.getTimestamp() < threshold) {
+							unconfirmed.add(pendingConfirm.getCorrelationData());
+							iterator.remove();
+						}
+						else {
+							break;
+						}
 					}
 				}
 			}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -639,16 +639,18 @@ public class PublisherCallbackChannelImpl
 		synchronized (this.pendingConfirms) {
 			for (Entry<Listener, SortedMap<Long, PendingConfirm>> entry : this.pendingConfirms.entrySet()) {
 				Listener listener = entry.getKey();
-				for (Entry<Long, PendingConfirm> confirmEntry : entry.getValue().entrySet()) {
-					try {
-						confirmEntry.getValue().setCause(cause);
-						handleNack(confirmEntry.getKey(), false);
+				synchronized(entry.getValue()) {
+					for (Entry<Long, PendingConfirm> confirmEntry : entry.getValue().entrySet()) {
+						try {
+							confirmEntry.getValue().setCause(cause);
+							handleNack(confirmEntry.getKey(), false);
+						}
+						catch (IOException e) {
+							logger.error("Error delivering Nack afterShutdown", e);
+						}
 					}
-					catch (IOException e) {
-						logger.error("Error delivering Nack afterShutdown", e);
-					}
+					listener.removePendingConfirmsReference(this, entry.getValue());
 				}
-				listener.removePendingConfirmsReference(this, entry.getValue());
 			}
 			this.pendingConfirms.clear();
 			this.listenerForSeq.clear();
@@ -724,13 +726,15 @@ public class PublisherCallbackChannelImpl
 					// find all unack'd confirms for this listener and handle them
 					SortedMap<Long, PendingConfirm> confirmsMap = this.pendingConfirms.get(involvedListener);
 					if (confirmsMap != null) {
-						Map<Long, PendingConfirm> confirms = confirmsMap.headMap(seq + 1);
-						Iterator<Entry<Long, PendingConfirm>> iterator = confirms.entrySet().iterator();
-						while (iterator.hasNext()) {
-							Entry<Long, PendingConfirm> entry = iterator.next();
-							PendingConfirm value = entry.getValue();
-							iterator.remove();
-							doHandleConfirm(ack, involvedListener, value);
+						synchronized(confirmsMap) {
+							Map<Long, PendingConfirm> confirms = confirmsMap.headMap(seq + 1);
+							Iterator<Entry<Long, PendingConfirm>> iterator = confirms.entrySet().iterator();
+							while (iterator.hasNext()) {
+								Entry<Long, PendingConfirm> entry = iterator.next();
+								PendingConfirm value = entry.getValue();
+								iterator.remove();
+								doHandleConfirm(ack, involvedListener, value);
+							}
 						}
 					}
 				}
@@ -743,7 +747,11 @@ public class PublisherCallbackChannelImpl
 		else {
 			Listener listener = this.listenerForSeq.remove(seq);
 			if (listener != null) {
-				PendingConfirm pendingConfirm = this.pendingConfirms.get(listener).remove(seq);
+				SortedMap<Long, PendingConfirm> confirmsForListener = this.pendingConfirms.get(listener);
+				PendingConfirm pendingConfirm = null;
+				synchronized (confirmsForListener) {
+					pendingConfirm = confirmsForListener.remove(seq);
+				}
 				if (pendingConfirm != null) {
 					doHandleConfirm(ack, listener, pendingConfirm);
 				}
@@ -771,7 +779,7 @@ public class PublisherCallbackChannelImpl
 	public void addPendingConfirm(Listener listener, long seq, PendingConfirm pendingConfirm) {
 		SortedMap<Long, PendingConfirm> pendingConfirmsForListener = this.pendingConfirms.get(listener);
 		Assert.notNull(pendingConfirmsForListener, "Listener not registered");
-		synchronized (this.pendingConfirms) {
+		synchronized (pendingConfirmsForListener) {
 			pendingConfirmsForListener.put(seq, pendingConfirm);
 		}
 		this.listenerForSeq.put(seq, listener);


### PR DESCRIPTION
JIRA:https://jira.spring.io/browse/AMQP-506

`RabbitTemplate` provides a method `getUnconfirmed` to get aged
non-confirmed correlation data.

This was not thread-safe.

While the `pendingConfirms` objects in `RabbitTemplate` and `PublisherCallbackChannelImpl`
are concurrent hash maps, they are maps of maps with the inner maps being
`Collections.synchronizedSortedMap`. While iterating over these maps, they must be
synchronized.

Add a test case to reproduce the exception and verify the problem is resolved.

__cherry-pick to 1.4.x, 1.3.x__