### PR TITLE
AMQP-546: Add SmartLifecycle to Caching Conn Fact

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -139,6 +139,8 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	private volatile boolean stopped;
 
+	private volatile boolean running;
+
 	private int phase = Integer.MIN_VALUE + 1000;
 
 	private volatile ConditionalExceptionLogger closeExceptionLogger = new DefaultChannelCloseLogger();
@@ -585,11 +587,12 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	@Override
 	public void start() {
+		this.running = true;
 	}
 
 	@Override
 	public boolean isRunning() {
-		return true;
+		return this.running;
 	}
 
 	@Override
@@ -614,10 +617,19 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		return true;
 	}
 
+	/**
+	 * Stop the connection factory to prevent its connection from being used.
+	 * Note: ignored unless the application context is in the process of being stopped.
+	 */
+	@Override
 	public void stop() {
 		if (this.contextStopped) {
+			this.running = false;
 			this.stopped = true;
 			this.deferredCloseExecutor.shutdownNow();
+		}
+		else {
+			logger.warn("stop() is ignored unless the application context is being stopped");
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -46,6 +46,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -85,7 +86,7 @@ import com.rabbitmq.client.ShutdownSignalException;
  */
 public class CachingConnectionFactory extends AbstractConnectionFactory
 		implements InitializingBean, ShutdownListener, ApplicationContextAware, ApplicationListener<ContextClosedEvent>,
-				PublisherCallbackChannelConnectionFactory {
+				PublisherCallbackChannelConnectionFactory, SmartLifecycle {
 
 	private ApplicationContext applicationContext;
 
@@ -134,7 +135,11 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	private volatile boolean initialized;
 
+	private volatile boolean contextStopped;
+
 	private volatile boolean stopped;
+
+	private int phase = Integer.MIN_VALUE + 1000;
 
 	private volatile ConditionalExceptionLogger closeExceptionLogger = new DefaultChannelCloseLogger();
 
@@ -327,8 +332,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	@Override
 	public void onApplicationEvent(ContextClosedEvent event) {
 		if (this.applicationContext == event.getApplicationContext()) {
-			this.stopped = true;
-			this.deferredCloseExecutor.shutdownNow();
+			this.contextStopped = true;
 		}
 	}
 
@@ -577,6 +581,50 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			this.openConnectionNonTransactionalChannels.clear();
 			this.openConnectionTransactionalChannels.clear();
 		}
+	}
+
+	@Override
+	public void start() {
+	}
+
+	@Override
+	public boolean isRunning() {
+		return true;
+	}
+
+	@Override
+	public int getPhase() {
+		return this.phase;
+	}
+
+	/**
+	 * Defaults to phase {@link Integer#MIN_VALUE - 1000} so the factory is
+	 * stopped in a very late phase, allowing other beans to use the connection
+	 * to clean up.
+	 * @see #getPhase()
+	 * @param phase the phase.
+	 * @since 1.5.3
+	 */
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return true;
+	}
+
+	public void stop() {
+		if (this.contextStopped) {
+			this.stopped = true;
+			this.deferredCloseExecutor.shutdownNow();
+		}
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		stop();
+		callback.run();
 	}
 
 	/*

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryLifecycleTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryLifecycleTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.connection;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.amqp.core.AnonymousQueue;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.test.BrokerRunning;
+import org.springframework.amqp.rabbit.test.BrokerTestUtils;
+import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Gary Russell
+ * @since 1.5.3
+ *
+ */
+public class ConnectionFactoryLifecycleTests {
+
+	@Rule
+	public BrokerRunning brokerRunning = BrokerRunning.isRunning();
+
+	@Test
+	public void testConnectionFactoryAvailableDuringStop() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
+		MyLifecycle myLifecycle = context.getBean(MyLifecycle.class);
+		CachingConnectionFactory cf = context.getBean(CachingConnectionFactory.class);
+		context.close();
+		assertFalse(myLifecycle.isRunning());
+		assertTrue(TestUtils.getPropertyValue(cf, "stopped", Boolean.class));
+		try {
+			cf.createConnection();
+			fail("Expected exception");
+		}
+		catch (IllegalStateException e) {
+			assertThat(e.getMessage(), containsString("The ApplicationContext is closed"));
+		}
+	}
+
+	@Configuration
+	public static class Config {
+
+		@Bean
+		public ConnectionFactory cf() {
+			return new CachingConnectionFactory("localhost", BrokerTestUtils.DEFAULT_PORT);
+		}
+
+		@Bean
+		public MyLifecycle myLifeCycle() {
+			return new MyLifecycle(cf());
+		}
+
+	}
+
+	public static class MyLifecycle implements SmartLifecycle {
+
+		private final RabbitAdmin admin;
+
+		private final Queue queue = new AnonymousQueue();
+
+		private volatile boolean running;
+
+		public MyLifecycle (ConnectionFactory cf) {
+			this.admin = new RabbitAdmin(cf);
+		}
+
+		@Override
+		public void start() {
+			this.running = true;
+			this.admin.declareQueue(this.queue);
+		}
+
+		@Override
+		public void stop() {
+			this.admin.deleteQueue(this.queue.getName());
+			this.running = false;
+		}
+
+		@Override
+		public boolean isRunning() {
+			return this.running;
+		}
+
+		@Override
+		public int getPhase() {
+			return 0;
+		}
+
+		@Override
+		public boolean isAutoStartup() {
+			return true;
+		}
+
+		@Override
+		public void stop(Runnable callback) {
+			stop();
+			callback.run();
+		}
+
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryLifecycleTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryLifecycleTests.java
@@ -97,6 +97,8 @@ public class ConnectionFactoryLifecycleTests {
 
 		@Override
 		public void stop() {
+			// Prior to the fix for AMQP-546, this threw an exception and
+			// running was not reset.
 			this.admin.deleteQueue(this.queue.getName());
 			this.running = false;
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-546

Code was added to prevent connection use after the context is closed. However,
this was too early in the lifecycle because other beans might not have been
stopped yet; they could no longer use the connection.

Add `SmartLifecyle` to `CachingConnectionFactory` and put it in a late phase,
by default, so that beans in earlier phases can still use the connection in
`stop()`.

Add test case to reproduce the problem.