### PR TITLE
AMQP-523: Fix Class Tangle

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ListenerContainerConsumerFailedEvent.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ListenerContainerConsumerFailedEvent.java
@@ -41,16 +41,12 @@ public class ListenerContainerConsumerFailedEvent extends AmqpEvent {
 	 * @param throwable the throwable.
 	 * @param fatal true if the startup failure was fatal (will not be retried).
 	 */
-	public ListenerContainerConsumerFailedEvent(SimpleMessageListenerContainer source, String reason,
+	public ListenerContainerConsumerFailedEvent(Object source, String reason,
 			Throwable throwable, boolean fatal) {
 		super(source);
 		this.reason = reason;
 		this.fatal = fatal;
 		this.throwable = throwable;
-	}
-
-	public SimpleMessageListenerContainer getContainer() {
-		return (SimpleMessageListenerContainer) this.source;
 	}
 
 	public String getReason() {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -184,6 +184,7 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		verify(publisher).publishEvent(captor.capture());
 		ListenerContainerConsumerFailedEvent event = captor.getValue();
 		assertThat(event.getThrowable(), instanceOf(ConsumerCancelledException.class));
+		assertFalse(event.isFatal());
 		DirectFieldAccessor dfa = new DirectFieldAccessor(newConsumer);
 		dfa.setPropertyValue("lastRetryDeclaration", 0);
 		dfa.setPropertyValue("retryDeclarationInterval", 100);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-523

`SimpleMessageListenerContainer` and `ListenerContainerConsumerFailedEvent`
referenced each other.

Revert to using `Object` as the event `source`.