### PR TITLE
AMQP-562: Check for Queue Declaration Mismatches

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
@@ -85,6 +85,8 @@ public class RabbitNamespaceUtils {
 
 	private static final String MISSING_QUEUES_FATAL = "missing-queues-fatal";
 
+	private static final String MISMATCHED_QUEUES_FATAL = "mismatched-queues-fatal";
+
 	private static final String AUTO_DECLARE = "auto-declare";
 
 	private static final String DECLARATION_RETRIES = "declaration-retries";
@@ -227,6 +229,11 @@ public class RabbitNamespaceUtils {
 		String missingQueuesFatal = containerEle.getAttribute(MISSING_QUEUES_FATAL);
 		if (StringUtils.hasText(missingQueuesFatal)) {
 			containerDef.getPropertyValues().add("missingQueuesFatal", new TypedStringValue(missingQueuesFatal));
+		}
+
+		String mismatchedQueuesFatal = containerEle.getAttribute(MISMATCHED_QUEUES_FATAL);
+		if (StringUtils.hasText(mismatchedQueuesFatal)) {
+			containerDef.getPropertyValues().add("mismatchedQueuesFatal", new TypedStringValue(mismatchedQueuesFatal));
 		}
 
 		String autoDeclare = containerEle.getAttribute(AUTO_DECLARE);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -23,6 +23,9 @@ import org.aopalliance.aop.Advice;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.support.ConsumerTagStrategy;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -43,7 +46,7 @@ import org.springframework.util.backoff.FixedBackOff;
  */
 public class SimpleRabbitListenerContainerFactory
 		extends AbstractRabbitListenerContainerFactory<SimpleMessageListenerContainer>
-		implements ApplicationEventPublisherAware {
+		implements ApplicationContextAware, ApplicationEventPublisherAware {
 
 	private Executor taskExecutor;
 
@@ -82,6 +85,8 @@ public class SimpleRabbitListenerContainerFactory
 	private Long idleEventInterval;
 
 	private ApplicationEventPublisher applicationEventPublisher;
+
+	private ApplicationContext applicationContext;
 
 	/**
 	 * @param taskExecutor the {@link Executor} to use.
@@ -206,7 +211,6 @@ public class SimpleRabbitListenerContainerFactory
 
 	/**
 	 * @param missingQueuesFatal the missingQueuesFatal to set.
-	 * @since 1.6
 	 * @see SimpleMessageListenerContainer#setMissingQueuesFatal
 	 */
 	public void setMissingQueuesFatal(Boolean missingQueuesFatal) {
@@ -215,6 +219,7 @@ public class SimpleRabbitListenerContainerFactory
 
 	/**
 	 * @param mismatchedQueuesFatal the mismatchedQueuesFatal to set.
+	 * @since 1.6
 	 * @see SimpleMessageListenerContainer#setMismatchedQueuesFatal(boolean)
 	 */
 	public void setMismatchedQueuesFatal(Boolean mismatchedQueuesFatal) {
@@ -242,6 +247,11 @@ public class SimpleRabbitListenerContainerFactory
 	}
 
 	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
 	protected SimpleMessageListenerContainer createContainerInstance() {
 		return new SimpleMessageListenerContainer();
 	}
@@ -250,6 +260,9 @@ public class SimpleRabbitListenerContainerFactory
 	protected void initializeContainer(SimpleMessageListenerContainer instance) {
 		super.initializeContainer(instance);
 
+		if (this.applicationContext != null) {
+			instance.setApplicationContext(this.applicationContext);
+		}
 		if (this.taskExecutor != null) {
 			instance.setTaskExecutor(this.taskExecutor);
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -75,6 +75,8 @@ public class SimpleRabbitListenerContainerFactory
 
 	private Boolean missingQueuesFatal;
 
+	private Boolean mismatchedQueuesFatal;
+
 	private ConsumerTagStrategy consumerTagStrategy;
 
 	private Long idleEventInterval;
@@ -211,6 +213,14 @@ public class SimpleRabbitListenerContainerFactory
 	}
 
 	/**
+	 * @param mismatchedQueuesFatal the mismatchedQueuesFatal to set.
+	 * @see SimpleMessageListenerContainer#setMismatchedQueuesFatal(boolean)
+	 */
+	public void setMismatchedQueuesFatal(Boolean mismatchedQueuesFatal) {
+		this.mismatchedQueuesFatal = mismatchedQueuesFatal;
+	}
+
+	/**
 	 * @param consumerTagStrategy the consumerTagStrategy to set
 	 * @see SimpleMessageListenerContainer#setConsumerTagStrategy(ConsumerTagStrategy)
 	 */
@@ -280,6 +290,9 @@ public class SimpleRabbitListenerContainerFactory
 		}
 		if (this.recoveryBackOff != null) {
 			instance.setRecoveryBackOff(this.recoveryBackOff);
+		}
+		if (this.mismatchedQueuesFatal != null) {
+			instance.setMismatchedQueuesFatal(this.mismatchedQueuesFatal);
 		}
 		if (this.missingQueuesFatal != null) {
 			instance.setMissingQueuesFatal(this.missingQueuesFatal);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -206,6 +206,7 @@ public class SimpleRabbitListenerContainerFactory
 
 	/**
 	 * @param missingQueuesFatal the missingQueuesFatal to set.
+	 * @since 1.6
 	 * @see SimpleMessageListenerContainer#setMissingQueuesFatal
 	 */
 	public void setMissingQueuesFatal(Boolean missingQueuesFatal) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -207,7 +207,7 @@ public abstract class RabbitUtils {
 	/**
 	 * Return true if the {@link ShutdownSignalException} reason is AMQP.Channel.Close
 	 * and the operation that failed was basicConsumer and the failure text contains
-	 * "exlusive".
+	 * "exclusive".
 	 * @param sig the exception.
 	 * @return true if the declaration failed because of an exclusive queue.
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -162,6 +162,12 @@ public abstract class RabbitUtils {
 		return mustClose;
 	}
 
+	/**
+	 * Return true if the {@link ShutdownSignalException} reason is AMQP.Connection.Close and
+	 * the reply code was AMQP.REPLY_SUCCESS (200) and the text equals "OK".
+	 * @param sig the exception.
+	 * @return true for a normal connection close.
+	 */
 	public static boolean isNormalShutdown(ShutdownSignalException sig) {
 		Method shutdownReason = sig.getReason();
 		return shutdownReason instanceof AMQP.Connection.Close
@@ -169,6 +175,12 @@ public abstract class RabbitUtils {
 				&& "OK".equals(((AMQP.Connection.Close) shutdownReason).getReplyText());
 	}
 
+	/**
+	 * Return true if the {@link ShutdownSignalException} reason is AMQP.Channel.Close and
+	 * the reply code was AMQP.REPLY_SUCCESS (200) and the text equals "OK".
+	 * @param sig the exception.
+	 * @return true for a normal channel close.
+	 */
 	public static boolean isNormalChannelClose(ShutdownSignalException sig) {
 		Method shutdownReason = sig.getReason();
 		return isNormalShutdown(sig) ||
@@ -177,6 +189,12 @@ public abstract class RabbitUtils {
 					&& "OK".equals(((AMQP.Channel.Close) shutdownReason).getReplyText()));
 	}
 
+	/**
+	 * Return true if the {@link ShutdownSignalException} reason is AMQP.Channel.Close
+	 * and the operation that failed was exchangeDeclare or queueDeclare.
+	 * @param sig the exception.
+	 * @return true if the failure meets the conditions.
+	 */
 	public static boolean isPassiveDeclarationChannelClose(ShutdownSignalException sig) {
 		Method shutdownReason = sig.getReason();
 		return shutdownReason instanceof AMQP.Channel.Close
@@ -186,6 +204,13 @@ public abstract class RabbitUtils {
 					&& ((AMQP.Channel.Close) shutdownReason).getMethodId() == 10); // declare
 	}
 
+	/**
+	 * Return true if the {@link ShutdownSignalException} reason is AMQP.Channel.Close
+	 * and the operation that failed was basicConsumer and the failure text contains
+	 * "exlusive".
+	 * @param sig the exception.
+	 * @return true if the declaration failed because of an exclusive queue.
+	 */
 	public static boolean isExclusiveUseChannelClose(ShutdownSignalException sig) {
 		Method shutdownReason = sig.getReason();
 		return shutdownReason instanceof AMQP.Channel.Close
@@ -195,6 +220,15 @@ public abstract class RabbitUtils {
 				&& ((AMQP.Channel.Close) shutdownReason).getReplyText().contains("exclusive");
 	}
 
+	/**
+	 * Return true if there is a {@link ShutdownSignalException} in the cause tree and its
+	 * reason is "PRECONDITION_FAILED" and the operation being performed was queueDeclare.
+	 * This can happen if a queue has mismatched properties (auto-delete etc) or arguments
+	 * (x-message-ttl etc).
+	 * @param e the exception.
+	 * @return true if the exception was due to queue declaration precondition failed.
+	 * @since 1.6
+	 */
 	public static boolean isMismatchedQueueArgs(Exception e) {
 		Throwable cause = e;
 		ShutdownSignalException sig = null;

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.6.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.6.xsd
@@ -759,6 +759,17 @@
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="mismatched-queues-fatal" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	When `true` if queues (defined in the context) are available on the broker, but have different arguments
+	(TTL etc) or properties (auto-delete etc), the condition is considered fatal; this
+	can prevent application startup; it can also cause the container to stop if the queues are deleted or the
+	connection is lost while the container is running. Default: 'false' - the container will listen to queues
+	even if the queue arguments and properties differ.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="declaration-retries" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
@@ -104,6 +104,7 @@ public class ListenerContainerParserTests {
 				beanFactory.getBean("testListener2")));
 		assertEquals(1235L, ReflectionTestUtils.getField(container, "idleEventInterval"));
 		assertEquals("container1", container.getListenerId());
+		assertTrue(TestUtils.getPropertyValue(container, "mismatchedQueuesFatal", Boolean.class));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerInitializationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerInitializationTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.amqp.rabbit.listener;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.amqp.rabbit.listener.exception.FatalListenerStartupException;
+import org.springframework.amqp.rabbit.test.BrokerRunning;
+import org.springframework.context.ApplicationContextException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Gary Russell
+ * @since 1.6
+ *
+ */
+public class ContainerInitializationTests {
+
+	@Rule
+	public BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues("test.mismatch");
+
+	@After
+	public void tearDown() {
+		brokerRunning.removeTestQueues();
+	}
+
+	@Test
+	public void testMismatchedQueue() {
+		try {
+			AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config1.class);
+			context.close();
+			fail("expected initialization failure");
+		}
+		catch (ApplicationContextException e) {
+			assertThat(e.getCause(), instanceOf(FatalListenerStartupException.class));
+		}
+	}
+
+	@Test
+	public void testMismatchedQueueDuringRestart() throws Exception {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config2.class);
+		RabbitAdmin admin = context.getBean(RabbitAdmin.class);
+		admin.deleteQueue("test.mismatch");
+		admin.declareQueue(new Queue("test.mismatch", false, false, true));
+		SimpleMessageListenerContainer container = context.getBean(SimpleMessageListenerContainer.class);
+		int n = 0;
+		while (n++ < 100 && container.isRunning()) {
+			Thread.sleep(100);
+		}
+		assertFalse(container.isRunning());
+		context.close();
+	}
+
+	@Configuration
+	public static class Config1 {
+
+		@Bean
+		public ConnectionFactory connectionFactory() {
+			return new CachingConnectionFactory("localhost");
+		}
+
+		@Bean
+		public RabbitAdmin admin() {
+			return new RabbitAdmin(connectionFactory());
+		}
+
+		@Bean
+		public Queue queue() {
+			return new Queue("test.mismatch", false, false, true); // mismatched
+		}
+
+		@Bean
+		public SimpleMessageListenerContainer container() {
+			SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory());
+			container.setQueueNames("test.mismatch");
+			container.setMessageListener(new MessageListenerAdapter(new Object() {
+
+				@SuppressWarnings("unused")
+				public void handleMessage(Message m) {
+				}
+
+			}));
+			container.setMismatchedQueuesFatal(true);
+			return container;
+		}
+
+	}
+
+	@Configuration
+	public static class Config2 extends Config1 {
+
+		@Override
+		@Bean
+		public Queue queue() {
+			return new Queue("test.mismatch", true, false, false);
+		}
+
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -221,6 +221,9 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		context.getBeanFactory().registerSingleton("foo", queue);
 		context.refresh();
 		container.setApplicationContext(context);
+		RabbitAdmin admin = new RabbitAdmin(this.template.getConnectionFactory());
+		admin.setApplicationContext(context);
+		container.setRabbitAdmin(admin);
 		container.afterPropertiesSet();
 		container.start();
 		for (int i = 0; i < 10; i++) {

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -12,7 +12,7 @@
 	<rabbit:queue id="bar" />
 
 	<rabbit:listener-container connection-factory="connectionFactory" acknowledge="manual" concurrency="5"
-			group="containerGroup" idle-event-interval="1235"
+			group="containerGroup" idle-event-interval="1235" mismatched-queues-fatal="true"
 			max-concurrency="6" receive-timeout="9876" recovery-interval="5555" missing-queues-fatal="false"
 			min-start-interval="1234" min-stop-interval="2345" min-consecutive-active="12" min-consecutive-idle="34"
 			declaration-retries="5" failed-declaration-retry-interval="1000" missing-queue-retry-interval="30000"

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
@@ -19,7 +19,7 @@
 	</rabbit:direct-exchange>
 
 	<rabbit:listener-container concurrency="2">
-		<rabbit:listener id="container1" ref="foo" queues="anon" />
+		<rabbit:listener id="container1" ref="foo" queues="anon" admin="containerAdmin" />
 	</rabbit:listener-container>
 
 	<!-- With Conditional Declarations -->
@@ -43,11 +43,11 @@
 	</rabbit:queue>
 
 	<rabbit:listener-container concurrency="2">
-		<rabbit:listener id="container3" ref="foo" queues="xExpires"/>
+		<rabbit:listener id="container3" ref="foo" queues="xExpires" admin="containerAdmin" />
 	</rabbit:listener-container>
 
 	<rabbit:listener-container auto-declare="false">
-		<rabbit:listener id="container4" ref="foo" queues="anon2"/>
+		<rabbit:listener id="container4" ref="foo" queues="anon2" admin="containerAdmin" />
 	</rabbit:listener-container>
 
 	<rabbit:admin connection-factory="rabbitConnectionFactory" />

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3089,23 +3089,34 @@ If mismatched properties (e.g. `auto-delete`) or arguments (e.g. `x-message-ttl`
 
 If the problem is detected during recovery (e.g. after a lost connection), the container will be stopped.
 
+There must be a single `RabbitAdmin` in the application context (or one specifically configured on the container
+using the `rabbitAdmin` property); otherwise this property must be `false`.
+
 NOTE: If the broker is not available during initial startup, the container will start and the conditions will be
 checked when the connection is established.
 
 IMPORTANT: the check is done against all queues in the context, not just the queues that a particular listener
 is configured to use.
 If you wish to limit the checks to just those queues used by a container, you should configure a separate
-`RabbitAdmin` for the container, and provide a reference to it using the `admin` property.
+`RabbitAdmin` for the container, and provide a reference to it using the `rabbitAdmin` property.
 See <<conditional-declaration>> for more information.
 
 | autoDeclare
 (auto-declare)
 
-| Starting with _version 1.4_, `SimpleMessageListenerContainer` has this new property.
+a| Starting with _version 1.4_, `SimpleMessageListenerContainer` has this new property.
 
-When set to `true` (default), the container will redeclare all AMQP objects (Queues, Exchanges, Bindings), if it detects that at least one of its queues is missing during startup, perhaps because it's an `auto-delete` or an expired queue, but the redeclaration will proceed if the queue is missing for any reason.
+When set to `true` (default), the container will use a `RabbitAdmin` to redeclare all AMQP objects (Queues, Exchanges,
+Bindings), if it detects that at least one of its queues is missing during startup, perhaps because it's an
+`auto-delete` or an expired queue, but the redeclaration will proceed if the queue is missing for any reason.
 To disable this behavior, set this property to `false`.
 Note that the container will fail to start if all of its queues are missing.
+
+NOTE: Prior to _version 1.6_, if there was more than one admin in the context, the container would randomly select one.
+If there were no admins, it would create one internally.
+In either case, this could cause unexpected results.
+Starting with _version 1.6_, for `autoDeclare` to work, there must be exactly one `RabbitAdmin` in the context, or
+a reference to a specific instance must be configured on the container using the `rabbitAdmin` property.
 
 | declarationRetries
 (declaration-retries)

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3078,6 +3078,26 @@ This global property will not be applied to any containers that have an explicit
 
 The default retry properties (3 retries at 5 second intervals) can be overridden using the properties below.
 
+| mismatchedQueuesFatal
+(mismatched-queues-fatal)
+
+a| This was added in _version 1.6_.
+When the container starts, if this property is true (default: false), the container checks that all queues declared in
+the context are compatible with queues already on the broker.
+If mismatched properties (e.g. `auto-delete`) or arguments (e.g. `x-message-ttl`) exist, the container
+(and application context) will fail to start with a fatal exception.
+
+If the problem is detected during recovery (e.g. after a lost connection), the container will be stopped.
+
+NOTE: If the broker is not available during initial startup, the container will start and the conditions will be
+checked when the connection is established.
+
+IMPORTANT: the check is done against all queues in the context, not just the queues that a particular listener
+is configured to use.
+If you wish to limit the checks to just those queues used by a container, you should configure a separate
+`RabbitAdmin` for the container, and provide a reference to it using the `admin` property.
+See <<conditional-declaration>> for more information.
+
 | autoDeclare
 (auto-declare)
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -15,10 +15,21 @@ See <<connections>> for more information.
 
 It is now possible to provide a naming strategy for anonymous queues; see <<anonymous-queue>> for more information.
 
-===== Idle Message Listener Detection
+===== Listener Container Changes
+
+====== Idle Message Listener Detection
 
 It is now possible to configure listener containers to publish `ApplicationEvent` s when idle.
 See <<idle-containers>> for more information.
+
+====== Mismatched Queue Detection
+
+By default, when a listener container starts, if queues with mismatched properties or arguments were detected,
+the container would log the exception but continue to listen.
+The container now has a property `mismatchedQueuesFatal` which will prevent the container (and context) from
+starting if the problem is detected during startup.
+It will also stop the container if the problem is detected later, such as after recovering from a connection failure.
+See <<containerAttributes>> for more information.
 
 ===== AmqpTemple: receive with timeout
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -31,6 +31,11 @@ starting if the problem is detected during startup.
 It will also stop the container if the problem is detected later, such as after recovering from a connection failure.
 See <<containerAttributes>> for more information.
 
+===== AutoDeclare and RabbitAdmins
+
+See <<containerAttributes>> (`autoDeclare`) for some changes to the semantics of that option with respect to the use
+of `RabbitAdmin` s in the application context.
+
 ===== AmqpTemple: receive with timeout
 
 A bunch of of new `receive()` methods with `timeout` have been introduced for the `AmqpTemple`


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-562

Add an option to the listener container to stop it running
if the queue declarations don't match what's on the broker.

Remove reflection on `ShutdownSignalException` now that the
mininmum client version is 3.4.