### PR TITLE
AMQP-537: Blocking methods RabbitTemplate.receive()

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpTemplate.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpTemplate.java
@@ -138,6 +138,31 @@ public interface AmqpTemplate {
 	 */
 	Message receive(String queueName) throws AmqpException;
 
+	/**
+	 * Receive a message from a default queue, waiting up to the specified wait time if necessary for a message
+	 * to become available.
+	 *
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method will return {@code null}
+	 *                      immediately if there is no message available. Negative value makes method wait for
+	 *                      a message indefinitely.
+	 * @return a message or null if the time expires
+	 * @throws AmqpException if there is a problem
+	 */
+	Message receive(long timeoutMillis) throws AmqpException;
+
+	/**
+	 * Receive a message from a specific queue, waiting up to the specified wait time if necessary for a message
+	 * to become available.
+	 *
+	 * @param queueName the queue to receive from
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method will return {@code null}
+	 *                      immediately if there is no message available. Negative value makes method wait for
+	 *                      a message indefinitely.
+	 * @return a message or null if the time expires
+	 * @throws AmqpException if there is a problem
+	 */
+	Message receive(String queueName, long timeoutMillis) throws AmqpException;
+
 	// receive methods with conversion
 
 	/**
@@ -158,6 +183,31 @@ public interface AmqpTemplate {
 	 * @throws AmqpException if there is a problem
 	 */
 	Object receiveAndConvert(String queueName) throws AmqpException;
+
+	/**
+	 * Receive a message if there is one from a default queue and convert it to a Java object. Wait up to the
+	 * specified wait time if necessary for a message to become available.
+	 *
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method will return {@code null}
+	 *                      immediately if there is no message available. Negative value makes method wait for
+	 *                      a message indefinitely.
+	 * @return a message or null if the time expires
+	 * @throws AmqpException if there is a problem
+	 */
+	Object receiveAndConvert(long timeoutMillis) throws AmqpException;
+
+	/**
+	 * Receive a message if there is one from a specific queue and convert it to a Java object. Wait up to the
+	 * specified wait time if necessary for a message to become available.
+	 *
+	 * @param queueName the name of the queue to poll
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method will return {@code null}
+	 *                      immediately if there is no message available. Negative value makes method wait for
+	 *                      a message indefinitely.
+	 * @return a message or null if the time expires
+	 * @throws AmqpException if there is a problem
+	 */
+	Object receiveAndConvert(String queueName, long timeoutMillis) throws AmqpException;
 
 	// receive and send methods for provided callback
 

--- a/spring-amqp/src/test/java/org/springframework/amqp/remoting/testhelper/AbstractAmqpTemplate.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/remoting/testhelper/AbstractAmqpTemplate.java
@@ -84,12 +84,32 @@ public abstract class AbstractAmqpTemplate implements AmqpTemplate {
 	}
 
 	@Override
+	public Message receive(long timeoutMillis) throws AmqpException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Message receive(String queueName, long timeoutMillis) throws AmqpException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public Object receiveAndConvert() throws AmqpException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public Object receiveAndConvert(String queueName) throws AmqpException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object receiveAndConvert(long timeoutMillis) throws AmqpException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Object receiveAndConvert(String queueName, long timeoutMillis) throws AmqpException {
 		throw new UnsupportedOperationException();
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -778,7 +778,13 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			@Override
 			public Message doInRabbit(Channel channel) throws Exception {
 				QueueingConsumer consumer = createQueueingConsumer(queueName, channel);
-				Delivery delivery = consumer.nextDelivery(timeoutMillis);
+				Delivery delivery;
+                if (timeoutMillis < 0) {
+                    delivery = consumer.nextDelivery();
+                }
+                else {
+                    delivery = consumer.nextDelivery(timeoutMillis);
+                }
 				channel.basicCancel(consumer.getConsumerTag());
 				if (delivery == null) {
 					return null;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -778,13 +778,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			@Override
 			public Message doInRabbit(Channel channel) throws Exception {
 				QueueingConsumer consumer = createQueueingConsumer(queueName, channel);
-				Delivery delivery;
-				if (receiveTimeout < 0) {
-					delivery = consumer.nextDelivery();
-				}
-				else {
-					delivery = consumer.nextDelivery(timeoutMillis);
-				}
+				Delivery delivery = consumer.nextDelivery(timeoutMillis);
 				channel.basicCancel(consumer.getConsumerTag());
 				if (delivery == null) {
 					return null;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-537

Four new methods in `AmqpTemplate` and `RabbitTemplate`: `receive` and `receiveAndConvert` with timeout arguments.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.