### PR TITLE
AMQP-580: Add Bean Name to Default Task Executor

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -129,6 +129,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	private volatile Executor taskExecutor = new SimpleAsyncTaskExecutor();
 
+	private volatile boolean taskExecutorSet;
+
 	private volatile int concurrentConsumers = 1;
 
 	private volatile Integer maxConcurrentConsumers;
@@ -416,6 +418,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	public void setTaskExecutor(Executor taskExecutor) {
 		Assert.notNull(taskExecutor, "taskExecutor must not be null");
 		this.taskExecutor = taskExecutor;
+		this.taskExecutorSet = true;
 	}
 
 	/**
@@ -732,6 +735,10 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		checkMissingQueuesFatal();
 		if (!this.isExposeListenerChannel() && this.transactionManager != null) {
 			logger.warn("exposeListenerChannel=false is ignored when using a TransactionManager");
+		}
+		if (!this.taskExecutorSet && StringUtils.hasText(this.getBeanName())) {
+			this.taskExecutor = new SimpleAsyncTaskExecutor(this.getBeanName() + "-");
+			this.taskExecutorSet = true;
 		}
 		initializeProxy();
 		if (this.transactionManager != null) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminIntegrationTests.java
@@ -12,10 +12,12 @@
  */
 package org.springframework.amqp.rabbit.core;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -390,7 +392,7 @@ public class RabbitAdminIntegrationTests {
 		received = template.receive(queue.getName());
 		assertNotNull(received);
 		assertEquals(Integer.valueOf(1000), received.getMessageProperties().getReceivedDelay());
-		assertTrue(System.currentTimeMillis() - t1 > 999);
+		assertThat(System.currentTimeMillis() - t1, greaterThan(950L));
 
 		this.rabbitAdmin.deleteQueue(queue.getName());
 		this.rabbitAdmin.deleteExchange(exchange.getName());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -257,6 +257,7 @@ public class SimpleMessageListenerContainerIntegrationTests {
 		container.setConcurrentConsumers(concurrentConsumers);
 		container.setChannelTransacted(transactional);
 		container.setAcknowledgeMode(acknowledgeMode);
+		container.setBeanName("integrationTestContainer");
 		// requires RabbitMQ 3.2.x
 //		container.setConsumerArguments(Collections. <String, Object> singletonMap("x-priority", Integer.valueOf(10)));
 		if (externalTransaction) {

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1675,6 +1675,15 @@ Threads from the `TaskExecutor` configured in the `SimpleMessageListener` are us
 If not configured, a `SimpleAsyncTaskExecutor` is used.
 If a pooled executor is used, ensure the pool size is sufficient to handle the configured concurrency.
 
+NOTE: When using the default `SimpleAsyncTaskExecutor`, for the threads the listener is invoked on, the listener
+container `beanName` is used as the `threadNamePrefix`.
+This is useful for log analysis; it's generally recommended to always include the thread name in the logging appender
+configuration.
+When a `TaskExecutor` is specifically provided via the `taskExcecutor` property on the `SimpleMessageListenerContainer`,
+it is used as is, without modification.
+It is recommended that you use a similar technique to name the threads created by a custom `TaskExecutor` bean
+definition, to aid with thread identification in log messages.
+
 The `Executor` configured in the `CachingConnectionFactory` is passed into the `RabbitMQ Client` when creating the connection, and its threads are used to deliver new messages to the listener container.
 At the time of writing, if this is not configured, the client uses an internal thread pool executor with a pool size of 5.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -36,6 +36,11 @@ starting if the problem is detected during startup.
 It will also stop the container if the problem is detected later, such as after recovering from a connection failure.
 See <<containerAttributes>> for more information.
 
+====== Listener Container Logging
+
+Now listener container provides its `beanName` into the internal `SimpleAsyncTaskExecutor` as a `threadNamePrefix`.
+It is useful for logs analysis.
+
 ===== AutoDeclare and RabbitAdmins
 
 See <<containerAttributes>> (`autoDeclare`) for some changes to the semantics of that option with respect to the use


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-580

Identify the originating container/consumer in logs.