### PR TITLE
AMQP-544: API to Obtain @RabbitListener ids

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -54,6 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Stephane Nicoll
  * @author Juergen Hoeller
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 1.4
  * @see RabbitListenerEndpoint
  * @see MessageListenerContainer
@@ -84,10 +86,20 @@ public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLife
 	 * @param id the id of the container
 	 * @return the container or {@code null} if no container with that id exists
 	 * @see RabbitListenerEndpoint#getId()
+	 * @see #getListenerContainerIds()
 	 */
 	public MessageListenerContainer getListenerContainer(String id) {
 		Assert.hasText(id, "Container identifier must not be empty");
 		return this.listenerContainers.get(id);
+	}
+
+	/**
+	 * Return the ids of the managed {@link MessageListenerContainer} instance(s).
+	 * @return the ids.
+	 * @see #getListenerContainer(String)
+	 */
+	public Set<String> getListenerContainerIds() {
+		return Collections.unmodifiableSet(this.listenerContainers.keySet());
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AbstractRabbitAnnotationDrivenTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AbstractRabbitAnnotationDrivenTests.java
@@ -183,6 +183,8 @@ public abstract class AbstractRabbitAnnotationDrivenTests {
 		RabbitListenerEndpointRegistry customRegistry =
 				context.getBean("customRegistry", RabbitListenerEndpointRegistry.class);
 		assertEquals("Wrong number of containers in the registry", 2,
+				customRegistry.getListenerContainerIds().size());
+		assertEquals("Wrong number of containers in the registry", 2,
 				customRegistry.getListenerContainers().size());
 		assertNotNull("Container with custom id on the annotation should be found",
 				customRegistry.getListenerContainer("listenerId"));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
@@ -73,12 +73,14 @@ import com.rabbitmq.client.ShutdownSignalException;
  */
 public class CachingConnectionFactoryIntegrationTests {
 
+	private static final String CF_INTEGRATION_TEST_QUEUE = "cfIntegrationTest";
+
 	private static Log logger = LogFactory.getLog(CachingConnectionFactoryIntegrationTests.class);
 
 	private CachingConnectionFactory connectionFactory;
 
 	@Rule
-	public BrokerRunning brokerIsRunning = BrokerRunning.isRunning();
+	public BrokerRunning brokerIsRunning = BrokerRunning.isRunningWithEmptyQueues(CF_INTEGRATION_TEST_QUEUE);
 
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
@@ -92,6 +94,9 @@ public class CachingConnectionFactoryIntegrationTests {
 
 	@After
 	public void close() {
+		if (!this.connectionFactory.getVirtualHost().equals("non-existent")) {
+			new RabbitAdmin(this.connectionFactory).deleteQueue(CF_INTEGRATION_TEST_QUEUE);
+		}
 		connectionFactory.destroy();
 	}
 
@@ -305,7 +310,7 @@ public class CachingConnectionFactoryIntegrationTests {
 
 		RabbitTemplate template = new RabbitTemplate(connectionFactory);
 		RabbitAdmin admin = new RabbitAdmin(connectionFactory);
-		Queue queue = new Queue("foo");
+		Queue queue = new Queue(CF_INTEGRATION_TEST_QUEUE);
 		admin.declareQueue(queue);
 		final String route = queue.getName();
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistrarTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistrarTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.amqp.rabbit.listener;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,11 +26,7 @@ import org.junit.rules.ExpectedException;
 
 import org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
-import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistrar;
-import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Stephane Nicoll
@@ -79,6 +78,7 @@ public class RabbitListenerEndpointRegistrarTests {
 		registrar.registerEndpoint(endpoint, null);
 		registrar.afterPropertiesSet();
 		assertNotNull("Container not created", registry.getListenerContainer("some id"));
+		assertEquals("some id", registry.getListenerContainerIds().iterator().next());
 		assertEquals(1, registry.getListenerContainers().size());
 	}
 
@@ -101,6 +101,7 @@ public class RabbitListenerEndpointRegistrarTests {
 		registrar.registerEndpoint(endpoint);
 		registrar.afterPropertiesSet();
 		assertNotNull("Container not created", registry.getListenerContainer("myEndpoint"));
+		assertEquals("myEndpoint", registry.getListenerContainerIds().iterator().next());
 		assertEquals(1, registry.getListenerContainers().size());
 	}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1547,6 +1547,8 @@ on the registry itself which will invoke the operations on each container.
 You can also get a reference to an individual container using its `id`, using `getListenerContainer(String id)`; for
 example `registry.getListenerContainer("multi")` for the container created by the snippet above.
 
+Starting with version _1.5.2_, you can obtain the `id` s of the registered containers with `getListenerContainerIds()`.
+
 Starting with _version 1.5_, you can now assign a `group` to the container on the `RabbitListener` endpoint.
 This provides a mechanism to get a reference to a subset of containers; adding a `group` attribute causes a
 bean of type `Collection<MessageListenerContainer>` to be registered with the context with the group name.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-544

Also fix a test that used a queue named `foo`. It failed
if the queue existed and had incompatible messages.