### PR TITLE
AMQP-524: Publisher CF Extract Interface

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -84,7 +84,8 @@ import com.rabbitmq.client.ShutdownSignalException;
  * @author Steve Powell
  */
 public class CachingConnectionFactory extends AbstractConnectionFactory
-		implements InitializingBean, ShutdownListener, ApplicationContextAware, ApplicationListener<ContextClosedEvent> {
+		implements InitializingBean, ShutdownListener, ApplicationContextAware, ApplicationListener<ContextClosedEvent>,
+				PublisherCallbackChannelConnectionFactory {
 
 	private ApplicationContext applicationContext;
 
@@ -242,10 +243,12 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		this.connectionCacheSize = connectionCacheSize;
 	}
 
+	@Override
 	public boolean isPublisherConfirms() {
 		return this.publisherConfirms;
 	}
 
+	@Override
 	public boolean isPublisherReturns() {
 		return this.publisherReturns;
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelConnectionFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.connection;
+
+/**
+ * Connection factories implementing this interface return a connection that
+ * provides {@code PublisherCallbackChannel} channel instances when confirms
+ * or returns are enabled.
+ *
+ * @author Gary Russell
+ * @since 1.5
+ *
+ */
+public interface PublisherCallbackChannelConnectionFactory {
+
+	/**
+	 * @return true if publisher confirms are enabled.
+	 */
+	boolean isPublisherConfirms();
+
+	/**
+	 * @return true if publisher returns are enabled.
+	 */
+	boolean isPublisherReturns();
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -46,10 +46,10 @@ import org.springframework.amqp.core.ReceiveAndReplyCallback;
 import org.springframework.amqp.core.ReceiveAndReplyMessageCallback;
 import org.springframework.amqp.core.ReplyToAddressCallback;
 import org.springframework.amqp.rabbit.connection.AbstractRoutingConnectionFactory;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ChannelProxy;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactoryUtils;
+import org.springframework.amqp.rabbit.connection.PublisherCallbackChannelConnectionFactory;
 import org.springframework.amqp.rabbit.connection.RabbitAccessor;
 import org.springframework.amqp.rabbit.connection.RabbitResourceHolder;
 import org.springframework.amqp.rabbit.connection.RabbitUtils;
@@ -1275,9 +1275,10 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 				(connectionFactory != null ? connectionFactory : getConnectionFactory()), isChannelTransacted());
 		Channel channel = resourceHolder.getChannel();
 		if (this.confirmsOrReturnsCapable == null) {
-			if (getConnectionFactory() instanceof CachingConnectionFactory) {
-				CachingConnectionFactory ccf = (CachingConnectionFactory) getConnectionFactory();
-				this.confirmsOrReturnsCapable = ccf.isPublisherConfirms() || ccf.isPublisherReturns();
+			if (getConnectionFactory() instanceof PublisherCallbackChannelConnectionFactory) {
+				PublisherCallbackChannelConnectionFactory pcccf =
+						(PublisherCallbackChannelConnectionFactory) getConnectionFactory();
+				this.confirmsOrReturnsCapable = pcccf.isPublisherConfirms() || pcccf.isPublisherReturns();
 			}
 			else {
 				this.confirmsOrReturnsCapable = Boolean.FALSE;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,8 +45,10 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.core.ReceiveAndReplyCallback;
 import org.springframework.amqp.rabbit.connection.AbstractRoutingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.PublisherCallbackChannelConnectionFactory;
 import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.SingleConnectionFactory;
+import org.springframework.amqp.rabbit.support.PublisherCallbackChannel;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.amqp.utils.SerializationUtils;
 import org.springframework.expression.Expression;
@@ -249,6 +252,24 @@ public class RabbitTemplateTests {
 		template.convertAndSend("foo", "bar", "baz");
 		assertEquals(3, count.get());
 		assertTrue(recoverInvoked.get());
+	}
+
+	@Test
+	public void testPublisherConfirmsReturnsSetup() {
+		org.springframework.amqp.rabbit.connection.ConnectionFactory cf =
+				mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class,
+						withSettings().extraInterfaces(PublisherCallbackChannelConnectionFactory.class));
+		PublisherCallbackChannelConnectionFactory pcccf = (PublisherCallbackChannelConnectionFactory) cf;
+		when(pcccf.isPublisherConfirms()).thenReturn(true);
+		when(pcccf.isPublisherReturns()).thenReturn(true);
+		org.springframework.amqp.rabbit.connection.Connection conn =
+				mock(org.springframework.amqp.rabbit.connection.Connection.class);
+		when(cf.createConnection()).thenReturn(conn);
+		PublisherCallbackChannel channel = mock(PublisherCallbackChannel.class);
+		when(conn.createChannel(false)).thenReturn(channel);
+		RabbitTemplate template = new RabbitTemplate(cf);
+		template.convertAndSend("foo");
+		verify(channel).addListener(template);
 	}
 
 	public final static AtomicInteger LOOKUP_KEY_COUNT = new AtomicInteger();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-524

Enable mocking of a connection factory that supports publisher confirms and
returns callbacks.