### PR TITLE
AMQP-522: Make RabbitAdmin Constants Public

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -56,13 +56,28 @@ import com.rabbitmq.client.Channel;
  */
 public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, InitializingBean {
 
-	protected static final String DEFAULT_EXCHANGE_NAME = "";
+	/**
+	 * The default exchange name.
+	 */
+	public static final String DEFAULT_EXCHANGE_NAME = "";
 
-	protected static final Object QUEUE_NAME = "QUEUE_NAME";
+	/**
+	 * Property key for the queue name in the {@link Properties} returned by
+	 * {@link #getQueueProperties(String)}.
+	 */
+	public static final Object QUEUE_NAME = "QUEUE_NAME";
 
-	protected static final Object QUEUE_MESSAGE_COUNT = "QUEUE_MESSAGE_COUNT";
+	/**
+	 * Property key for the message count in the {@link Properties} returned by
+	 * {@link #getQueueProperties(String)}.
+	 */
+	public static final Object QUEUE_MESSAGE_COUNT = "QUEUE_MESSAGE_COUNT";
 
-	protected static final Object QUEUE_CONSUMER_COUNT = "QUEUE_CONSUMER_COUNT";
+	/**
+	 * Property key for the consumer count in the {@link Properties} returned by
+	 * {@link #getQueueProperties(String)}.
+	 */
+	public static final Object QUEUE_CONSUMER_COUNT = "QUEUE_CONSUMER_COUNT";
 
 	/** Logger available to subclasses */
 	protected final Log logger = LogFactory.getLog(getClass());

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1939,6 +1939,11 @@ public interface AmqpAdmin {
 }
 ----
 
+The `getQueueProperties()` method returns some limited information about the queue (message count and consumer count).
+The keys for the properties returned are available as constants in the `RabbitTemplate` (`QUEUE_NAME`,
+`QUEUE_MESSAGE_COUNT`, `QUEUE_CONSUMER_COUNT`).
+The <<management-template, RabbitMQ REST API>> provides much more information in the `QueueInfo` object.
+
 The no-arg declareQueue() method defines a queue on the broker whose name is automatically generated.
 The additional properties of this auto-generated queue are `exclusive=true`, `autoDelete=true`, and `durable=false`.
 
@@ -2336,7 +2341,8 @@ public Binding binding() {
 When the management plugin is enabled, the RabbitMQ server exposes a REST API to monitor and configure the broker.
 A https://github.com/rabbitmq/hop[Java Binding for the API] is now provided.
 In general, you can use that API directly, but a convenience wrapper is provided to use the familiar Spring AMQP `Queue`, `Exchange`, and `Binding` domain objects with the API.
-More information is available for these objects when using the `com.rabbitmq.http.client.Client` API directly (`QueueInfo`, `ExchangeInfo`, and `BindingInfo` respectively).
+Much more information is available for these objects when using the `com.rabbitmq.http.client.Client` API directly
+(`QueueInfo`, `ExchangeInfo`, and `BindingInfo` respectively).
 The following operations are available on the `RabbitManagementTemplate`:
 
 [source, java]


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-522

Update docs.

__cherry-pick to 4.1.x (minus docs)__