### PR TITLE
AMQP-532: Pub.Conf. Concurrency

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -691,6 +691,10 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			}
 			try {
 				if (this.target == null || !this.target.isOpen()) {
+					if (this.target instanceof PublisherCallbackChannel) {
+						this.target.close();
+						throw new InvocationTargetException(new AmqpException("PublisherCallBackChannel is closed"));
+					}
 					this.target = null;
 				}
 				synchronized (targetMonitor) {
@@ -703,10 +707,10 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			catch (InvocationTargetException ex) {
 				if (this.target == null || !this.target.isOpen()) {
 					// Basic re-connection logic...
-					this.target = null;
 					if (logger.isDebugEnabled()) {
-						logger.debug("Detected closed channel on exception.  Re-initializing: " + target);
+						logger.debug("Detected closed channel on exception.  Re-initializing: " + this.target);
 					}
+					this.target = null;
 					synchronized (targetMonitor) {
 						if (this.target == null) {
 							this.target = createBareChannel(theConnection, transactional);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -548,7 +548,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			long threshold = System.currentTimeMillis() - age;
 			for (Entry<Object, SortedMap<Long, PendingConfirm>> channelPendingConfirmEntry : this.pendingConfirms.entrySet()) {
 				SortedMap<Long, PendingConfirm> channelPendingConfirms = channelPendingConfirmEntry.getValue();
-				synchronized(channelPendingConfirms) {
+				synchronized(channelPendingConfirmEntry.getKey()) { // channel
 					Iterator<Entry<Long, PendingConfirm>> iterator = channelPendingConfirms.entrySet().iterator();
 					PendingConfirm pendingConfirm;
 					while (iterator.hasNext()) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-532

Previously, pending confirms were synchronized on the map value (itself a map).

A concurrent modifification exception was reported in `generateNacksForPendingAcks`.

It's not clear how this could happen because all uses synchronize on the map value.

However, since only one thread can use a channel at a time (obtained from the CF), it
is safe to simply synchronize on the channel itself rather than using a complex locking
scheme.

Change synchronization to the channel object; synchronize on the channel in the
`RabbitTemplate.getUnconfirmed()` method.

Add javadocs to `addListener` to tell users they must synchronize on the channel.

In a future release, we should not expose the map - add a note to the Javadoc.

Also, while testing, it was determined that an issue could occur if the channel closes
after the listener is added but before the message was sent.

When the channel is a `PublisherCallbackChannel` throw an exception to the called if
the underlying channel closes; call the channel so it will distribute pending acks as
nacks.

__cherry-pick to 1.4.x__

__review with `?w=1` - mostly indentation__