### PR TITLE
AMQP-591: Channel Cache (with Permits) Backport

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -273,6 +274,140 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
+	public void testConnectionLimit() throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
+		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
+
+		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnection.isOpen()).thenReturn(true);
+
+		final CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ccf.setCacheMode(CacheMode.CONNECTION);
+		ccf.setConnectionCacheSize(1);
+		ccf.setConnectionLimit(1);
+		ccf.setChannelCheckoutTimeout(10);
+
+		Connection con1 = ccf.createConnection();
+
+		try {
+			ccf.createConnection();
+			fail("Exception expected");
+		}
+		catch (AmqpTimeoutException e) {}
+
+		// should be ignored, and added to cache
+		con1.close();
+
+		Connection con2 = ccf.createConnection();
+		assertSame(con1, con2);
+
+		final CountDownLatch latch2 = new CountDownLatch(1);
+		final CountDownLatch latch1 = new CountDownLatch(1);
+		final AtomicReference<Connection> connection = new AtomicReference<Connection>();
+		ccf.setChannelCheckoutTimeout(30000);
+		Executors.newSingleThreadExecutor().execute(new Runnable() {
+
+			@Override
+			public void run() {
+				latch1.countDown();
+				connection.set(ccf.createConnection());
+				latch2.countDown();
+			}
+
+		});
+
+		assertTrue(latch1.await(10, TimeUnit.SECONDS));
+		Thread.sleep(100);
+		con2.close();
+		assertTrue(latch2.await(10, TimeUnit.SECONDS));
+		assertSame(con2, connection.get());
+
+		ccf.destroy();
+	}
+
+	@Test
+	public void testCheckoutsWithRefreshedConnectionModeChannel() throws Exception {
+		testCheckoutsWithRefreshedConnectionGuts(CacheMode.CHANNEL);
+	}
+
+	@Test
+	public void testCheckoutsWithRefreshedConnectionModeConnection() throws Exception {
+		testCheckoutsWithRefreshedConnectionGuts(CacheMode.CONNECTION);
+	}
+
+	public void testCheckoutsWithRefreshedConnectionGuts(CacheMode mode) throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
+		com.rabbitmq.client.Connection mockConnection1 = mock(com.rabbitmq.client.Connection.class);
+		com.rabbitmq.client.Connection mockConnection2 = mock(com.rabbitmq.client.Connection.class);
+		Channel mockChannel1 = mock(Channel.class);
+		Channel mockChannel2 = mock(Channel.class);
+		Channel mockChannel3 = mock(Channel.class);
+		Channel mockChannel4 = mock(Channel.class);
+
+		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection1, mockConnection2);
+		when(mockConnection1.createChannel()).thenReturn(mockChannel1, mockChannel2);
+		when(mockConnection1.isOpen()).thenReturn(true);
+		when(mockConnection2.createChannel()).thenReturn(mockChannel3, mockChannel4);
+		when(mockConnection2.isOpen()).thenReturn(true);
+
+		when(mockChannel1.isOpen()).thenReturn(true);
+		when(mockChannel2.isOpen()).thenReturn(true);
+		when(mockChannel3.isOpen()).thenReturn(true);
+		when(mockChannel4.isOpen()).thenReturn(true);
+
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ccf.setChannelCacheSize(2);
+		ccf.setChannelCheckoutTimeout(10);
+		ccf.setCacheMode(mode);
+
+		ccf.addConnectionListener(new ConnectionListener() { // simulate admin
+
+			@Override
+			public void onCreate(Connection connection) {
+				try {
+					connection.createChannel(false).close();
+				}
+				catch (Exception e) {
+					fail(e.getMessage());
+				}
+			}
+
+			@Override
+			public void onClose(Connection connection) {
+				// empty
+			}
+		});
+
+		Connection con = ccf.createConnection();
+
+		Channel channel1 = con.createChannel(false);
+		channel1.close();
+		con.close();
+
+		when(mockConnection1.isOpen()).thenReturn(false);
+		when(mockChannel1.isOpen()).thenReturn(false);
+		when(mockChannel2.isOpen()).thenReturn(false);
+
+		con.createChannel(false).close();
+		con = ccf.createConnection();
+		con.createChannel(false).close();
+		con.createChannel(false).close();
+		con.createChannel(false).close();
+		con.createChannel(false).close();
+		con.createChannel(false).close();
+
+		verify(mockConnection1, times(1)).createChannel();
+		verify(mockConnection2, times(2)).createChannel();
+
+		con.close();
+
+		verify(mockConnection2, never()).close();
+
+		ccf.destroy();
+
+	}
+
+	@Test
 	public void testCheckoutLimitWithRelease() throws IOException, Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
@@ -435,22 +570,24 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	@Test
 	public void testWithConnectionFactoryDestroy() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
-		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
+		com.rabbitmq.client.Connection mockConnection1 = mock(com.rabbitmq.client.Connection.class);
+		com.rabbitmq.client.Connection mockConnection2 = mock(com.rabbitmq.client.Connection.class);
 
 		Channel mockChannel1 = mock(Channel.class);
 		Channel mockChannel2 = mock(Channel.class);
+		Channel mockChannel3 = mock(Channel.class);
 
 		assertNotSame(mockChannel1, mockChannel2);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
-		// You can't repeat 'when' statements for stubbing consecutive calls to
-		// the same method to returning different
-		// values.
-		when(mockConnection.createChannel()).thenReturn(mockChannel1).thenReturn(mockChannel2);
-		when(mockConnection.isOpen()).thenReturn(true);
+		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection1, mockConnection2);
+		when(mockConnection1.createChannel()).thenReturn(mockChannel1, mockChannel2);
+		when(mockConnection1.isOpen()).thenReturn(true);
+		when(mockConnection2.createChannel()).thenReturn(mockChannel3);
+		when(mockConnection2.isOpen()).thenReturn(true);
 		// Called during physical close
 		when(mockChannel1.isOpen()).thenReturn(true);
 		when(mockChannel2.isOpen()).thenReturn(true);
+		when(mockChannel3.isOpen()).thenReturn(true);
 
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
 		ccf.setChannelCacheSize(2);
@@ -482,19 +619,20 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ch1.close();
 		ch2.close();
 		con.close(); // should be ignored
+		com.rabbitmq.client.Connection conDelegate = targetDelegate(con);
 
 		ccf.destroy(); // should call close on connection and channels in cache
 
-		verify(mockConnection, times(2)).createChannel();
+		verify(mockConnection1, times(2)).createChannel();
 
-		verify(mockConnection).close(anyInt());
+		verify(mockConnection1).close(anyInt());
 
 		// verify(mockChannel1).close();
 		verify(mockChannel2).close();
 
 		// After destroy we can get a new connection
 		Connection con1 = ccf.createConnection();
-		assertNotSame(con, con1);
+		assertNotSame(conDelegate, targetDelegate(con1));
 
 		// This will return a proxy that surpresses calls to close
 		Channel channel3 = con.createChannel(false);
@@ -548,7 +686,9 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection1 = mock(com.rabbitmq.client.Connection.class);
+		when(mockConnection1.toString()).thenReturn("conn1");
 		com.rabbitmq.client.Connection mockConnection2 = mock(com.rabbitmq.client.Connection.class);
+		when(mockConnection2.toString()).thenReturn("conn2");
 		Channel mockChannel = mock(Channel.class);
 
 		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection1, mockConnection2);
@@ -586,6 +726,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		channel = con.createChannel(false);
 		assertSame(con, same);
 		channel.close();
+		com.rabbitmq.client.Connection conDelegate = targetDelegate(con);
 
 		when(mockConnection1.isOpen()).thenReturn(false);
 		when(mockChannel.isOpen()).thenReturn(false); // force a connection refresh
@@ -593,7 +734,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		channel.close();
 
 		Connection notSame = connectionFactory.createConnection();
-		assertNotSame(con, notSame);
+		assertNotSame(conDelegate, targetDelegate(notSame));
 		assertSame(con, closed.get());
 		assertSame(notSame, created.get());
 
@@ -640,34 +781,36 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.setCacheMode(CacheMode.CONNECTION);
 		ccf.afterPropertiesSet();
 
