### PR TITLE
AMQP-556: NPE in SMLC After Shutdown Timeout

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -818,7 +818,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				logger.info("Successfully waited for workers to finish.");
 			}
 			else {
-				logger.info("Workers not finished.  Forcing connections to close.");
+				logger.info("Workers not finished.");
 			}
 		}
 		catch (InterruptedException e) {
@@ -835,7 +835,13 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	private boolean isActive(BlockingQueueConsumer consumer) {
 		Boolean consumerActive;
 		synchronized(consumersMonitor) {
-			consumerActive = this.consumers != null && this.consumers.get(consumer);
+			if (this.consumers != null) {
+				Boolean active = this.consumers.get(consumer);
+				consumerActive = active != null && active;
+			}
+			else {
+				consumerActive = false;
+			}
 		}
 		return consumerActive && this.isActive();
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-556

If a listener doesn't shut down within the timeout, when it
next checks whether it is active, it gets an NPE.

Since it is a terminating listener, it is benign.