### PR TITLE
Fix some race conditions around mocks

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryTests.java
@@ -110,8 +110,8 @@ public class LocalizedQueueConnectionFactoryTests {
 
 		};
 		Log logger = spy(TestUtils.getPropertyValue(lqcf, "logger", Log.class));
-		new DirectFieldAccessor(lqcf).setPropertyValue("logger", logger);
 		doReturn(true).when(logger).isInfoEnabled();
+		new DirectFieldAccessor(lqcf).setPropertyValue("logger", logger);
 		doAnswer(new CallsRealMethods()).when(logger).debug(anyString());
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(lqcf);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplateTests.java
@@ -321,9 +321,9 @@ public class BatchingRabbitTemplateTests {
 		container.afterPropertiesSet();
 		container.start();
 		Log logger = spy(TestUtils.getPropertyValue(errorHandler, "logger", Log.class));
-		new DirectFieldAccessor(errorHandler).setPropertyValue("logger", logger);
 		doReturn(true).when(logger).isWarnEnabled();
 		doAnswer(new DoesNothing()).when(logger).warn(anyString(), any(Throwable.class));
+		new DirectFieldAccessor(errorHandler).setPropertyValue("logger", logger);
 		try {
 			RabbitTemplate template = new RabbitTemplate();
 			template.setConnectionFactory(this.connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
@@ -757,7 +757,6 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 			}
 		});
 		Log logger = spy(TestUtils.getPropertyValue(connectionFactoryWithConfirmsEnabled, "logger", Log.class));
-		new DirectFieldAccessor(connectionFactoryWithConfirmsEnabled).setPropertyValue("logger", logger);
 		final AtomicReference<String> log = new AtomicReference<String>();
 		doAnswer(new Answer<Object>() {
 
@@ -769,6 +768,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 				return null;
 			}
 		}).when(logger).error(any());
+		new DirectFieldAccessor(connectionFactoryWithConfirmsEnabled).setPropertyValue("logger", logger);
 
 		CorrelationData correlationData = new CorrelationData("bar");
 		String exchange = UUID.randomUUID().toString();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -137,15 +137,15 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		});
 		container.start();
 		Log logger = spy(TestUtils.getPropertyValue(container, "logger", Log.class));
-		new DirectFieldAccessor(container).setPropertyValue("logger", logger);
 		doReturn(true).when(logger).isWarnEnabled();
+		new DirectFieldAccessor(container).setPropertyValue("logger", logger);
 		template.convertAndSend(queue.getName(), "baz");
 		assertTrue(messageReceived.await(10, TimeUnit.SECONDS));
 		Object consumer = TestUtils.getPropertyValue(container, "consumers", Map.class)
 				.keySet().iterator().next();
 		Log qLogger = spy(TestUtils.getPropertyValue(consumer, "logger", Log.class));
-		new DirectFieldAccessor(consumer).setPropertyValue("logger", qLogger);
 		doReturn(true).when(qLogger).isDebugEnabled();
+		new DirectFieldAccessor(consumer).setPropertyValue("logger", qLogger);
 		spiedQLogger.countDown();
 		assertTrue(errorHandled.await(10, TimeUnit.SECONDS));
 		container.stop();


### PR DESCRIPTION
The symptom looks like:
```
2015-12-11 05:13:01,513 ERROR SimpleAsyncTaskExecutor-1 [org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer] - <Consumer thread error, thread abort.>
java.lang.AssertionError
	at org.mockito.internal.stubbing.InvocationContainerImpl.setMethodForStubbing(InvocationContainerImpl.java:108)
	at org.mockito.internal.handler.MockHandlerImpl.handle(MockHandlerImpl.java:54)
	at org.mockito.internal.handler.NullResultGuardian.handle(NullResultGuardian.java:29)
	at org.mockito.internal.handler.InvocationNotifierHandler.handle(InvocationNotifierHandler.java:38)
	at org.mockito.internal.creation.cglib.MethodInterceptorFilter.intercept(MethodInterceptorFilter.java:59)
	at org.apache.commons.logging.impl.Log4JLogger$$EnhancerByMockitoWithCGLIB$$8fedbd5a.trace(<generated>)
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer.doReceiveAndExecute(SimpleMessageListenerContainer.java:1090)
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer.receiveAndExecute(SimpleMessageListenerContainer.java:1080)
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer.access$1100(SimpleMessageListenerContainer.java:93)
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer$AsyncMessageProcessingConsumer.run(SimpleMessageListenerContainer.java:1197)
	at java.lang.Thread.run(Thread.java:745)
```

And the guilty code is:

```
Log logger = spy(TestUtils.getPropertyValue(container, "logger", Log.class));
new DirectFieldAccessor(container).setPropertyValue("logger", logger);
doReturn(true).when(logger).isWarnEnabled();
```
Where the target object may use this `spy` just after `setPropertyValue()` and during the next `doReturn()`.
Therefore Mockito might not initialize the spy properly.

Fix moving the `setPropertyValue()` only after the full spy definition.