### PR TITLE
Support @RabbitListener on interface methods

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -224,7 +224,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 
 			@Override
 			public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
-				RabbitListener rabbitListener = AnnotationUtils.getAnnotation(method, RabbitListener.class);
+				RabbitListener rabbitListener = AnnotationUtils.findAnnotation(method, RabbitListener.class);
 				if (rabbitListener != null) {
 					processAmqpListener(rabbitListener, method, bean, beanName);
 				}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -229,7 +229,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 					processAmqpListener(rabbitListener, method, bean, beanName);
 				}
 				if (classLevelListener != null) {
-					RabbitHandler rabbitHandler = AnnotationUtils.getAnnotation(method, RabbitHandler.class);
+					RabbitHandler rabbitHandler = AnnotationUtils.findAnnotation(method, RabbitHandler.class);
 					if (rabbitHandler != null) {
 						multiMethods.add(method);
 					}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -91,7 +91,7 @@ public class EnableRabbitIntegrationTests {
 
 	@ClassRule
 	public static final BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues(
-			"test.simple", "test.header", "test.message", "test.reply", "test.sendTo", "test.sendTo.reply",
+					"test.simple", "test.inheritance",  "test.header", "test.message", "test.reply", "test.sendTo", "test.sendTo.reply",
 			"test.sendTo.spel", "test.sendTo.reply.spel",
 			"test.invalidPojo",
 			"test.comma.1", "test.comma.2", "test.comma.3", "test.comma.4", "test,with,commas");
@@ -162,6 +162,11 @@ public class EnableRabbitIntegrationTests {
 	public void simpleEndpoint() {
 		assertEquals("FOO", rabbitTemplate.convertSendAndReceive("test.simple", "foo"));
 		assertEquals(2, this.context.getBean("testGroup", List.class).size());
+	}
+
+	@Test
+	public void simpleInheritance() {
+		assertEquals("FOO", rabbitTemplate.convertSendAndReceive("test.inheritance", "foo"));
 	}
 
 	@Test
@@ -285,6 +290,20 @@ public class EnableRabbitIntegrationTests {
 			return "BAZ: " + baz.field + ": " + rk;
 		}
 
+	}
+
+	public interface MyServiceInterface {
+
+		@RabbitListener(queues = "test.inheritance")
+		public String testAnnotationInheritance(String foo);
+	}
+
+	public static class MyServiceInterfaceImpl implements MyServiceInterface {
+
+		@Override
+		public String testAnnotationInheritance(String foo) {
+			return foo.toUpperCase();
+		}
 	}
 
 	public static class MyService {
@@ -453,6 +472,11 @@ public class EnableRabbitIntegrationTests {
 		@Bean
 		public MyService myService() {
 			return new MyService();
+		}
+
+		@Bean
+		public MyServiceInterface myInheritanceService() {
+			return new MyServiceInterfaceImpl();
 		}
 
 		@Bean


### PR DESCRIPTION
At our project we are using modules to define our interfaces between services.
In this module we put our hystrix interfaces as well as our amqp events that the services emits.
For a particular event we create interfaces that services can implement to listen on those events:
```java
interface UserCreatedEventListener {

    /**
     * Will be sent as soon as a new User was created
     */
    @RabbitListener(
            bindings = @QueueBinding(
                    value = @Queue(
                            value = '${spring.application.name}',
                            autoDelete = "true",
                            durable = "false"
                    ),
                    exchange = @Exchange(
                            type = "fanout",
                            value = "all-events",
                            durable = "true"
                    )
            )
    )
    void onEvent(UserCreated event);
}

//--- other class on the service
class UserService implements UserCreatedEventListener {
  void onEvent(UserCreated event) {
    // do stuff
  }
}
```

Now a service can implement this method and should auto register on the bus.
This does not work at the moment, because Annotations can not be inherited.

Luckily the `RabbitListenerAnnotationBeanPostProcessor` is responsible for the creation of the listener and does this in the method `postProcessAfterInitialization`.

Unfortunately the method `getAnnotation` does not consider superclasses or interfaces, but luckily the `findAnnotation` does.

So i propose to use the latter instead and enable us to provide the binding in another class (e.g. interface) than the implementing class.