### PR TITLE
AMQP-499: Make WARN Log Configurable

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -262,6 +263,9 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
 		container2.setApplicationEventPublisher(publisher);
 		container2.afterPropertiesSet();
+		Log containerLogger = spy(TestUtils.getPropertyValue(container2, "logger", Log.class));
+		when(containerLogger.isWarnEnabled()).thenReturn(true);
+		new DirectFieldAccessor(container2).setPropertyValue("logger", containerLogger);
 		container2.start();
 		for (int i = 0; i < 1000; i++) {
 			template.convertAndSend(queue.getName(), i + "foo");
@@ -285,6 +289,7 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		assertEquals("Consumer raised exception, attempting restart", event.getReason());
 		assertFalse(event.isFatal());
 		assertThat(event.getThrowable(), instanceOf(AmqpIOException.class));
+		verify(containerLogger).warn(any());
 	}
 
 	@Test

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -440,6 +440,7 @@ INFO level.
 To modify this behavior, inject a custom `ConditionalExceptionLogger` into the
 `CachingConnectionFactory` in its `closeExceptionLogger` property.
 
+Also see <<consumer-events>>.
 
 [[amqp-template]]
 ==== AmqpTemplate
@@ -1043,6 +1044,13 @@ These events can be consumed by implementing `ApplicationListener<ListenerContai
 
 NOTE: System-wide events (such as connection failures) will be published by all consumers when `concurrentConsumers`
 is greater than 1.
+
+If a consumer fails because one if its queues is being used exclusively, by default, as well as publishing the
+event, a `WARN` log is issued. To change this logging behavior, provide a custom `ConditionalExceptionLogger` in the
+`SimpleMessageListenerContainer` 's `exclusiveConsumerExceptionLogger` property.
+See also <<channel-close-logging>>.
+
+Fatal errors are always logged at `ERROR` level; this it not modifiable.
 
 [[consumerTags]]
 ==== Consumer Tags


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-499

The previous fix was incomplete. The listener container also
emits a WARN log when the queue cannot be consumed due to exclusivity.

Provide a mechanism to customize that log too.