-		Set<?> openConnections = TestUtils.getPropertyValue(ccf, "openConnections", Set.class);
-		assertEquals(0, openConnections.size());
+		Set<?> allocatedConnections = TestUtils.getPropertyValue(ccf, "allocatedConnections", Set.class);
+		assertEquals(0, allocatedConnections.size());
 		BlockingQueue<?> idleConnections = TestUtils.getPropertyValue(ccf, "idleConnections", BlockingQueue.class);
 		assertEquals(0, idleConnections.size());
 
-		final AtomicReference<Connection> createNotification = new AtomicReference<Connection>();
-		final AtomicReference<Connection> closedNotification = new AtomicReference<Connection>();
+		final AtomicReference<com.rabbitmq.client.Connection> createNotification =
+				new AtomicReference<com.rabbitmq.client.Connection>();
+		final AtomicReference<com.rabbitmq.client.Connection> closedNotification =
+				new AtomicReference<com.rabbitmq.client.Connection>();
 		ccf.setConnectionListeners(Collections.singletonList(new ConnectionListener(){
 
 			@Override
 			public void onCreate(Connection connection) {
 				assertNull(createNotification.get());
-				createNotification.set(connection);
+				createNotification.set(targetDelegate(connection));
 			}
 
 			@Override
 			public void onClose(Connection connection) {
 				assertNull(closedNotification.get());
-				closedNotification.set(connection);
+				closedNotification.set(targetDelegate(connection));
 			}
 		}));
 
 		Connection con1 = ccf.createConnection();
 		verifyConnectionIs(mockConnections.get(0), con1);
-		assertEquals(1, openConnections.size());
+		assertEquals(1, allocatedConnections.size());
 		assertEquals(0, idleConnections.size());
 		assertNotNull(createNotification.get());
-		assertSame(mockConnections.get(0), targetDelegate(createNotification.getAndSet(null)));
+		assertSame(mockConnections.get(0), createNotification.getAndSet(null));
 
 		Channel channel1 = con1.createChannel(false);
 		verifyChannelIs(mockChannels.get(0), channel1);
@@ -677,7 +820,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 		con1.close(); // should be ignored, and placed into connection cache.
 		verify(mockConnections.get(0), never()).close();
-		assertEquals(1, openConnections.size());
+		assertEquals(1, allocatedConnections.size());
 		assertEquals(1, idleConnections.size());
 		assertNull(closedNotification.get());
 
@@ -692,7 +835,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		verify(mockChannels.get(0), never()).close();
 		con2.close();
 		verify(mockConnections.get(0), never()).close();
-		assertEquals(1, openConnections.size());
+		assertEquals(1, allocatedConnections.size());
 		assertEquals(1, idleConnections.size());
 		assertNull(createNotification.get());
 
@@ -707,17 +850,17 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		verifyChannelIs(mockChannels.get(0), channel1);
 		channel2 = con2.createChannel(false);
 		verifyChannelIs(mockChannels.get(1), channel2);
-		assertEquals(2, openConnections.size());
+		assertEquals(2, allocatedConnections.size());
 		assertEquals(0, idleConnections.size());
 		assertNotNull(createNotification.get());
-		assertSame(mockConnections.get(1), targetDelegate(createNotification.getAndSet(null)));
+		assertSame(mockConnections.get(1), createNotification.getAndSet(null));
 
 		// put mock1 in cache
 		channel1.close();
 		verify(mockChannels.get(1), never()).close();
 		con1.close();
 		verify(mockConnections.get(0), never()).close();
-		assertEquals(2, openConnections.size());
+		assertEquals(2, allocatedConnections.size());
 		assertEquals(1, idleConnections.size());
 		assertNull(closedNotification.get());
 
@@ -727,24 +870,25 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		Channel channel3 = con3.createChannel(false);
 		verifyChannelIs(mockChannels.get(0), channel3);
 
-		assertEquals(2, openConnections.size());
+		assertEquals(2, allocatedConnections.size());
 		assertEquals(0, idleConnections.size());
 
 		channel2.close();
 		con2.close();
