### PR TITLE
AMQP-594: Fix for `@RabbitListener` when CGLIB

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -238,7 +238,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 					}
 				}
 			}
-		});
+		}, ReflectionUtils.USER_DECLARED_METHODS);
 		if (hasClassLevelListeners) {
 			processMultiMethodListeners(classLevelListeners, multiMethods, bean, beanName);
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitCglibProxyTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitCglibProxyTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.io.Serializable;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.test.BrokerRunning;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Artem Bilan
+ * @since 1.5.5
+ */
+@ContextConfiguration(classes = EnableRabbitCglibProxyTests.Config.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
+public class EnableRabbitCglibProxyTests {
+
+	@ClassRule
+	public static final BrokerRunning brokerRunning = BrokerRunning.isRunning();
+
+	@Autowired
+	private RabbitTemplate rabbitTemplate;
+
+	@Test
+	public void testCglibProxy() {
+		this.rabbitTemplate.setReplyTimeout(600000);
+		Foo foo = new Foo();
+		foo.field = "foo";
+		assertEquals("Reply: foo: AUTO.RK.TEST",
+				this.rabbitTemplate.convertSendAndReceive("auto.exch.test", "auto.rk.test", foo));
+	}
+
+	@Configuration
+	@EnableRabbit
+	@EnableTransactionManagement(proxyTargetClass = true)
+	public static class Config {
+
+		@Bean
+		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() {
+			SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+			factory.setConnectionFactory(rabbitConnectionFactory());
+			return factory;
+		}
+
+
+		@Bean
+		public TxService<?> txService() {
+			return new TxServiceImpl();
+		}
+
+		@Bean
+		public ConnectionFactory rabbitConnectionFactory() {
+			CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+			connectionFactory.setHost("localhost");
+			return connectionFactory;
+		}
+
+		@Bean
+		public RabbitTemplate rabbitTemplate() {
+			return new RabbitTemplate(rabbitConnectionFactory());
+		}
+
+		@Bean
+		public RabbitAdmin rabbitAdmin(ConnectionFactory connectionFactory) {
+			return new RabbitAdmin(connectionFactory);
+		}
+
+		@Bean
+		public PlatformTransactionManager transactionManager() {
+			return mock(PlatformTransactionManager.class);
+		}
+
+	}
+
+
+	interface TxService<P> {
+
+		String handle(P payload, String rk);
+
+	}
+
+	static class TxServiceImpl implements TxService<Foo> {
+
+		@Override
+		@Transactional
+		@RabbitListener(bindings = @QueueBinding(
+				value = @Queue(),
+				exchange = @Exchange(value = "auto.exch.test", autoDelete = "true"),
+				key = "auto.rk.test")
+		)
+		public String handle(@Payload Foo foo, @Header("amqp_receivedRoutingKey") String rk) {
+			return "Reply: " + foo.field + ": " + rk.toUpperCase();
+		}
+
+	}
+
+	@SuppressWarnings("serial")
+	static class Foo implements Serializable {
+
+		public String field;
+
+	}
+
+}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1799,6 +1799,55 @@ In this case, a separate listener container is created for each annotation, each
 Repeatable annotations can be used with Java 8 or above; when using Java 7 or earlier, the same effect can be achieved
 by using the `@RabbitListeners` "container" annotation, with an array of `@RabbitListener` annotations.
 
+====== Proxy @RabbitListener
+
+If your service is intended to be proxied (e.g. in case of `@Transactional`) you should follow with the rule, when
+at least parameter annotations must be present on the interface method.
+It is by default with the JDK Dynamic proxy.
+However with the generic interface and its particular implementation, e.g.:
+
+[source, java]
+----
+interface TxService<P> {
+
+   String handle(P payload, String header);
+
+}
+
+static class TxServiceImpl implements TxService<Foo> {
+
+    @Override
+    public String handle(Foo foo, String rk) {
+         ...
+    }
+
+}
+----
+
+you are forced to switch to the CGLIB target class proxy.
+For example in case of transaction management it is
+an annotation option - `@EnableTransactionManagement(proxyTargetClass = true)`,
+because it isn't possible to determine the interface method to infer parameters.
+And in this case all annotations have to move to the target method in the implementation:
+
+[source, java]
+----
+static class TxServiceImpl implements TxService<Foo> {
+
+    @Override
+    @Transactional
+    @RabbitListener(bindings = @QueueBinding(
+    		value = @Queue(),
+    		exchange = @Exchange(value = "auto.exch.test", autoDelete = "true"),
+    		key = "auto.rk.test")
+    )
+    public String handle(@Payload Foo foo, @Header("amqp_receivedRoutingKey") String rk) {
+        ...
+    }
+
+}
+----
+
 
 ====== Container Management
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-594

Previously with the CGLIB proxy and generic interface implementation
the `RabbitListenerAnnotationBeanPostProcessor` registered two endpoints for "different"
methods for the same `@RabbitListener`.

* Fix the issue adding `ReflectionUtils.USER_DECLARED_METHODS` to the method processor
* Add test on the matter
* Also add a note to the Reference Manual regarding Proxy behavior

**Cherry-pick to 1.5.x**