### PR TITLE
AMQP-535: PublisherCallbackChannel Improvements

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -801,6 +801,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			if (this.target != null && !this.target.isOpen()) {
 				synchronized (targetMonitor) {
 					if (this.target != null && !this.target.isOpen()) {
+						if (this.target instanceof PublisherCallbackChannel) {
+							this.target.close(); // emit nacks if necessary
+						}
 						if (this.channelList.contains(proxy)) {
 							this.channelList.remove(proxy);
 						}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -19,15 +19,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -139,8 +137,8 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 
 	private static final String DEFAULT_ENCODING = "UTF-8";
 
-	private final ConcurrentHashMap<Object, SortedMap<Long, PendingConfirm>> pendingConfirms =
-			new ConcurrentHashMap<Object, SortedMap<Long, PendingConfirm>>();
+	private final ConcurrentMap<Channel, RabbitTemplate> publisherConfirmChannels =
+			new ConcurrentHashMap<Channel, RabbitTemplate>();
 
 	private final Map<String, PendingReply> replyHolder = new ConcurrentHashMap<String, PendingReply>();
 
@@ -541,27 +539,16 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	 * Gets unconfirmed correlation data older than age and removes them.
 	 * @param age in milliseconds
 	 * @return the collection of correlation data for which confirms have
-	 * not been received.
+	 * not been received or null if no such confirms exist.
 	 */
 	public Collection<CorrelationData> getUnconfirmed(long age) {
 		Set<CorrelationData> unconfirmed = new HashSet<CorrelationData>();
-		synchronized (this.pendingConfirms) {
-			long threshold = System.currentTimeMillis() - age;
-			for (Entry<Object, SortedMap<Long, PendingConfirm>> channelPendingConfirmEntry : this.pendingConfirms.entrySet()) {
-				SortedMap<Long, PendingConfirm> channelPendingConfirms = channelPendingConfirmEntry.getValue();
-				synchronized(channelPendingConfirmEntry.getKey()) { // channel
-					Iterator<Entry<Long, PendingConfirm>> iterator = channelPendingConfirms.entrySet().iterator();
-					PendingConfirm pendingConfirm;
-					while (iterator.hasNext()) {
-						pendingConfirm = iterator.next().getValue();
-						if (pendingConfirm.getTimestamp() < threshold) {
-							unconfirmed.add(pendingConfirm.getCorrelationData());
-							iterator.remove();
-						}
-						else {
-							break;
-						}
-					}
+		synchronized (this.publisherConfirmChannels) {
+			long cutoffTime = System.currentTimeMillis() - age;
+			for (Channel channel : this.publisherConfirmChannels.keySet()) {
+				Collection<PendingConfirm> confirms = ((PublisherCallbackChannel) channel).expire(this, cutoffTime);
+				for (PendingConfirm confirm : confirms) {
+					unconfirmed.add(confirm.getCorrelationData());
 				}
 			}
 		}
@@ -1461,11 +1448,12 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	private void addListener(Channel channel) {
 		if (channel instanceof PublisherCallbackChannel) {
 			PublisherCallbackChannel publisherCallbackChannel = (PublisherCallbackChannel) channel;
-			SortedMap<Long, PendingConfirm> pendingConfirms = publisherCallbackChannel.addListener(this);
 			Channel key = channel instanceof ChannelProxy ? ((ChannelProxy) channel).getTargetChannel() : channel;
-			if (this.pendingConfirms.putIfAbsent(key, pendingConfirms) == null
-					&& logger.isDebugEnabled()) {
-				logger.debug("Added pending confirms for " + channel + " to map, size now " + this.pendingConfirms.size());
+			if (this.publisherConfirmChannels.putIfAbsent(key, this) == null) {
+				publisherCallbackChannel.addListener(this);
+				if (logger.isDebugEnabled()) {
+					logger.debug("Added pubsub channel: " + channel + " to map, size now " + this.publisherConfirmChannels.size());
+				}
 			}
 		}
 		else {
@@ -1542,11 +1530,11 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	}
 
 	@Override
-	public void removePendingConfirmsReference(Channel channel,
-			SortedMap<Long, PendingConfirm> unconfirmed) {
-		this.pendingConfirms.remove(channel);
+	public void revoke(Channel channel) {
+		this.publisherConfirmChannels.remove(channel);
 		if (logger.isDebugEnabled()) {
-			logger.debug("Removed pending confirms for " + channel + " from map, size now " + this.pendingConfirms.size());
+			logger.debug("Removed pubsub channel: " + channel + " from map, size now "
+					+ this.publisherConfirmChannels.size());
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -17,6 +17,7 @@ package org.springframework.amqp.rabbit.support;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -658,7 +659,7 @@ public class PublisherCallbackChannelImpl
 				processAck(confirmEntry.getKey(), false, false, false);
 				iterator.remove();
 			}
-			listener.removePendingConfirmsReference(this, entry.getValue());
+			listener.revoke(this);
 		}
 		if (logger.isDebugEnabled()) {
 			logger.debug("PendingConfirms cleared");
@@ -670,15 +671,10 @@ public class PublisherCallbackChannelImpl
 
 	/**
 	 * Add the listener and return the internal map of pending confirmations for that listener.
-	 * Callers <b>must</b> synchronize on this channel object when modifying the map.
-	 * This method will be changed in a future release to NOT expose the map.
 	 * @param listener the listener.
-	 * @return the internal map of pending confirmations.
-	 * TODO: do not expose the map externally; change the {@code RabbitTemplate#getUnconfirmed(long)}
-	 * functionality to delegate to a method here.
 	 */
 	@Override
-	public synchronized SortedMap<Long, PendingConfirm> addListener(Listener listener) {
+	public void addListener(Listener listener) {
 		Assert.notNull(listener, "Listener cannot be null");
 		if (this.listeners.size() == 0) {
 			this.delegate.addConfirmListener(this);
@@ -691,31 +687,32 @@ public class PublisherCallbackChannelImpl
 				logger.debug("Added listener " + listener);
 			}
 		}
-		return this.pendingConfirms.get(listener);
 	}
 
 	@Override
-	public synchronized boolean removeListener(Listener listener) {
-		Listener mappedListener = this.listeners.remove(listener.getUUID());
-		boolean result = mappedListener != null;
-		if (result && this.listeners.size() == 0) {
-			this.delegate.removeConfirmListener(this);
-			this.delegate.removeReturnListener(this);
+	public synchronized Collection<PendingConfirm> expire(Listener listener, long cutoffTime) {
+		SortedMap<Long, PendingConfirm> pendingConfirmsForListener = this.pendingConfirms.get(listener);
+		if (pendingConfirmsForListener == null) {
+			return Collections.<PendingConfirm>emptyList();
 		}
-		Iterator<Entry<Long, Listener>> iterator = this.listenerForSeq.entrySet().iterator();
-		while (iterator.hasNext()) {
-			Entry<Long, Listener> entry = iterator.next();
-			if (entry.getValue() == listener) {
-				iterator.remove();
+		else {
+			synchronized (pendingConfirmsForListener) {
+				List<PendingConfirm> expired = new ArrayList<PendingConfirm>();
+				Iterator<Entry<Long, PendingConfirm>> iterator = pendingConfirmsForListener.entrySet().iterator();
+				while (iterator.hasNext()) {
+					PendingConfirm pendingConfirm = iterator.next().getValue();
+					if (pendingConfirm.getTimestamp() < cutoffTime) {
+						expired.add(pendingConfirm);
+						iterator.remove();
+					}
+					else {
+						break;
+					}
+				}
+				return expired;
 			}
 		}
-		this.pendingConfirms.remove(listener);
-		if (logger.isDebugEnabled()) {
-			logger.debug("Removed listener " + listener);
-		}
-		return result;
 	}
-
 
 //	ConfirmListener
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -678,8 +677,8 @@ public class PublisherCallbackChannelImpl
 			this.delegate.addConfirmListener(this);
 			this.delegate.addReturnListener(this);
 		}
-		if (this.listeners.putIfAbsent(listener.getUUID(), listener) != null) {
-			this.pendingConfirms.put(listener, Collections.synchronizedSortedMap(new TreeMap<Long, PendingConfirm>()));
+		if (this.listeners.putIfAbsent(listener.getUUID(), listener) == null) {
+			this.pendingConfirms.put(listener, new ConcurrentSkipListMap<Long, PendingConfirm>());
 			if (logger.isDebugEnabled()) {
 				logger.debug("Added listener " + listener);
 			}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-535

Internal state from the `PublisherCallbackChannel` (pending confirms) leaked
into the `RabbitTemplate` for the sole purpose of supporting `getUnconfirmed()`
which expires old entries and returns them to the caller.

Encapsulate this state within the channel and do not expose externally.

- Change `addListener` to return `void`
- Delete the unused `removeListener()` method from `PublisherCallbackChannel`
- Add `expire()` to `PublisherCallbackChannel`
- Change `getUnconfirmed` to invoke `expire` on each channel
- Change `PublisherCallbackChannel.Listener.removePendingConfirmsReference` to `...revoke()`
  (used to tell the Listener that it will receive no more confirms or returns from this channel
- Fix a problem in the `CachingConnectionFactory` where the pending confirms are not nacked
  if the underlying channel was detected as closed in `logicalClose()`