### PR TITLE
AMQP-591: Fix Permit Release on Factory Destroy

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -876,9 +876,8 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 						if (!RabbitUtils.isPhysicalCloseRequired() &&
 								(this.channelList.size() < getChannelCacheSize()
 										|| this.channelList.contains(proxy))) {
+							releasePermitIfNecessary(proxy);
 							logicalClose((ChannelProxy) proxy);
-							// Remain open in the channel list.
-							releasePermit();
 							return null;
 						}
 					}
@@ -886,14 +885,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 				// If we get here, we're supposed to shut down.
 				physicalClose();
-				/*
-				 *  Only release a permit if this is a normal close; if the channel is
-				 *  in the list, it means we're closing a cached channel (for which a permit
-				 *  has already been released).
-				 */
-				if (!this.channelList.contains(proxy)) {
-					releasePermit();
-				}
+				releasePermitIfNecessary(proxy);
 				return null;
 			}
 			else if (methodName.equals("getTargetChannel")) {
@@ -939,8 +931,18 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			}
 		}
 
-		private void releasePermit() {
+		private void releasePermitIfNecessary(Object proxy) {
 			if (CachingConnectionFactory.this.channelCheckoutTimeout > 0) {
+				/*
+				 *  Only release a permit if this is a normal close; if the channel is
+				 *  in the list, it means we're closing a cached channel (for which a permit
+				 *  has already been released).
+				 */
+				synchronized(this.channelList) {
+					if (this.channelList.contains(proxy)) {
+						return;
+					}
+				}
 				Semaphore checkoutPermits = CachingConnectionFactory.this.checkoutPermits.get(this.theConnection);
 				if (checkoutPermits != null) {
 					checkoutPermits.release();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -483,6 +483,58 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
+	public void testReleaseWithForcedPhysicalClose() throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
+		com.rabbitmq.client.Connection mockConnection1 = mock(com.rabbitmq.client.Connection.class);
+		Channel mockChannel1 = mock(Channel.class);
+
+		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection1);
+		when(mockConnection1.createChannel()).thenReturn(mockChannel1);
+		when(mockConnection1.isOpen()).thenReturn(true);
+
+		when(mockChannel1.isOpen()).thenReturn(true);
+
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ccf.setChannelCacheSize(1);
+		ccf.setChannelCheckoutTimeout(10);
+
+		Connection con = ccf.createConnection();
+
+		Channel channel1 = con.createChannel(false);
+		assertEquals(0,
+				((Semaphore) TestUtils.getPropertyValue(ccf, "checkoutPermits", Map.class).values().iterator().next())
+					.availablePermits());
+		channel1.close();
+		con.close();
+
+		assertEquals(1,
+				((Semaphore) TestUtils.getPropertyValue(ccf, "checkoutPermits", Map.class).values().iterator().next())
+					.availablePermits());
+
+		channel1 = con.createChannel(false);
+		RabbitUtils.setPhysicalCloseRequired(true);
+		assertEquals(0,
+				((Semaphore) TestUtils.getPropertyValue(ccf, "checkoutPermits", Map.class).values().iterator().next())
+					.availablePermits());
+
+		channel1.close();
+		RabbitUtils.setPhysicalCloseRequired(false);
+		con.close();
+		verify(mockConnection1, never()).close();
+
+		assertEquals(1,
+				((Semaphore) TestUtils.getPropertyValue(ccf, "checkoutPermits", Map.class).values().iterator().next())
+					.availablePermits());
+
+		ccf.destroy();
+
+		assertEquals(1,
+				((Semaphore) TestUtils.getPropertyValue(ccf, "checkoutPermits", Map.class).values().iterator().next())
+					.availablePermits());
+
+	}
+
+	@Test
 	public void testCacheSizeExceededAfterClose() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -520,6 +520,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		channel1.close();
 		RabbitUtils.setPhysicalCloseRequired(false);
 		con.close();
+		verify(mockChannel1).close();
 		verify(mockConnection1, never()).close();
 
 		assertEquals(1,

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RabbitReconnectProblemTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RabbitReconnectProblemTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.rabbitmq.client.ConnectionFactory;
+
+/**
+ * @author Lars Hvile
+ * @author Gary Russell
+ * @since 1.5.6
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@Ignore
+public class RabbitReconnectProblemTests {
+
+	@Autowired
+	CachingConnectionFactory connFactory;
+
+	@Autowired
+	AmqpAdmin admin;
+
+	@Autowired
+	AmqpTemplate template;
+
+	final Queue myQueue = new Queue("my-queue");
+
+	@Before
+	public void setup() {
+		admin.declareQueue(myQueue);
+	}
+
+	@Test
+	public void surviveAReconnect() throws Exception {
+		checkIt(0);
+		System.out.println("Restart RabbitMQ & press any key...");
+		System.in.read();
+
+		for (int i = 1; i < 10; i++) {
+			checkIt(i);
+		}
+
+		int availablePermits = ((Semaphore) TestUtils.getPropertyValue(this.connFactory, "checkoutPermits", Map.class).values()
+				.iterator().next()).availablePermits();
+		System.out.println("Permits after test: " + availablePermits);
+		assertEquals(2, availablePermits);
+	}
+
+	void checkIt(int counter) {
+		System.out.println("\n#" + counter);
+		template.receive(myQueue.getName());
+		System.out.println("OK");
+	}
+
+	@Configuration
+	static class Cfg {
+
+		@Bean
+		CachingConnectionFactory connectionFactory() throws Exception {
+			final ConnectionFactory cf = new ConnectionFactory();
+			cf.setUri("amqp://localhost");
+
+			final CachingConnectionFactory result = new CachingConnectionFactory(cf);
+			result.setChannelCacheSize(2);
+			result.setChannelCheckoutTimeout(2000);
+
+			return result;
+		}
+
+		@Bean
+		AmqpAdmin rabbitAdmin() throws Exception {
+			return new RabbitAdmin(connectionFactory());
+		}
+
+		@Bean
+		AmqpTemplate rabbitTemplate() throws Exception {
+			return new RabbitTemplate(connectionFactory());
+		}
+	}
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-591

Don't release a permit if the channel being closed is
actually in the cache (e.g. during `destroy()` or `resetConnection()`).

Also drop ERROR log to DEBUG for permit release.

Also add Lars Hvile test (`@Ignored` because it needs user interaction).

__cherry-pick to 1.5.x__