### PR TITLE
Make getSpy method visible to other packages.

### DIFF
--- a/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
+++ b/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
@@ -105,7 +105,7 @@ public class RabbitListenerTestHarness extends RabbitListenerAnnotationBeanPostP
 	}
 
 	@SuppressWarnings("unchecked")
-	<T> T getSpy(String id) {
+	public <T> T getSpy(String id) {
 		return (T) this.listeners.get(id);
 	}
 


### PR DESCRIPTION
In the [testing documentation](http://docs.spring.io/spring-amqp/docs/1.6.0.M1/reference/html/_reference.html#__rabbitlistenertest_and_rabbitlistenertestharness) examples use the harness method getSpy to get a spied upon handler. However, the method currently has package-private visibility, so it can't be used by classes outside that package. The method just needs to be made public!