### PR TITLE
AMQP-516: Fix Auto-Declare Anonymous Queue

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -401,10 +401,13 @@ public class RabbitListenerAnnotationBeanPostProcessor
 				boolean autoDelete = false;
 				if (!StringUtils.hasText(queueName)) {
 					queueName = UUID.randomUUID().toString();
-					if (!StringUtils.hasText(bindingQueue.exclusive())) {
+					// default exclusive/autodelete to true when anonymous
+					if (!StringUtils.hasText(bindingQueue.exclusive())
+							|| resolveExpressionAsBoolean(bindingQueue.exclusive())) {
 						exclusive = true;
 					}
-					if (!StringUtils.hasText(bindingQueue.autoDelete())) {
+					if (!StringUtils.hasText(bindingQueue.autoDelete())
+							|| resolveExpressionAsBoolean(bindingQueue.autoDelete())) {
 						autoDelete = true;
 					}
 				}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-516

Previously, anonymous queues (no value attribute) were only declared
auto-delete and exclusive if those attributes were not provided.

Still default to true, but also use the value if provided.