### PR TITLE
AMQP-582: Compatibility with SF-4.3

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpointTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -389,7 +389,8 @@ public class MethodRabbitListenerEndpointTests {
 		Channel channel = mock(Channel.class);
 
 		thrown.expect(ListenerExecutionFailedException.class);
-		thrown.expectCause(Matchers.isA(MethodArgumentTypeMismatchException.class));
+		thrown.expectCause(Matchers.<Throwable>either(Matchers.instanceOf(MethodArgumentTypeMismatchException.class))
+				.or(Matchers.instanceOf(MessageConversionException.class)));
 		listener.onMessage(createTextMessage("test"), channel);  // Message<String> as Message<Integer>
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-582

Since the recent change in the SF-4.3 the `MessageMethodArgumentResolver` supports now the payload conversion option.
With that the conversion exception expectation has been changed.

Make `MethodRabbitListenerEndpointTests` compatible with SF-4.3, as well retain compatibility with previous versions.