-		assertEquals(2, openConnections.size());
+		assertEquals(2, allocatedConnections.size());
 		assertEquals(1, idleConnections.size());
 		channel3.close();
 		con3.close();
-		assertEquals(1, openConnections.size());
-		assertEquals(1, idleConnections.size());
+		assertEquals(2, allocatedConnections.size());
+		assertEquals(2, idleConnections.size());
+		assertEquals("1", countOpenConnections(allocatedConnections));
 		/*
 		 *  Cache size is 1; con3 (mock1) should have been a real close.
 		 *  con2 (mock2) should still be in the cache.
 		 */
 		verify(mockConnections.get(0)).close(30000);
 		assertNotNull(closedNotification.get());
-		assertSame(mockConnections.get(0), targetDelegate(closedNotification.getAndSet(null)));
+		assertSame(mockConnections.get(0), closedNotification.getAndSet(null));
 		verify(mockChannels.get(1), never()).close();
 		verify(mockConnections.get(1), never()).close(30000);
 		verify(mockChannels.get(1), never()).close();
@@ -753,21 +897,24 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		 * Now a closed cached connection
 		 */
 		when(mockConnections.get(1).isOpen()).thenReturn(false);
+		when(mockChannels.get(1).isOpen()).thenReturn(false);
 		con3 = ccf.createConnection();
 		assertNotNull(closedNotification.get());
-		assertSame(mockConnections.get(1), targetDelegate(closedNotification.getAndSet(null)));
+		assertSame(mockConnections.get(1), closedNotification.getAndSet(null));
 		verifyConnectionIs(mockConnections.get(2), con3);
 		assertNotNull(createNotification.get());
-		assertSame(mockConnections.get(2), targetDelegate(createNotification.getAndSet(null)));
-		assertEquals(1, openConnections.size());
-		assertEquals(0, idleConnections.size());
+		assertSame(mockConnections.get(2), createNotification.getAndSet(null));
+		assertEquals(2, allocatedConnections.size());
+		assertEquals(1, idleConnections.size());
+		assertEquals("1", countOpenConnections(allocatedConnections));
 		channel3 = con3.createChannel(false);
 		verifyChannelIs(mockChannels.get(2), channel3);
 		channel3.close();
 		con3.close();
 		assertNull(closedNotification.get());
