### PR TITLE
AMQP-518: Remove <listener-container/> id Attrib.

### DIFF
--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.5.xsd
@@ -509,6 +509,12 @@
 	</xsd:element>
 
 	<xsd:complexType name="listenerContainerBaseType">
+<!--
+	REMOVED in 1.5 - originally, it was deprecated in 1.5 M1 but that resulted in confusion.
+	So, we decided to remove it completely so configuration will fail fast when migrating to 1.5.
+
+	Users need to move the id from the listener-container element to the child listener elements.
+
 		<xsd:attribute name="id" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -520,6 +526,7 @@
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+-->
 		<xsd:attribute name="task-executor" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -40,7 +40,7 @@
 		<rabbit:listener id="container6" queues="foo" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 
-	<rabbit:listener-container id="containerWithNamedListeners" connection-factory="connectionFactory">
+	<rabbit:listener-container connection-factory="connectionFactory">
 		<rabbit:listener id="testListener1" queues="foo" ref="testBean" method="handle"/>
 		<rabbit:listener id="testListener2" queues="bar" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
@@ -62,11 +62,11 @@
 <!-- Invalid -->
 
 
-	<rabbit:listener-container id="containerWithAnonListener" connection-factory="connectionFactory">
+	<rabbit:listener-container connection-factory="connectionFactory">
 		<rabbit:listener queues="foo" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 
-	<rabbit:listener-container id="containerWithAnonListeners" connection-factory="connectionFactory">
+	<rabbit:listener-container connection-factory="connectionFactory">
 		<rabbit:listener queues="foo" ref="testBean" method="handle"/>
 		<rabbit:listener id="namedListener" queues="bar" ref="testBean" method="handle"/>
 		<rabbit:listener queues="bar" ref="testBean" method="handle"/>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-fail-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-fail-context.xml
@@ -11,7 +11,7 @@
 
 	<rabbit:queue id="bar" />
 
-	<rabbit:listener-container id="container6" connection-factory="connectionFactory" channel-transacted="true" acknowledge="none" >
+	<rabbit:listener-container connection-factory="connectionFactory" channel-transacted="true" acknowledge="none" >
 		<rabbit:listener id="testListener" queues="foo" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests-context.xml
@@ -19,7 +19,8 @@
 
 	<rabbit:queue id="bar" />
 
-	<rabbit:listener-container id="container1" connection-factory="connectionFactory" acknowledge="manual" concurrency="${five}" transaction-size="${one}" auto-startup="${false}">
+	<rabbit:listener-container connection-factory="connectionFactory" acknowledge="manual"
+			concurrency="${five}" transaction-size="${one}" auto-startup="${false}">
 		<rabbit:listener id="testListener" queue-names="foo, #{bar.name}" ref="testBean" method="handle"/>
 	</rabbit:listener-container>
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -109,12 +109,19 @@ See <<management-template>> for more information.
 
 ===== Listener Container Bean Names (XML)
 
-The `id` attribute on the `<listener-container/>` element is deprecated and ignored.
+[IMPORTANT]
+====
+The `id` attribute on the `<listener-container/>` element has been removed.
 Starting with this release, the `id` on the `<listener/>` child element is used alone to name the listener container
-bean.
+bean created for each listener element.
+
 Normal Spring bean name overrides are applied; if a later `<listener/>` is parsed with the same `id` as an existing
 bean, the new definition will override the existing one.
 Previously, bean names were composed from the ids of the `<listener-container/>` and `<listener/>` elements.
+
+When migrating to this release, if you have `id` s on your `<listener-container/>` elements, remove them and set the
+`id` on the child `<listener/>` element instead.
+====
 
 ===== Class-Level @RabbitListener
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-518

Previously, we deprecated the ID (AMQP-416) but simply ignoring it
is not really a good solution because the user "discovers" the bean
name changes (e.g. when autowiring).

Remove the attribute instead to force a fast failure.

Leave the attribute in the schema as a comment, in case users look there
first after seeing the problem after an upgrade.

Beef up the what's new to an `IMPORTANT` block.