### PR TITLE
AMQP-579: @SendTo - Support Runtime SpEL

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
@@ -96,7 +96,7 @@ public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter {
 	 * set the precedence to {@link TypePrecedence#TYPE_ID}.
 	 * @param typePrecedence the precedence.
 	 * @since 1.6
-	 * @see DefaultJackson2JavaTypeMapper#setTypePrecedence(TypePrecedence)
+	 * @see DefaultJackson2JavaTypeMapper#setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence)
 	 */
 	public void setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence typePrecedence) {
 		if (this.typeMapperSet) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
@@ -32,6 +32,8 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.config.BeanExpressionContext;
 import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.expression.BeanResolver;
 import org.springframework.util.Assert;
 
 /**
@@ -63,8 +65,9 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 
 	private BeanExpressionContext expressionContext;
 
-	private String group;
+	private BeanResolver beanResolver;
 
+	private String group;
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
@@ -73,6 +76,7 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 			this.resolver = ((ConfigurableListableBeanFactory) beanFactory).getBeanExpressionResolver();
 			this.expressionContext = new BeanExpressionContext((ConfigurableListableBeanFactory) beanFactory, null);
 		}
+		this.beanResolver = new BeanFactoryResolver(beanFactory);
 	}
 
 	protected BeanFactory getBeanFactory() {
@@ -81,6 +85,10 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 
 	protected BeanExpressionResolver getResolver() {
 		return this.resolver;
+	}
+
+	protected BeanResolver getBeanResolver() {
+		return this.beanResolver;
 	}
 
 	protected BeanExpressionContext getBeanExpressionContext() {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MultiMethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MultiMethodRabbitListenerEndpoint.java
@@ -20,9 +20,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.amqp.AmqpException;
-import org.springframework.amqp.core.Address;
-import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.listener.adapter.DelegatingInvocableHandler;
 import org.springframework.amqp.rabbit.listener.adapter.HandlerAdapter;
 import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
@@ -54,37 +51,6 @@ public class MultiMethodRabbitListenerEndpoint extends MethodRabbitListenerEndpo
 		this.delegatingHandler = new DelegatingInvocableHandler(invocableHandlerMethods, getBean(), getResolver(),
 				getBeanExpressionContext());
 		return new HandlerAdapter(this.delegatingHandler);
-	}
-
-
-	@Override
-	protected MessagingMessageListenerAdapter createMessageListenerInstance() {
-		return new MultiMethodMessageListenerAdapter(getBean());
-	}
-
-
-	private final class MultiMethodMessageListenerAdapter extends MessagingMessageListenerAdapter {
-
-		public MultiMethodMessageListenerAdapter(Object bean) {
-			super(bean, null);
-		}
-
-		@Override
-		protected Address getReplyToAddress(Message request) throws Exception {
-			Address replyTo = request.getMessageProperties().getReplyToAddress();
-			Address defaultReplyTo = null;
-			if (MultiMethodRabbitListenerEndpoint.this.delegatingHandler != null) {
-				defaultReplyTo = MultiMethodRabbitListenerEndpoint.this.delegatingHandler.getDefaultReplyTo();
-			}
-			if (replyTo == null && defaultReplyTo == null) {
-				throw new AmqpException(
-						"Cannot determine ReplyTo message property value: " +
-								"Request message does not contain reply-to property, " +
-								"and no @SendTo annotation found.");
-			}
-			return replyTo == null ? defaultReplyTo : replyTo;
-		}
-
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -59,7 +59,6 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 
 	private final MessagingMessageConverterAdapter messagingMessageConverter;
 
-
 	public MessagingMessageListenerAdapter() {
 		this(null, null);
 	}
@@ -97,7 +96,6 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 		return this.messagingMessageConverter;
 	}
 
-
 	@Override
 	public void onMessage(org.springframework.amqp.core.Message amqpMessage, Channel channel) throws Exception {
 		Message<?> message = toMessagingMessage(amqpMessage);
@@ -106,7 +104,7 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 		}
 		Object result = invokeHandler(amqpMessage, channel, message);
 		if (result != null) {
-			handleResult(result, amqpMessage, channel);
+			handleResult(result, amqpMessage, channel, message);
 		}
 		else {
 			logger.trace("No result object given - no result to handle");

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -621,13 +621,13 @@ public class EnableRabbitIntegrationTests {
 		}
 
 		@RabbitListener(queues = "test.sendTo.runtimespel")
-		@SendTo("SpEL:'test.sendTo.reply.' + result")
+		@SendTo("!{'test.sendTo.reply.' + result}")
 		public String capitalizeAndSendToSpelRuntime(String foo) {
 			return "runtime" + foo;
 		}
 
 		@RabbitListener(queues = "test.sendTo.runtimespelsource")
-		@SendTo("SpEL:source.headers['amqp_consumerQueue'] + '.reply'")
+		@SendTo("!{source.headers['amqp_consumerQueue'] + '.reply'}")
 		public String capitalizeAndSendToSpelRuntimeSource(String foo) {
 			return "sourceEval";
 		}
@@ -998,7 +998,7 @@ public class EnableRabbitIntegrationTests {
 	static class MultiListenerJsonBean {
 
 		@RabbitHandler
-		@SendTo("SpEL:@sendToRepliesSpELBean")
+		@SendTo("!{@sendToRepliesSpELBean}")
 		public String bar(Bar bar, Message message) {
 			return "BAR: " + bar.field + message.getMessageProperties().getTargetBean().getClass().getSimpleName();
 		}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1665,7 +1665,8 @@ public Message<OrderStatus> processOrder(Order order) {
 }
 ----
 
-The `@SendTo` value is assumed as a reply `exchange` and `routingKey` pair following the pattern `exchange/routingKey`, where one of those parts can be omitted.
+The `@SendTo` value is assumed as a reply `exchange` and `routingKey` pair following the pattern `exchange/routingKey`,
+where one of those parts can be omitted.
 The valid values are:
 
 `foo/bar` - the replyTo exchange and routingKey.
@@ -1685,7 +1686,7 @@ Also `@SendTo` can be used without a `value` attribute.
 This case is equal to an empty sendTo pattern.
 `@SendTo` is only used if the inbound message does not have a `replyToAddress` property.
 
-Starting with _version 1.5_, the `@SendTo` value can be a SpEL Expression, for example...
+Starting with _version 1.5_, the `@SendTo` value can be a bean initialization SpEL Expression, for example...
 
 [source, java]
 ----
@@ -1703,10 +1704,11 @@ public String spelReplyTo() {
 
 The expression must evaluate to a `String`, which can be a simple queue name (sent to the default exchange) or with
 the form `exchange/routingKey` as discussed above.
-The expression is evaluated once, during context initialization.
-For dynamic reply routing, the message sender should include a `reply_to` message property.
 
-NOTE: The expression is evaluated once, during initialization.
+NOTE: The `#{...}` expression is evaluated once, during initialization.
+
+For dynamic reply routing, the message sender should include a `reply_to` message property or use the alternate
+runtime SpEL expression described below.
 
 Starting with _version 1.6_, the `@SendTo` can be a SpEL expression that is evaluated at runtime against the request
 and reply:
@@ -1714,14 +1716,14 @@ and reply:
 [source, java]
 ----
 @RabbitListener(queues = "test.sendTo.spel")
-@SendTo("SpEL:'some.reply.queue.with.' + result.queueName")
+@SendTo("!{'some.reply.queue.with.' + result.queueName}")
 public Bar capitalizeWithSendToSpel(Foo foo) {
     return processTheFooAndReturnABar(foo);
 }
 ----
 
-The runtime nature of the SpEL expression is indicated with the `SpEL:` prefix.
-The evaluation context `#root` object for the expression has two properties:
+The runtime nature of the SpEL expression is indicated with the `!{...}` prefix.
+The evaluation context `#root` object for the expression has three properties:
 
 - `request` - the `o.s.amqp.core.Message` request object.
 - `source` - the `o.s.messaging.Message<?>` after conversion.
@@ -1729,6 +1731,11 @@ The evaluation context `#root` object for the expression has two properties:
 
 The context has a map property accessor, a standard type converter and a bean resolver, allowing other beans in the
 context to be referenced (e.g. `@someBeanName.determineReplyQ(request, result)`).
+
+In summary, `#{...}` is evaluated once during initialization, with the `#root` object being the application context;
+beans are referenced by their names.
+`!{...}` is evaluated at runtime for each message with the root object having the properties above and beans are
+referenced with their names, prefixed by `@`.
 
 [[annotation-method-selection]]
 ====== Multi-Method Listeners

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1706,6 +1706,30 @@ the form `exchange/routingKey` as discussed above.
 The expression is evaluated once, during context initialization.
 For dynamic reply routing, the message sender should include a `reply_to` message property.
 
+NOTE: The expression is evaluated once, during initialization.
+
+Starting with _version 1.6_, the `@SendTo` can be a SpEL expression that is evaluated at runtime against the request
+and reply:
+
+[source, java]
+----
+@RabbitListener(queues = "test.sendTo.spel")
+@SendTo("SpEL:'some.reply.queue.with.' + result.queueName")
+public Bar capitalizeWithSendToSpel(Foo foo) {
+    return processTheFooAndReturnABar(foo);
+}
+----
+
+The runtime nature of the SpEL expression is indicated with the `SpEL:` prefix.
+The evaluation context `#root` object for the expression has two properties:
+
+- `request` - the `o.s.amqp.core.Message` request object.
+- `source` - the `o.s.messaging.Message<?>` after conversion.
+- `result` - the method result.
+
+The context has a map property accessor, a standard type converter and a bean resolver, allowing other beans in the
+context to be referenced (e.g. `@someBeanName.determineReplyQ(request, result)`).
+
 [[annotation-method-selection]]
 ====== Multi-Method Listeners
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -112,11 +112,19 @@ See <<broker-configuration>> for more information.
 
 ===== @RabbitListener Changes
 
+====== Multiple Containers per Bean
+
 When using Java 8 or later, it is now possible to add multiple `@RabbitListener` annotations to `@Bean` classes or
 their methods.
 When using Java 7 or earlier, you can use the `@RabbitListeners` container annotation to provide the same
 functionality.
 See <<repeatable-rabbit-listener>> for more information.
+
+====== @SendTo SpEL Expressions
+
+`@SendTo` for routing replies with no `replyTo` property can now be SpEL expressions evaluated against the
+request/reply.
+See <<async-annotation-driven-reply>> for more information.
 
 ===== Delayed Message Exchange
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-579

`@SendTo` currently supports initialization time SpEL (`#{...}`).

Add support for runtime SpEL evaluation against the request and reply objects.

This change also eliminates the `ThreadLocal` for `@SendTo`s in the
`DelegatingInvocableHandler` for multi-method listeners, in favor of
returning a `ResultHolder` containg the result and sendTo (when there
is no `replyTo` property.