-		assertEquals(1, openConnections.size());
-		assertEquals(1, idleConnections.size());
+		assertEquals(2, allocatedConnections.size());
+		assertEquals(2, idleConnections.size());
+		assertEquals("1", countOpenConnections(allocatedConnections));
 
 		/*
 		 * Now a closed cached connection when creating a channel
@@ -775,8 +922,8 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		con3 = ccf.createConnection();
 		verifyConnectionIs(mockConnections.get(2), con3);
 		assertNull(createNotification.get());
-		assertEquals(1, openConnections.size());
-		assertEquals(0, idleConnections.size());
+		assertEquals(2, allocatedConnections.size());
+		assertEquals(1, idleConnections.size());
 		when(mockConnections.get(2).isOpen()).thenReturn(false);
 		channel3 = con3.createChannel(false);
 		assertNotNull(closedNotification.getAndSet(null));
@@ -786,8 +933,9 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		channel3.close();
 		con3.close();
 		assertNull(closedNotification.get());
-		assertEquals(1, openConnections.size());
-		assertEquals(1, idleConnections.size());
+		assertEquals(2, allocatedConnections.size());
+		assertEquals(2, idleConnections.size());
+		assertEquals("1", countOpenConnections(allocatedConnections));
 
 		// destroy
 		ccf.destroy();
@@ -834,36 +982,39 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.setChannelCacheSize(2);
 		ccf.afterPropertiesSet();
 
-		Set<?> openConnections = TestUtils.getPropertyValue(ccf, "openConnections", Set.class);
-		assertEquals(0, openConnections.size());
+		Set<?> allocatedConnections = TestUtils.getPropertyValue(ccf, "allocatedConnections", Set.class);
+		assertEquals(0, allocatedConnections.size());
 		BlockingQueue<?> idleConnections = TestUtils.getPropertyValue(ccf, "idleConnections", BlockingQueue.class);
 		assertEquals(0, idleConnections.size());
 		@SuppressWarnings("unchecked")
-		Map<?, List<?>> cachedChannels = TestUtils.getPropertyValue(ccf, "openConnectionNonTransactionalChannels", Map.class);
+		Map<?, List<?>> cachedChannels = TestUtils.getPropertyValue(ccf, "allocatedConnectionNonTransactionalChannels",
+				Map.class);
 
-		final AtomicReference<Connection> createNotification = new AtomicReference<Connection>();
-		final AtomicReference<Connection> closedNotification = new AtomicReference<Connection>();
+		final AtomicReference<com.rabbitmq.client.Connection> createNotification =
+				new AtomicReference<com.rabbitmq.client.Connection>();
+		final AtomicReference<com.rabbitmq.client.Connection> closedNotification =
+				new AtomicReference<com.rabbitmq.client.Connection>();
 		ccf.setConnectionListeners(Collections.singletonList(new ConnectionListener(){
 
 			@Override
 			public void onCreate(Connection connection) {
 				assertNull(createNotification.get());
-				createNotification.set(connection);
+				createNotification.set(targetDelegate(connection));
 			}
 
 			@Override
 			public void onClose(Connection connection) {
 				assertNull(closedNotification.get());
-				closedNotification.set(connection);
+				closedNotification.set(targetDelegate(connection));
 			}
 		}));
 
 		Connection con1 = ccf.createConnection();
 		verifyConnectionIs(mockConnections.get(0), con1);
-		assertEquals(1, openConnections.size());
+		assertEquals(1, allocatedConnections.size());
 		assertEquals(0, idleConnections.size());
 		assertNotNull(createNotification.get());
-		assertSame(mockConnections.get(0), targetDelegate(createNotification.getAndSet(null)));
+		assertSame(mockConnections.get(0), createNotification.getAndSet(null));
 
 		Channel channel1 = con1.createChannel(false);
 		verifyChannelIs(mockChannels.get(0), channel1);
@@ -873,7 +1024,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 		con1.close(); // should be ignored, and placed into connection cache.
 		verify(mockConnections.get(0), never()).close();
-		assertEquals(1, openConnections.size());
+		assertEquals(1, allocatedConnections.size());
 		assertEquals(1, idleConnections.size());
 		assertEquals(1, cachedChannels.get(con1).size());
 		assertNull(closedNotification.get());
@@ -889,7 +1040,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		verify(mockChannels.get(0), never()).close();
 		con2.close();
 		verify(mockConnections.get(0), never()).close();
-		assertEquals(1, openConnections.size());
+		assertEquals(1, allocatedConnections.size());
 		assertEquals(1, idleConnections.size());
 		assertNull(createNotification.get());
 
@@ -904,17 +1055,17 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		verifyChannelIs(mockChannels.get(0), channel1);
 		channel2 = con2.createChannel(false);
 		verifyChannelIs(mockChannels.get(1), channel2);
-		assertEquals(2, openConnections.size());
+		assertEquals(2, allocatedConnections.size());
 		assertEquals(0, idleConnections.size());
 		assertNotNull(createNotification.get());
-		assertSame(mockConnections.get(1), targetDelegate(createNotification.getAndSet(null)));
+		assertSame(mockConnections.get(1), createNotification.getAndSet(null));
 
 		// put mock1 in cache
 		channel1.close();
 		verify(mockChannels.get(1), never()).close();
 		con1.close();
 		verify(mockConnections.get(0), never()).close();
-		assertEquals(2, openConnections.size());
+		assertEquals(2, allocatedConnections.size());
 		assertEquals(1, idleConnections.size());
 		assertNull(closedNotification.get());
 
@@ -924,16 +1075,16 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		Channel channel3 = con3.createChannel(false);
 		verifyChannelIs(mockChannels.get(0), channel3);
 
-		assertEquals(2, openConnections.size());
+		assertEquals(2, allocatedConnections.size());
 		assertEquals(0, idleConnections.size());
 
 		channel2.close();
 		con2.close();
-		assertEquals(2, openConnections.size());
+		assertEquals(2, allocatedConnections.size());
 		assertEquals(1, idleConnections.size());
 		channel3.close();
 		con3.close();
-		assertEquals(2, openConnections.size());
+		assertEquals(2, allocatedConnections.size());
 		assertEquals(2, idleConnections.size());
 		assertEquals(1, cachedChannels.get(con1).size());
 		assertEquals(1, cachedChannels.get(con2).size());
@@ -956,18 +1107,18 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		when(mockConnections.get(1).isOpen()).thenReturn(false);
 		con3 = ccf.createConnection();
 		assertNotNull(closedNotification.get());
-		assertSame(mockConnections.get(1), targetDelegate(closedNotification.getAndSet(null)));
+		assertSame(mockConnections.get(1), closedNotification.getAndSet(null));
 		verifyConnectionIs(mockConnections.get(0), con3);
 		assertNull(createNotification.get());
-		assertEquals(1, openConnections.size());
-		assertEquals(0, idleConnections.size());
+		assertEquals(2, allocatedConnections.size());
+		assertEquals(1, idleConnections.size());
 		channel3 = con3.createChannel(false);
 		verifyChannelIs(mockChannels.get(0), channel3);
 		channel3.close();
 		con3.close();
 		assertNull(closedNotification.get());
-		assertEquals(1, openConnections.size());
-		assertEquals(1, idleConnections.size());
+		assertEquals(2, allocatedConnections.size());
+		assertEquals(2, idleConnections.size());
 
 		/*
 		 * Now a closed cached connection when creating a channel
@@ -975,8 +1126,8 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		con3 = ccf.createConnection();
 		verifyConnectionIs(mockConnections.get(0), con3);
 		assertNull(createNotification.get());
-		assertEquals(1, openConnections.size());
-		assertEquals(0, idleConnections.size());
+		assertEquals(2, allocatedConnections.size());
+		assertEquals(1, idleConnections.size());
 		when(mockConnections.get(0).isOpen()).thenReturn(false);
 		channel3 = con3.createChannel(false);
 		assertNotNull(closedNotification.getAndSet(null));
@@ -986,12 +1137,12 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		channel3.close();
 		con3.close();
 		assertNull(closedNotification.get());
-		assertEquals(1, openConnections.size());
-		assertEquals(1, idleConnections.size());
+		assertEquals(2, allocatedConnections.size());
+		assertEquals(2, idleConnections.size());
 
 		Connection con4 = ccf.createConnection();
 		assertSame(con3, con4);
-		assertEquals(0, idleConnections.size());
+		assertEquals(1, idleConnections.size());
 		Channel channelA = con4.createChannel(false);
 		Channel channelB = con4.createChannel(false);
 		Channel channelC = con4.createChannel(false);
@@ -1006,8 +1157,8 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.destroy();
 		assertNotNull(closedNotification.get());
 		// physical wasn't invoked, because this mockConnection marked with 'false' for 'isOpen()'
-		verify(mockConnections.get(0), never()).close(30000);
-		verify(mockConnections.get(1), never()).close(30000);
+		verify(mockConnections.get(0)).close(30000);
+		verify(mockConnections.get(1)).close(30000);
 		verify(mockConnections.get(2)).close(30000);
 	}
 
@@ -1048,35 +1199,37 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.setConnectionCacheSize(5);
 		ccf.afterPropertiesSet();
 
-		Set<?> openConnections = TestUtils.getPropertyValue(ccf, "openConnections", Set.class);
-		assertEquals(0, openConnections.size());
+		Set<?> allocatedConnections = TestUtils.getPropertyValue(ccf, "allocatedConnections", Set.class);
+		assertEquals(0, allocatedConnections.size());
 		BlockingQueue<?> idleConnections = TestUtils.getPropertyValue(ccf, "idleConnections", BlockingQueue.class);
 		assertEquals(0, idleConnections.size());
 
 		Connection conn1 = ccf.createConnection();
 		Connection conn2 = ccf.createConnection();
 		Connection conn3 = ccf.createConnection();
-		assertEquals(3, openConnections.size());
+		assertEquals(3, allocatedConnections.size());
 		assertEquals(0, idleConnections.size());
 		conn1.close();
 		conn2.close();
 		conn3.close();
-		assertEquals(3, openConnections.size());
+		assertEquals(3, allocatedConnections.size());
 		assertEquals(3, idleConnections.size());
 
 		when(mockConnections.get(0).isOpen()).thenReturn(false);
 		when(mockConnections.get(1).isOpen()).thenReturn(false);
 		Connection conn4 = ccf.createConnection();
-		assertEquals(1, openConnections.size());
-		assertEquals(0, idleConnections.size());
+		assertEquals(3, allocatedConnections.size());
+		assertEquals(2, idleConnections.size());
 		assertSame(conn3, conn4);
 		conn4.close();
-		assertEquals(1, openConnections.size());
-		assertEquals(1, idleConnections.size());
+		assertEquals(3, allocatedConnections.size());
+		assertEquals(3, idleConnections.size());
+		assertEquals("1", countOpenConnections(allocatedConnections));
 
 		ccf.destroy();
-		assertEquals(0, openConnections.size());
-		assertEquals(0, idleConnections.size());
+		assertEquals(3, allocatedConnections.size());
+		assertEquals(3, idleConnections.size());
+		assertEquals("0", countOpenConnections(allocatedConnections));
 	}
 
 	private void verifyConnectionIs(com.rabbitmq.client.Connection mockConnection, Object con) {
@@ -1163,6 +1316,17 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		channel.close(); // physically closed and removed from the cache  before, so void "close".
 		Channel channel2 = con.createChannel(false);
 		assertNotSame(channel, channel2);
+	}
+
+	@SuppressWarnings("unchecked")
+	private String countOpenConnections(Set<?> allocatedConnections) {
+		int n = 0;
+		for (Connection connection : (Set<Connection>) allocatedConnections) {
+			if (connection.isOpen()) {
+				n++;
+			}
+		}
+		return Integer.toBinaryString(n);
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplateTests.java
@@ -333,7 +333,7 @@ public class BatchingRabbitTemplateTests {
 			Thread.sleep(1000);
 			ArgumentCaptor<Object> arg1 = ArgumentCaptor.forClass(Object.class);
 			ArgumentCaptor<Throwable> arg2 = ArgumentCaptor.forClass(Throwable.class);
-			verify(logger).warn(arg1.capture(), arg2.capture()); // CRE logs 2 WARNs ensure the message was rejected
+			verify(logger).warn(arg1.capture(), arg2.capture());
 			assertThat(arg2.getValue().getMessage(), containsString("Bad batched message received"));
 		}
 		finally {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplateTests.java
@@ -172,7 +172,7 @@ public class RabbitManagementTemplateTests {
 		String consumer = channel.basicConsume(queue1.getName(), false, "", false, true, null, new DefaultConsumer(channel));
 		QueueInfo qi = this.template.getClient().getQueue("/", queue1.getName());
 		int n = 0;
-		while (n++ < 100 && qi.getExclusiveConsumerTag().equals("")) {
+		while (n++ < 100 && (qi.getExclusiveConsumerTag() == null || qi.getExclusiveConsumerTag().equals(""))) {
 			Thread.sleep(100);
 			qi = this.template.getClient().getQueue("/", queue1.getName());
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -515,8 +515,9 @@ public class SimpleMessageListenerContainerTests {
 		assertTrue(latch2.await(10, TimeUnit.SECONDS));
 
 		waitForConsumersToStop(consumers);
-		Set<?> openConnections = TestUtils.getPropertyValue(ccf, "openConnections", Set.class);
-		assertEquals(1, openConnections.size());
+		Set<?> allocatedConnections = TestUtils.getPropertyValue(ccf, "allocatedConnections", Set.class);
+		assertEquals(2, allocatedConnections.size());
+		assertEquals("1", countOpenConnections(allocatedConnections));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -636,6 +637,17 @@ public class SimpleMessageListenerContainerTests {
 			Thread.sleep(10);
 		}
 		assertFalse(stillUp);
+	}
+
+	@SuppressWarnings("unchecked")
+	private String countOpenConnections(Set<?> allocatedConnections) {
+		int n = 0;
+		for (Connection connection : (Set<Connection>) allocatedConnections) {
+			if (connection.isOpen()) {
+				n++;
+			}
+		}
+		return Integer.toBinaryString(n);
 	}
 
 	@SuppressWarnings("serial")

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -119,8 +119,6 @@ public class Queue  {
     }
 
     // Getters and Setters omitted for brevity
-
-
 ----
 
 Notice that the constructor takes the Queue name.
@@ -197,7 +195,17 @@ Starting with _version 1.3_, the `CachingConnectionFactory` can be configured to
 In this case, each call to `createConnection()` creates a new connection (or retrieves an idle one from the cache).
 Closing a connection returns it to the cache (if the cache size has not been reached).
 Channels created on such connections are cached too.
-The use of separate connections might be useful in some environments, such as consuming from an HA cluster, in conjunction with a load balancer, to connect to different cluster members.
+The use of separate connections might be useful in some environments, such as consuming from an HA cluster, in
+conjunction with a load balancer, to connect to different cluster members.
+Set the `cacheMode` to `CacheMode.CONNECTION`.
+
+NOTE: This does not limit the number of connections, it specifies how many idle open connections are allowed.
+
+Starting with _version 1.5.5_, a new property `connectionLimit` is provided.
+When this is set, it limits the total number of connections allowed.
+When set, if the limit is reached, the `channelCheckoutTimeLimit` is used to wait for a connection to become idle.
+If the time is exceeded, an `AmqpTimeoutException` is thrown.
+This property is not currently available on the XML namespace when using XML configuration.
 
 [IMPORTANT]
 ======

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -18,6 +18,8 @@ Now, an empty `addresses` String is treated the same as a `null`, and the host/p
 
 ====== URI Constructor
 
+====== Queue Definitions
+
 The `CachingConnectionFactory` has an additional constructor, with a `URI` parameter, to configure the broker connection.
 
 ====== Connection Reset
@@ -181,11 +183,16 @@ It is important to consider creating a white list if you accept messages with se
 untrusted sources.
 See <<java-deserialization>> for more information.
 
-====== Default Error Handler
+===== Default Error Handler
 
 The default error handler (`ConditionalRejectingErrorHandler`) now considers irrecoverable `@RabbitListener`
 exceptions as fatal.
 See <<exception-handling>> for more information.
+
+===== Caching Connection Factory
+
+When using `CacheMode.CONNECTION`, you can now limit the total number of connections allowed.
+See <<connections>> for more information.
 
 ==== Changes in 1.4 Since 1.3
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-591

Permits are not released after a connection loss.

Cached channels held a reference to the old connection proxy; since this
was the key to the checkoutPermits map, the map entry was not found
when closing, and hence the permits were not increased.

The solution is to change the channel proxy to be permanent, and just refresh
its target connection; remove the hashCode method so cached channels can always
find their permits. Previously the hashcode included the hashcode of the delegate.

For `CacheMode.CONNECTION`, when a new proxy is created it is permanently stored
in `allocatedConnections` (previously called `openConnections`). When a connection
is retrieved from the cache, if the underlying physical connection is closed we
look at the next cached connection. If all cached connections are closed, we
attempt to refresh the underlying connection.

Also, the permits map entry for a connection was set up after the
listeners were called, so the admin, for example didn't consult the permits
at all.

Added an illegal state exception if the permits are not found when checking out as
well as error logging during return.

Add a test case.

Polishing

We now never remove proxy classes; when the connection cache limit is exceeded,
we leave the allocated proxy and keep it in the idle cache. We do, however, ensure
that the over-the-limit connection is closed, but the proxy will be reused later,
thus retaining the same map key value.

Finally, added a new property `connectionLimit` which limits the total number
of connections allowed.

Also, reverted the cache stats to show the actual number of open connections.

Fix Test Comment

Conflicts:
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachePropertiesTests.java
	src/reference/asciidoc/amqp.adoc
	src/reference/asciidoc/whats-new.adoc

Resolved.