### PR TITLE
AMQP-563: Support Explicit Temporary Reply Queue

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -39,13 +39,24 @@ import org.springframework.util.StringUtils;
  */
 public class Address {
 
+	/**
+	 * Use this value in {@code RabbitTemplate#setReplyAddress(String)} to use a temporary reply queue
+	 * for each request, regardless of whether the broker supports direct reply-to.
+	 */
+	public static final String TEMPORARY_REPLY_QUEUE_TOKEN = "##TEMPORARY_QUEUE##";
+
+	/**
+	 * Use this value in {@code RabbitTemplate#setReplyAddress(String)} to explicitly
+	 * indicate that direct reply-to is to be used. When there is no replyAddress, the
+	 * template will use direct reply-to if the broker supports it. See {@link #TEMPORARY_REPLY_QUEUE_TOKEN}.
+	 */
+	public static final String AMQ_RABBITMQ_REPLY_TO = "amq.rabbitmq.reply-to";
+
 	private static final Pattern pattern = Pattern.compile("^(?:.*://)?([^/]*)/?(.*)$");
 
 	private final String exchangeName;
 
 	private final String routingKey;
-
-	public static final String AMQ_RABBITMQ_REPLY_TO = "amq.rabbitmq.reply-to";
 
 	/**
 	 * Create an Address instance from a structured String in the form

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
@@ -40,15 +40,8 @@ import org.springframework.util.StringUtils;
 public class Address {
 
 	/**
-	 * Use this value in {@code RabbitTemplate#setReplyAddress(String)} to use a temporary reply queue
-	 * for each request, regardless of whether the broker supports direct reply-to.
-	 */
-	public static final String TEMPORARY_REPLY_QUEUE_TOKEN = "##TEMPORARY_QUEUE##";
-
-	/**
 	 * Use this value in {@code RabbitTemplate#setReplyAddress(String)} to explicitly
-	 * indicate that direct reply-to is to be used. When there is no replyAddress, the
-	 * template will use direct reply-to if the broker supports it. See {@link #TEMPORARY_REPLY_QUEUE_TOKEN}.
+	 * indicate that direct reply-to is to be used.
 	 */
 	public static final String AMQ_RABBITMQ_REPLY_TO = "amq.rabbitmq.reply-to";
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
@@ -56,6 +56,8 @@ class TemplateParser extends AbstractSingleBeanDefinitionParser {
 
 	private static final String REPLY_ADDRESS_ATTRIBUTE = "reply-address";
 
+	private static final String USE_TEMPORARY_REPLY_QUEUES_ATTRIBUTE = "use-temporary-reply-queues";
+
 	private static final String LISTENER_ELEMENT = "reply-listener";
 
 	private static final String MANDATORY_ATTRIBUTE = "mandatory";
@@ -112,6 +114,7 @@ class TemplateParser extends AbstractSingleBeanDefinitionParser {
 			NamespaceUtils.setReferenceIfAttributeDefined(builder, element, REPLY_QUEUE_ATTRIBUTE,
 					Conventions.attributeNameToPropertyName(REPLY_ADDRESS_ATTRIBUTE));
 		}
+		NamespaceUtils.setValueIfAttributeDefined(builder, element, USE_TEMPORARY_REPLY_QUEUES_ATTRIBUTE);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, REPLY_ADDRESS_ATTRIBUTE);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, RETURN_CALLBACK_ATTRIBUTE);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, CONFIRM_CALLBACK_ATTRIBUTE);

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.6.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.6.xsd
@@ -1120,6 +1120,20 @@
 					</xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="use-temporary-reply-queues" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When 'true', instructs the template to use a temporary, exclusive, auto-delete queue for
+	each 'sendAndReceive'. By default, when there is no 'reply-address', the template will
+	use Direct reply-to ('http://www.rabbitmq.com/direct-reply-to.html') when the broker supports it.
+	This flag overrides that behavior; it is ignored if a 'reply-address' is provided.
+	Defaults to 'false'.
+					]]></xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
 			<xsd:attribute name="mandatory" use="optional">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
