### PR TITLE
AMQP-511: Support SpEL in @SendTo

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -254,6 +254,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 		method = checkProxy(method, bean);
 		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
 		endpoint.setMethod(method);
+		endpoint.setBeanFactory(this.beanFactory);
 		processListener(endpoint, rabbitListener, bean, method, beanName);
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,23 +26,30 @@ import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.config.BeanExpressionContext;
+import org.springframework.beans.factory.config.BeanExpressionResolver;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.util.Assert;
 
 /**
  * Base model for a Rabbit listener endpoint
  *
  * @author Stephane Nicoll
+ * @author Gary Russell
  * @since 1.4
  * @see MethodRabbitListenerEndpoint
  * @see SimpleRabbitListenerEndpoint
  */
-public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEndpoint {
+public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEndpoint, BeanFactoryAware {
 
 	private String id;
 
-	private Collection<Queue> queues = new ArrayList<Queue>();
+	private final Collection<Queue> queues = new ArrayList<Queue>();
 
-	private Collection<String> queueNames = new ArrayList<String>();
+	private final Collection<String> queueNames = new ArrayList<String>();
 
 	private boolean exclusive;
 
@@ -50,6 +57,33 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 
 	private RabbitAdmin admin;
 
+	private BeanFactory beanFactory;
+
+	private BeanExpressionResolver resolver;
+
+	private BeanExpressionContext expressionContext;
+
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+		if (beanFactory instanceof ConfigurableListableBeanFactory) {
+			this.resolver = ((ConfigurableListableBeanFactory) beanFactory).getBeanExpressionResolver();
+			this.expressionContext = new BeanExpressionContext((ConfigurableListableBeanFactory) beanFactory, null);
+		}
+	}
+
+	protected BeanFactory getBeanFactory() {
+		return beanFactory;
+	}
+
+	protected BeanExpressionResolver getResolver() {
+		return resolver;
+	}
+
+	protected BeanExpressionContext getBeanExpressionContext() {
+		return expressionContext;
+	}
 
 	public void setId(String id) {
 		this.id = id;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
@@ -132,9 +132,20 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 				throw new IllegalStateException("Invalid @" + SendTo.class.getSimpleName() + " annotation on '"
 						+ getMethod() + "' one destination must be set (got " + Arrays.toString(destinations) + ")");
 			}
-			return destinations.length == 1 ? new Address(destinations[0]) : new Address(null);
+			return destinations.length == 1 ? new Address(resolve(destinations[0])) : new Address(null);
 		}
 		return null;
+	}
+
+	private String resolve(String value) {
+		if (this.getResolver() != null) {
+			Object newValue = this.getResolver().evaluate(value, getBeanExpressionContext());
+			Assert.isInstanceOf(String.class, newValue, "Invalid @SendTo expression");
+			return (String) newValue;
+		}
+		else {
+			return value;
+		}
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/RabbitExceptionTranslator.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/RabbitExceptionTranslator.java
@@ -65,7 +65,7 @@ public class RabbitExceptionTranslator {
 			return new AmqpIOException((IOException) ex);
 		}
 		if (ex instanceof TimeoutException) {
-			return new AmqpTimeoutException((IOException) ex);
+			return new AmqpTimeoutException(ex);
 		}
 		// fallback
 		return new UncategorizedAmqpException(ex);

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1352,6 +1352,27 @@ Also `@SendTo` can be used without a `value` attribute.
 This case is equal to an empty sendTo pattern.
 `@SendTo` is only used if the inbound message does not have a `replyToAddress` property.
 
+Starting with _version 1.5_, the `@SendTo` value can be a SpEL Expression, for example...
+
+[source, java]
+----
+@RabbitListener(queues = "test.sendTo.spel")
+@SendTo("#{spelReplyTo}")
+public String capitalizeWithSendToSpel(String foo) {
+    return foo.toUpperCase();
+}
+...
+@Bean
+public String spelReplyTo() {
+    return "test.sendTo.reply.spel";
+}
+----
+
+The expression must evaluate to a `String`, which can be a simple queue name (sent to the default exchange) or with
+the form `exchange/routingKey` as discussed above.
+The expression is evaluated once, during context initialization.
+For dynamic reply routing, the message sender should include a `reply_to` message property.
+
 [[annotation-method-selection]]
 ====== Multi-Method Listeners
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -47,11 +47,19 @@ The converter has an alternative constructor that takes the value as a limit.
 Previously, this limit was hard-coded at `1024` bytes.
 (Also available in _1.4.4_).
 
-===== @QueueBinding for @RabbitListener
+===== @RabbitListener Improvements
+
+====== @QueueBinding for @RabbitListener
 
 The `bindings` attribute has been added to the `@RabbitListener` annotation as mutually exclusive with the `queues`
 attribute to allow the specification of the `queue`, its `exchange` and `binding` for declaration by a `RabbitAdmin` on
 the Broker.
+
+====== SpEL in @SendTo
+
+The default reply address (`@SendTo`) for a `@RabbitListener` can now be a SpEL expression.
+
+
 See <<async-annotation-driven>> for more information.
 
 ===== Automatic Exchange, Queue, Binding Declaration


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-511

Previously, only literals were supported in `@SendTo` values.

Add support for SpEL expressions (`#{...}`).