### PR TITLE
AMQP-583: Fatal @RabbitListener Exceptions

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ErrorHandlerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ErrorHandlerTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import org.apache.commons.logging.Log;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.internal.stubbing.answers.DoesNothing;
+
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
+import org.springframework.amqp.support.converter.MessageConversionException;
+import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentTypeMismatchException;
+
+/**
+ * @author Gary Russell
+ * @since 1.6
+ *
+ */
+public class ErrorHandlerTests {
+
+	@Test
+	public void testFatalsAreRejected() throws Exception {
+		ConditionalRejectingErrorHandler handler = new ConditionalRejectingErrorHandler();
+		Log logger = spy(TestUtils.getPropertyValue(handler, "logger", Log.class));
+		doAnswer(new DoesNothing()).when(logger).warn(Matchers.anyString(), Matchers.any(Throwable.class));
+		new DirectFieldAccessor(handler).setPropertyValue("logger", logger);
+		handler.handleError(new ListenerExecutionFailedException("intended", new RuntimeException()));
+
+		try {
+			handler.handleError(new ListenerExecutionFailedException("intended", new MessageConversionException("")));
+			fail("Expected exception");
+		}
+		catch (AmqpRejectAndDontRequeueException e) {
+		}
+
+		try {
+			handler.handleError(new ListenerExecutionFailedException("intended",
+					new org.springframework.messaging.converter.MessageConversionException("")));
+			fail("Expected exception");
+		}
+		catch (AmqpRejectAndDontRequeueException e) {
+		}
+
+		Message<?> message = mock(Message.class);
+		MethodParameter mp = new MethodParameter(Foo.class.getMethod("foo", String.class), 0);
+		try {
+			handler.handleError(new ListenerExecutionFailedException("intended",
+					new MethodArgumentNotValidException(message, mp)));
+			fail("Expected exception");
+		}
+		catch (AmqpRejectAndDontRequeueException e) {
+		}
+
+		try {
+			handler.handleError(new ListenerExecutionFailedException("intended",
+					new MethodArgumentTypeMismatchException(message, mp, "")));
+			fail("Expected exception");
+		}
+		catch (AmqpRejectAndDontRequeueException e) {
+		}
+	}
+
+	private static class Foo {
+
+		@SuppressWarnings("unused")
+		public void foo(String foo) {
+		}
+
+	}
+}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3164,17 +3164,36 @@ For example, there are a lot of cases where IOExceptions may be thrown.
 The RabbitTemplate, SimpleMessageListenerContainer, and other Spring AMQP components will catch those Exceptions and convert into one of the Exceptions within our runtime hierarchy.
 Those are defined in the 'org.springframework.amqp' package, and AmqpException is the base of the hierarchy.
 
-When a listener throws an exception, it is wrapped in a `ListenerExecutionFailedException` and, normally the message is rejected and requeued by the broker.
+When a listener throws an exception, it is wrapped in a `ListenerExecutionFailedException` and, normally the message is
+rejected and requeued by the broker.
 Setting `defaultRequeueRejected` to false will cause messages to be discarded (or routed to a dead letter exchange).
-As discussed in <<async-listeners>>, the listener can throw an `AmqpRejectAndDontRequeueException` to conditionally control this behavior.
+As discussed in <<async-listeners>>, the listener can throw an `AmqpRejectAndDontRequeueException` to conditionally
+control this behavior.
 
 However, there is a class of errors where the listener cannot control the behavior.
-When a message that cannot be converted is encountered (for example an invalid `content_encoding` header), the `MessageConversionException` is thrown before the message reaches user code.
+When a message that cannot be converted is encountered (for example an invalid `content_encoding` header), some
+exceptions are thrown before the message reaches user code.
 With `defaultRequeueRejected` set to `true` (default), such messages would be redelivered over and over.
-Before _version 1.3.2_, users needed to write a custom `ErrorHandler`, as discussed in <<exception-handling>> to avoid this situation.
+Before _version 1.3.2_, users needed to write a custom `ErrorHandler`, as discussed in <<exception-handling>> to avoid
+this situation.
 
-Starting with _version 1.3.2_, the default `ErrorHandler` is now a `ConditionalRejectingErrorHandler` which will reject (and not requeue) messages that fail with a `MessageConversionException`.
-An instance of this error handler can be configured with a `FatalExceptionStrategy` so users can provide their own rules for conditional message rejection, e.g.
+Starting with _version 1.3.2_, the default `ErrorHandler` is now a `ConditionalRejectingErrorHandler` which will reject
+(and not requeue) messages that fail with an irrecoverable error:
+
+- `o.s.amqp...MessageConversionException`
+- `o.s.messaging...MessageConversionException`
+- `o.s.messaging...MethodArgumentNotValidException`
+- `o.s.messaging...MethodArgumentTypeMismatchException`
+
+The first can be thrown when converting the incoming message payload using a `MessageConverter`.
+The second may be thrown by the conversion service if additional conversion is required when mapping to a
+`@RabbitListener` method.
+The third may be thrown if validation (e.g. `@Valid`) is used in the listener and the validation fails.
+The fourth may be thrown if the inbound message was converted to a type that is not correct for the target method.
+For example, the parameter is declared as `Message<Foo>` but `Message<Bar>` is received.
+
+An instance of this error handler can be configured with a `FatalExceptionStrategy` so users can provide their own rules
+for conditional message rejection, e.g.
 a delegate implementation to the `BinaryExceptionClassifier` from Spring Retry (<<async-listeners>>).
 In addition, the `ListenerExecutionFailedException` now has a `failedMessage` property which can be used in the decision.
 If the `FatalExceptionStrategy.isFatal()` method returns `true`, the error handler throws an `AmqpRejectAndDontRequeueException`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -41,6 +41,13 @@ See <<containerAttributes>> for more information.
 Now listener container provides its `beanName` into the internal `SimpleAsyncTaskExecutor` as a `threadNamePrefix`.
 It is useful for logs analysis.
 
+====== Default Error Handler
+
+The default error handler (`ConditionalRejectingErrorHandler`) now considers irrecoverable `@RabbitListener`
+exceptions as fatal.
+See <<exception-handling>> for more information.
+
+
 ===== AutoDeclare and RabbitAdmins
 
 See <<containerAttributes>> (`autoDeclare`) for some changes to the semantics of that option with respect to the use


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-583

The `ConditionalRejectingErrorHandler` now considers irrecoverable
`@RabbitListener` exceptions as fatal (rejecting the message so it is
discarded or routed to a DLX/DLQ).

Previously, only `MessageConversionException`s were fatal by default
and users had to configure a customized error handler.

`o.s.amqp.support.converter.MessageConversionException`
`o.s.messaging.converter.MessageConversionException`
`MethodArgumentNotValidException`
`MethodArgumentTypeMismatchException`

are all fatal exceptions.

Also, previously, the stack trace was logged twice; it is now only logged once.

__cherry-pick to 1.5.x__ What's new will need adjustment.