### PR TITLE
AMQP-542: @SendTo with Class Level @RabbitListener

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -23,8 +23,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.amqp.core.MessageListener;
-import org.springframework.amqp.rabbit.listener.MethodRabbitListenerEndpoint;
-import org.springframework.amqp.rabbit.listener.MultiMethodRabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 
@@ -78,13 +76,13 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
  *
  * <p>When defined at the method level, a listener container is created for each method. The
  * {@link MessageListener} is a {@link MessagingMessageListenerAdapter}, configured with a
- * {@link MethodRabbitListenerEndpoint}.
+ * {@link org.springframework.amqp.rabbit.listener.MethodRabbitListenerEndpoint}.
  *
  * <p>When defined at the class level, a single message listener container is used to service
  * all methods annotated with {@code @RabbitHandler}. Method signatures of such annotated
  * methods must not cause any ambiguity such that a single method can be resolved for a
  * particular inbound message. The {@link MessagingMessageListenerAdapter} is configured with
- * a {@link MultiMethodRabbitListenerEndpoint}.
+ * a {@link org.springframework.amqp.rabbit.listener.MultiMethodRabbitListenerEndpoint}.
  *
  * @author Stephane Nicoll
  * @author Gary Russell

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -248,6 +248,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 			checkedMethods.add(checkProxy(method, bean));
 		}
 		MultiMethodRabbitListenerEndpoint endpoint = new MultiMethodRabbitListenerEndpoint(checkedMethods, bean);
