### PR TITLE
Include module in exclusions so they are included in generated pom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,11 +235,11 @@ project('spring-rabbit-test') {
 
 		compile project(":spring-rabbit")
 		compile ("junit:junit:$junitVersion") {
-			exclude group: 'org.hamcrest'
+			exclude group: 'org.hamcrest', module: 'hamcrest-core'
 		}
 		compile "org.hamcrest:hamcrest-all:$hamcrestVersion"
 		compile ("org.mockito:mockito-core:$mockitoVersion") {
-			exclude group: 'org.hamcrest'
+			exclude group: 'org.hamcrest', module: 'hamcrest-core'
 		}
 		testCompile project(":spring-rabbit").sourceSets.test.output
 


### PR DESCRIPTION
This change fixes the generated pom and gets the Spring IO checks passing again