### PR TITLE
Decrement coundown latch after original is invoked.

### DIFF
--- a/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/mockito/LatchCountDownAndCallRealMethodAnswer.java
+++ b/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/mockito/LatchCountDownAndCallRealMethodAnswer.java
@@ -41,8 +41,8 @@ public class LatchCountDownAndCallRealMethodAnswer implements Answer<Void> {
 
 	@Override
 	public Void answer(InvocationOnMock invocation) throws Throwable {
-		this.latch.countDown();
 		invocation.callRealMethod();
+		this.latch.countDown();
 		return null;
 	}
 


### PR DESCRIPTION
If the latch is counted down before the original method is invoked, assertion in the test case waiting on the latch may fire before the handler method is 100% complete. This can even lead to messages staying in queues if tests terminate quickly enough.