@@ -14,6 +14,7 @@
 package org.springframework.amqp.rabbit.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -81,6 +82,7 @@ public final class TemplateParserTests {
 				TestUtils.getPropertyValue(template, "sendConnectionFactorySelectorExpression.expression"));
 		assertEquals("'foo'",
 				TestUtils.getPropertyValue(template, "receiveConnectionFactorySelectorExpression.expression"));
+		assertFalse(TestUtils.getPropertyValue(template, "useTemporaryReplyQueues", Boolean.class));
 	}
 
 	@Test
@@ -97,6 +99,7 @@ public final class TemplateParserTests {
 		assertEquals("foo", accessor.getPropertyValue("exchange"));
 		assertEquals("bar", accessor.getPropertyValue("queue"));
 		assertEquals("spam", accessor.getPropertyValue("routingKey"));
+		assertTrue(TestUtils.getPropertyValue(template, "useTemporaryReplyQueues", Boolean.class));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -1326,9 +1326,16 @@ public class RabbitTemplateIntegrationTests {
 	}
 
 	@Test
-	public void testSendAndReceiveNeverFastt() {
-		this.template.setReplyAddress(Address.TEMPORARY_REPLY_QUEUE_TOKEN);
+	public void testSendAndReceiveNeverFast() {
+		this.template.setUseTemporaryReplyQueues(true);
 		sendAndReceiveFastGuts(true);
+	}
+
+	@Test
+	public void testSendAndReceiveNeverFastWitReplyQueue() {
+		this.template.setUseTemporaryReplyQueues(true);
+		this.template.setReplyAddress(Address.AMQ_RABBITMQ_REPLY_TO);
+		sendAndReceiveFastGuts();
 	}
 
 	private void sendAndReceiveFastGuts() {
@@ -1374,7 +1381,6 @@ public class RabbitTemplateIntegrationTests {
 			}
 		}
 		catch (Exception e) {
-			e.printStackTrace();
 			assertThat(e.getCause().getCause().getMessage(), containsString("404"));
 			logger.info("Broker does not support fast replies; test skipped " + e.getMessage());
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -15,6 +15,7 @@ package org.springframework.amqp.rabbit.core;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1324,7 +1325,17 @@ public class RabbitTemplateIntegrationTests {
 		sendAndReceiveFastGuts();
 	}
 
+	@Test
+	public void testSendAndReceiveNeverFastt() {
+		this.template.setReplyAddress(Address.TEMPORARY_REPLY_QUEUE_TOKEN);
+		sendAndReceiveFastGuts(true);
+	}
+
 	private void sendAndReceiveFastGuts() {
+		sendAndReceiveFastGuts(false);
+	}
+
+	private void sendAndReceiveFastGuts(boolean tempQueue) {
 		try {
 			this.template.execute(new ChannelCallback<Void>() {
 
@@ -1355,9 +1366,15 @@ public class RabbitTemplateIntegrationTests {
 			Object result = this.template.convertSendAndReceive("foo");
 			container.stop();
 			assertEquals("FOO", result);
-			assertThat(replyToWas.get(), startsWith(Address.AMQ_RABBITMQ_REPLY_TO));
+			if (tempQueue) {
+				assertThat(replyToWas.get(), not(startsWith(Address.AMQ_RABBITMQ_REPLY_TO)));
+			}
+			else {
+				assertThat(replyToWas.get(), startsWith(Address.AMQ_RABBITMQ_REPLY_TO));
+			}
 		}
 		catch (Exception e) {
+			e.printStackTrace();
 			assertThat(e.getCause().getCause().getMessage(), containsString("404"));
 			logger.info("Broker does not support fast replies; test skipped " + e.getMessage());
 		}

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
@@ -10,6 +10,7 @@
 					 correlation-key="foo"
 					 encoding="UTF-8" exchange="foo" queue="bar" routing-key="spam" message-converter="converter"
 					 reply-timeout="1000"
+					 use-temporary-reply-queues="true"
 					 receive-timeout="123"
 					 retry-template="retrier"
 					 recovery-callback="recoverer"/>

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1948,6 +1948,14 @@ When using Direct reply-to, a `reply-listener` is not required and should not be
 
 Reply listeners are still supported with named queues (other than `amq.rabbitmq.reply-to`), allowing control of reply concurrency etc.
 
+Starting with _version 1.5.4_ if, for some reason, you wish to use a temporary auto-delete queue for each reply, set
+the `replyAddress` property to `##TEMPORARY_QUEUE##` a constant `o.s.amqp.core.Address.TEMPORARY_REPLY_QUEUE_TOKEN` is
+provided when configuring with Java or SpEL.
+
+The decision whether or not to use direct reply-to can be changed to use different criteria by subclassing
+`RabbitTemplate` and overriding `useDirectReplyTo()`.
+The method is called once only; when the first request is sent.
+
 ===== Message Correlation With A Reply Queue
 
 When using a fixed reply queue (other than `amq.rabbitmq.reply-to`), it is necessary to provide correlation data so that replies can be correlated to requests.

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1948,9 +1948,9 @@ When using Direct reply-to, a `reply-listener` is not required and should not be
 
 Reply listeners are still supported with named queues (other than `amq.rabbitmq.reply-to`), allowing control of reply concurrency etc.
 
-Starting with _version 1.5.4_ if, for some reason, you wish to use a temporary auto-delete queue for each reply, set
-the `replyAddress` property to `##TEMPORARY_QUEUE##` a constant `o.s.amqp.core.Address.TEMPORARY_REPLY_QUEUE_TOKEN` is
-provided when configuring with Java or SpEL.
+Starting with _version 1.6_ if, for some reason, you wish to use a temporary, exclusive, auto-delete queue for each
+reply, set the `useTemporaryReplyQueues` property to `true`.
+This property is ignored if you you set a `replyAddress`.
 
 The decision whether or not to use direct reply-to can be changed to use different criteria by subclassing
 `RabbitTemplate` and overriding `useDirectReplyTo()`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -36,11 +36,19 @@ See <<containerAttributes>> for more information.
 See <<containerAttributes>> (`autoDeclare`) for some changes to the semantics of that option with respect to the use
 of `RabbitAdmin` s in the application context.
 
-===== AmqpTemple: receive with timeout
+===== AmqpTemplate: receive with timeout
 
 A bunch of of new `receive()` methods with `timeout` have been introduced for the `AmqpTemple`
  and its `RabbitTemplate` implementation.
 See <<polling-consumer>> for more information.
+
+===== RabbitTemplate Changes
+
+1.4.1 introduced the ability to use https://www.rabbitmq.com/direct-reply-to.html[Direct reply-to] when the broker
+supports it; it is more efficient than using a temporary queue for each reply.
+This version allows you to override this default behavior and use a temporary queue by setting the `replyAddress`
+property to `##TEMPORARY_QUEUE##`.
+See <<direct-reply-to>> for more information.
 
 ==== Changes in 1.5 Since 1.4
 
@@ -214,6 +222,7 @@ See <<queue-affinity>>.
 
 Starting with _version 1.5.3_, you can now control how `AnonymousQueue` names are generated.
 See <<anonymous-queue>> for more information.
+
 
 ==== Changes in 1.4 Since 1.3
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -46,8 +46,8 @@ See <<polling-consumer>> for more information.
 
 1.4.1 introduced the ability to use https://www.rabbitmq.com/direct-reply-to.html[Direct reply-to] when the broker
 supports it; it is more efficient than using a temporary queue for each reply.
-This version allows you to override this default behavior and use a temporary queue by setting the `replyAddress`
-property to `##TEMPORARY_QUEUE##`.
+This version allows you to override this default behavior and use a temporary queue by setting the
+`useTemporaryReplyQueues` property to `true`.
 See <<direct-reply-to>> for more information.
 
 ==== Changes in 1.5 Since 1.4


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-563

Allow user to override the use of direct reply-to when the broker supports it and use a
temporary reply queue for request/reply.

__cherry-pick to 1.5.x__ - what's new will need fixup.