+		endpoint.setBeanFactory(this.beanFactory);
 		processListener(endpoint, classLevelListener, bean, bean.getClass(), beanName);
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
@@ -125,14 +125,17 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 	}
 
 	private Address getDefaultReplyToAddress() {
-		SendTo ann = AnnotationUtils.getAnnotation(getMethod(), SendTo.class);
-		if (ann != null) {
-			String[] destinations = ann.value();
-			if (destinations.length > 1) {
-				throw new IllegalStateException("Invalid @" + SendTo.class.getSimpleName() + " annotation on '"
-						+ getMethod() + "' one destination must be set (got " + Arrays.toString(destinations) + ")");
+		Method method = getMethod();
+		if (method != null) {
+			SendTo ann = AnnotationUtils.getAnnotation(method, SendTo.class);
+			if (ann != null) {
+				String[] destinations = ann.value();
+				if (destinations.length > 1) {
+					throw new IllegalStateException("Invalid @" + SendTo.class.getSimpleName() + " annotation on '"
+							+ method + "' one destination must be set (got " + Arrays.toString(destinations) + ")");
+				}
+				return destinations.length == 1 ? new Address(resolve(destinations[0])) : new Address(null);
 			}
-			return destinations.length == 1 ? new Address(resolve(destinations[0])) : new Address(null);
 		}
 		return null;
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MultiMethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MultiMethodRabbitListenerEndpoint.java
@@ -69,7 +69,10 @@ public class MultiMethodRabbitListenerEndpoint extends MethodRabbitListenerEndpo
 		@Override
 		protected Address getReplyToAddress(Message request) throws Exception {
 			Address replyTo = request.getMessageProperties().getReplyToAddress();
-			Address defaultReplyTo = delegatingHandler.getDefaultReplyTo();
+			Address defaultReplyTo = null;
+			if (delegatingHandler != null) {
+				defaultReplyTo = delegatingHandler.getDefaultReplyTo();
+			}
 			if (replyTo == null && defaultReplyTo == null) {
 				throw new AmqpException(
 						"Cannot determine ReplyTo message property value: " +

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MultiMethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MultiMethodRabbitListenerEndpoint.java
@@ -36,13 +36,11 @@ public class MultiMethodRabbitListenerEndpoint extends MethodRabbitListenerEndpo
 
 	private final List<Method> methods;
 
-	private final Object bean;
-
 	private DelegatingInvocableHandler delegatingHandler;
 
 	public MultiMethodRabbitListenerEndpoint(List<Method> methods, Object bean) {
 		this.methods = methods;
-		this.bean = bean;
+		setBean(bean);
 	}
 
 	@Override
@@ -52,7 +50,7 @@ public class MultiMethodRabbitListenerEndpoint extends MethodRabbitListenerEndpo
 			invocableHandlerMethods.add(getMessageHandlerMethodFactory()
 					.createInvocableHandlerMethod(getBean(), method));
 		}
-		this.delegatingHandler = new DelegatingInvocableHandler(invocableHandlerMethods, this.bean, getResolver(),
+		this.delegatingHandler = new DelegatingInvocableHandler(invocableHandlerMethods, getBean(), getResolver(),
 				getBeanExpressionContext());
 		return new HandlerAdapter(this.delegatingHandler);
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
@@ -98,11 +98,12 @@ public class DelegatingInvocableHandler {
 	public Object invoke(Message<?> message, Object... providedArgs) throws Exception {
 		Class<? extends Object> payloadClass = message.getPayload().getClass();
 		InvocableHandlerMethod handler = getHandlerForPayload(payloadClass);
+		Object result = handler.invoke(message, providedArgs);
 		Address replyTo = this.defaultReplyToForHandler.get(handler);
 		if (replyTo != null) {
 			defaultReplyTo.set(replyTo);
 		}
-		return handler.invoke(message, providedArgs);
+		return result;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
@@ -18,15 +18,24 @@ package org.springframework.amqp.rabbit.listener.adapter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.core.Address;
+import org.springframework.beans.factory.config.BeanExpressionContext;
+import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.springframework.util.Assert;
 
 
 /**
@@ -40,20 +49,35 @@ import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
  */
 public class DelegatingInvocableHandler {
 
+	private static final ThreadLocal<Address> defaultReplyTo = new ThreadLocal<Address>();
+
 	private final List<InvocableHandlerMethod> handlers;
 
-	private final ConcurrentMap<Class<?>, InvocableHandlerMethod> cachedHandlers = new ConcurrentHashMap<Class<?>, InvocableHandlerMethod>();
+	private final ConcurrentMap<Class<?>, InvocableHandlerMethod> cachedHandlers =
+			new ConcurrentHashMap<Class<?>, InvocableHandlerMethod>();
+
+	private final Map<InvocableHandlerMethod, Address> defaultReplyToForHandler =
+			new HashMap<InvocableHandlerMethod, Address>();
 
 	private final Object bean;
+
+	private final BeanExpressionResolver resolver;
+
+	private final BeanExpressionContext beanExpressionContext;
 
 	/**
 	 * Construct an instance with the supplied handlers for the bean.
 	 * @param handlers the handlers.
 	 * @param bean the bean.
+	 * @param beanExpressionResolver the resolver.
+	 * @param beanExpressionContext the context.
 	 */
-	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers, Object bean) {
+	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers, Object bean,
+			BeanExpressionResolver beanExpressionResolver, BeanExpressionContext beanExpressionContext) {
 		this.handlers = new ArrayList<InvocableHandlerMethod>(handlers);
 		this.bean = bean;
+		this.resolver = beanExpressionResolver;
+		this.beanExpressionContext = beanExpressionContext;
 	}
 
 	/**
@@ -74,6 +98,10 @@ public class DelegatingInvocableHandler {
 	public Object invoke(Message<?> message, Object... providedArgs) throws Exception {
 		Class<? extends Object> payloadClass = message.getPayload().getClass();
 		InvocableHandlerMethod handler = getHandlerForPayload(payloadClass);
+		Address replyTo = this.defaultReplyToForHandler.get(handler);
+		if (replyTo != null) {
+			defaultReplyTo.set(replyTo);
+		}
 		return handler.invoke(message, providedArgs);
 	}
 
@@ -89,8 +117,39 @@ public class DelegatingInvocableHandler {
 				throw new AmqpException("No method found for " + payloadClass);
 			}
 			this.cachedHandlers.putIfAbsent(payloadClass, handler);//NOSONAR
+			setupReplyTo(handler);
 		}
 		return handler;
+	}
+
+	private void setupReplyTo(InvocableHandlerMethod handler) {
+		Method method = handler.getMethod();
+		if (method != null) {
+			SendTo ann = AnnotationUtils.getAnnotation(method, SendTo.class);
+			if (ann != null) {
+				String[] destinations = ann.value();
+				if (destinations.length > 1) {
+					throw new IllegalStateException("Invalid @" + SendTo.class.getSimpleName() + " annotation on '"
+							+ method + "' one destination must be set (got " + Arrays.toString(destinations) + ")");
+				}
+				Address replyTo = destinations.length == 1 ? new Address(resolve(destinations[0])) : null;
+				if (replyTo != null) {
+					this.defaultReplyToForHandler.put(handler, replyTo);
+				}
+			}
+		}
+
+	}
+
+	private String resolve(String value) {
+		if (this.resolver != null) {
+			Object newValue = this.resolver.evaluate(value, this.beanExpressionContext);
+			Assert.isInstanceOf(String.class, newValue, "Invalid @SendTo expression");
+			return (String) newValue;
+		}
+		else {
+			return value;
+		}
 	}
 
 	protected InvocableHandlerMethod findHandlerForPayload(Class<? extends Object> payloadClass) {
@@ -142,6 +201,17 @@ public class DelegatingInvocableHandler {
 	public String getMethodNameFor(Object payload) {
 		InvocableHandlerMethod handlerForPayload = getHandlerForPayload(payload.getClass());
 		return handlerForPayload == null ? "no match" : handlerForPayload.getMethod().toGenericString();//NOSONAR
+	}
+
+	/**
+	 * @return the default replyTo for the invoked method, if any.
+	 */
+	public Address getDefaultReplyTo() {
+		Address replyTo = defaultReplyTo.get();
+		if (replyTo != null) {
+			defaultReplyTo.remove();
+		}
+		return replyTo;
 	}
 
 }

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1510,20 +1510,21 @@ This is best described using an example:
 @RabbitListener(queues = "someQueue")
 public class MultiListenerBean {
 
-	@RabbitHandler
-	public String bar(Bar bar) {
-		...
-	}
+    @RabbitHandler
+    @SendTo("my.reply.queue")
+    public String bar(Bar bar) {
+        ...
+    }
 
-	@RabbitHandler
-	public String baz(Baz baz) {
-		...
-	}
+    @RabbitHandler
+    public String baz(Baz baz) {
+        ...
+    }
 
-	@RabbitHandler
-	public String qux(@Header("amqp_receivedRoutingKey") String rk, @Payload Qux qux) {
-		...
-	}
+    @RabbitHandler
+    public String qux(@Header("amqp_receivedRoutingKey") String rk, @Payload Qux qux) {
+        ...
+    }
 
 }
 ----
@@ -1532,6 +1533,8 @@ In this case, the individual `@RabbitHandler` methods are invoked if the convert
 It is important to understand that the system must be able to identify a unique method based on the payload type.
 The type is checked for assignability to a single parameter that has no annotations, or is annotated with the `@Payload` annotation.
 Notice that the same method signatures apply as discussed in the method-level `@RabbitListener` described above.
+
+Notice that the `@SendTo` must be specified on each method (if needed); it is not supported at the class level.
 
 ====== Container Management
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-542

Spurious NPE logged in `AnnotationUtils` when using class-level annotation.

Detect a null `method` and add support for `@SendTo` on `@RabbitHandler`.

Class-level `@SendTo` is not supported due to annotation restrictions.
See SPR-13578.