### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -55,9 +55,9 @@ public class MessageProperties implements Serializable {
 
 	public static final String X_DELAY = "x-delay";
 
-	protected static final String DEFAULT_CONTENT_TYPE = CONTENT_TYPE_BYTES;
+	public static final String DEFAULT_CONTENT_TYPE = CONTENT_TYPE_BYTES;
 
-	protected static final MessageDeliveryMode DEFAULT_DELIVERY_MODE = MessageDeliveryMode.PERSISTENT;
+	public static final MessageDeliveryMode DEFAULT_DELIVERY_MODE = MessageDeliveryMode.PERSISTENT;
 
 	public static final Integer DEFAULT_PRIORITY = Integer.valueOf(0);
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -55,11 +55,11 @@ public class MessageProperties implements Serializable {
 
 	public static final String X_DELAY = "x-delay";
 
-	static final String DEFAULT_CONTENT_TYPE = CONTENT_TYPE_BYTES;
+	protected static final String DEFAULT_CONTENT_TYPE = CONTENT_TYPE_BYTES;
 
-	static final MessageDeliveryMode DEFAULT_DELIVERY_MODE = MessageDeliveryMode.PERSISTENT;
+	protected static final MessageDeliveryMode DEFAULT_DELIVERY_MODE = MessageDeliveryMode.PERSISTENT;
 
-	static final Integer DEFAULT_PRIORITY = Integer.valueOf(0);
+	public static final Integer DEFAULT_PRIORITY = Integer.valueOf(0);
 
 	private final Map<String, Object> headers = new HashMap<String, Object>();
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -110,7 +110,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 	/**
 	 * The bean name of the default {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory}.
 	 */
-	static final String DEFAULT_RABBIT_LISTENER_CONTAINER_FACTORY_BEAN_NAME = "rabbitListenerContainerFactory";
+	public static final String DEFAULT_RABBIT_LISTENER_CONTAINER_FACTORY_BEAN_NAME = "rabbitListenerContainerFactory";
 
 	private static final ConversionService CONVERSION_SERVICE = new DefaultConversionService();
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/NamespaceUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/NamespaceUtils.java
@@ -48,10 +48,10 @@ import org.springframework.util.xml.DomUtils;
  */
 public abstract class NamespaceUtils {
 
-	static final String BASE_PACKAGE = "org.springframework.amqp.core.rabbit.config";
-	static final String REF_ATTRIBUTE = "ref";
-	static final String METHOD_ATTRIBUTE = "method";
-	static final String ORDER = "order";
+	public static final String BASE_PACKAGE = "org.springframework.amqp.core.rabbit.config";
+	public static final String REF_ATTRIBUTE = "ref";
+	public static final String METHOD_ATTRIBUTE = "method";
+	public static final String ORDER = "order";
 
 	/**
 	 * Populates the specified bean definition property with the value of the attribute whose name is provided if that

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -440,9 +440,9 @@ public abstract class AbstractAdaptableMessageListener implements MessageListene
 
 	public static final class ResultHolder {
 
-		final Object result;
+		private final Object result;
 
-		final Expression sendTo;
+		private final Expression sendTo;
 
 		public ResultHolder(Object result, Expression sendTo) {
 			this.result = result;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j/AmqpAppender.java
@@ -618,11 +618,11 @@ public class AmqpAppender extends AppenderSkeleton {
 	@SuppressWarnings("rawtypes")
 	protected static class Event {
 
-		final LoggingEvent event;
+		private final LoggingEvent event;
 
-		final Map properties;
+		private final Map properties;
 
-		final AtomicInteger retries = new AtomicInteger(0);
+		private final AtomicInteger retries = new AtomicInteger(0);
 
 		public Event(LoggingEvent event, Map properties) {
 			this.event = event;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -311,11 +311,11 @@ public class AmqpAppender extends AbstractAppender {
 	@SuppressWarnings("rawtypes")
 	protected static class Event {
 
-		final LogEvent event;
+		private final LogEvent event;
 
-		final Map properties;
+		private final Map properties;
 
-		final AtomicInteger retries = new AtomicInteger(0);
+		private final AtomicInteger retries = new AtomicInteger(0);
 
 		public Event(LogEvent event, Map properties) {
 			this.event = event;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -581,11 +581,11 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	 */
 	protected static class Event {
 
-		final ILoggingEvent event;
+		private final ILoggingEvent event;
 
-		final Map<String, String> properties;
+		private final Map<String, String> properties;
 
-		final AtomicInteger retries = new AtomicInteger(0);
+		private final AtomicInteger retries = new AtomicInteger(0);
 
 		public Event(ILoggingEvent event) {
 			this.event = event;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderConfiguration.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderConfiguration.java
@@ -41,11 +41,11 @@ public class AmqpAppenderConfiguration {
 		// DOMConfigurator.configure(AmqpAppenderTests.class.getResource("/log4j.xml"));
 	}
 
-	static final String QUEUE = "amqp.appender.test";
+	private static final String QUEUE = "amqp.appender.test";
 
-	static final String EXCHANGE = "logs";
+	private static final String EXCHANGE = "logs";
 
-	static final String ROUTING_KEY = "AmqpAppenderTest.#";
+	private static final String ROUTING_KEY = "AmqpAppenderTest.#";
 
 	@Bean
 	public SingleConnectionFactory connectionFactory() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat