### PR TITLE
AMQP-602: Add `Exchange` `internal` option

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractExchange.java
@@ -26,6 +26,7 @@ import java.util.Map;
  *
  * @author Mark Pollack
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @see AmqpAdmin
  */
@@ -40,6 +41,8 @@ public abstract class AbstractExchange extends AbstractDeclarable implements Exc
 	private final Map<String, Object> arguments;
 
 	private volatile boolean delayed;
+
+	private boolean internal;
 
 	/**
 	 * Construct a new Exchange for bean usage.
@@ -116,6 +119,15 @@ public abstract class AbstractExchange extends AbstractDeclarable implements Exc
 
 	public void setDelayed(boolean delayed) {
 		this.delayed = delayed;
+	}
+
+	@Override
+	public boolean isInternal() {
+		return this.internal;
+	}
+
+	public void setInternal(boolean internal) {
+		this.internal = internal;
 	}
 
 	@Override

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Exchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Exchange.java
@@ -21,6 +21,7 @@ import java.util.Map;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public interface Exchange extends Declarable {
 
@@ -66,5 +67,12 @@ public interface Exchange extends Declarable {
 	 * @since 1.6
 	 */
 	boolean isDelayed();
+
+	/**
+	 * Is an exchange internal; e.g. can't be directly published to by a client.
+	 * @return true if internal.
+	 * @since 1.6
+	 */
+	boolean isInternal();
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractExchangeParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractExchangeParser.java
@@ -73,6 +73,7 @@ public abstract class AbstractExchangeParser extends AbstractSingleBeanDefinitio
 		NamespaceUtils.addConstructorArgBooleanValueIfAttributeDefined(builder, element, AUTO_DELETE_ATTRIBUTE,
 				false);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, DELAYED_ATTRIBUTE);
+		NamespaceUtils.setValueIfAttributeDefined(builder, element, "internal");
 
 		this.parseArguments(element, ARGUMENTS_ELEMENT, parserContext, builder, null);
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -550,11 +550,11 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 						}
 						arguments.put("x-delayed-type", exchange.getType());
 						channel.exchangeDeclare(exchange.getName(), ExchangeTypes.DELAYED, exchange.isDurable(),
-								exchange.isAutoDelete(), arguments);
+								exchange.isAutoDelete(), exchange.isInternal(), arguments);
 					}
 					else {
 						channel.exchangeDeclare(exchange.getName(), exchange.getType(), exchange.isDurable(),
-							exchange.isAutoDelete(), exchange.getArguments());
+							exchange.isAutoDelete(), exchange.isInternal(), exchange.getArguments());
 					}
 				}
 				catch (IOException e) {

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.6.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.6.xsd
@@ -294,6 +294,14 @@
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="internal" type="xsd:string" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Flag indicating that the exchange is internal for Broker purposes.
+					E.g. can't be directly published to by a client. Default is false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attributeGroup ref="declarable" />
 	</xsd:complexType>
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ExchangeParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ExchangeParserTests.java
@@ -64,7 +64,8 @@ public final class ExchangeParserTests {
 		assertFalse(exchange.isAutoDelete());
 		assertFalse(exchange.shouldDeclare());
 		assertEquals(2, exchange.getDeclaringAdmins().size());
-		Binding binding = beanFactory.getBean("org.springframework.amqp.rabbit.config.BindingFactoryBean#0", Binding.class);
+		Binding binding =
+				beanFactory.getBean("org.springframework.amqp.rabbit.config.BindingFactoryBean#0", Binding.class);
 		assertFalse(binding.shouldDeclare());
 		assertEquals(2, binding.getDeclaringAdmins().size());
 
@@ -94,6 +95,7 @@ public final class ExchangeParserTests {
 		assertFalse(exchange.isAutoDelete());
 		assertTrue(exchange.shouldDeclare());
 		assertTrue(exchange.isDelayed());
+		assertTrue(exchange.isInternal());
 		assertEquals(1, exchange.getDeclaringAdmins().size());
 
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminIntegrationTests.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpIOException;
+import org.springframework.amqp.core.AbstractExchange;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Binding.DestinationType;
@@ -248,6 +249,18 @@ public class RabbitAdminIntegrationTests {
 	@Test
 	public void testDeleteExchangeWithDefaultExchange() throws Exception {
 		boolean result = rabbitAdmin.deleteExchange(RabbitAdmin.DEFAULT_EXCHANGE_NAME);
+
+		assertTrue(result);
+	}
+
+	@Test
+	public void testDeleteExchangeWithInternalOption() throws Exception {
+		String exchangeName = "test.exchange.internal";
+		AbstractExchange exchange = new DirectExchange(exchangeName);
+		exchange.setInternal(true);
+		rabbitAdmin.declareExchange(exchange);
+
+		boolean result = rabbitAdmin.deleteExchange(exchangeName);
 
 		assertTrue(result);
 	}

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ExchangeParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ExchangeParserTests-context.xml
@@ -39,7 +39,7 @@
 		<rabbit:exchange-arguments ref="myRefArguments"/>
 	</direct-exchange>
 
-	<rabbit:topic-exchange name="topic" declared-by="admin1" delayed="true" />
+	<rabbit:topic-exchange name="topic" declared-by="admin1" delayed="true" internal="true"/>
 
 	<rabbit:fanout-exchange name="fanout" declared-by="admin2" />
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2755,7 +2755,7 @@ If the message has no `replyToAddress` property, the message will be rejected an
 NOTE: By default, if the request message cannot be delivered, the calling thread will eventually timeout and a
 `RemoteProxyFailureException` will be thrown.
 The timeout is 5 seconds by default, and can be modified by setting the `replyTimeout` property on the
-`RabbbitTemplate`.
+`RabbitTemplate`.
 Starting with _version 1.5_, setting the `mandatory` property to true, and enabling returns on the connection
 factory (see <<cf-pub-conf-ret>>), the calling thread will throw an `AmqpMessageReturnedException`.
 See <<reply-timeout>> for more information.
@@ -2953,7 +2953,7 @@ In addition, any declaration exceptions result in the publishing of a `Declarati
 The event contains a reference to the admin, the element that was being declared, and the `Throwable`.
 
 [[headers-exchange]]
-Starting with _version 1.3_ the HeadersExchange can be configured to match on multiple headers; you can also specify whether any or all headers must match:
+Starting with _version 1.3_ the `HeadersExchange` can be configured to match on multiple headers; you can also specify whether any or all headers must match:
 
 [source,xml]
 ----
@@ -2969,6 +2969,12 @@ Starting with _version 1.3_ the HeadersExchange can be configured to match on mu
 	</rabbit:bindings>
 </rabbit:headers-exchange>
 ----
+
+Starting with _version 1.6_ `Exchanges` can be configured with an `internal` flag (default to `false`) and such an
+`Exchange` will be properly configured on Broker via `RabbitAdmin`.
+If the `internal` flag is `true` for an exchange RabbitMQ will not allow clients to use the exchange.
+This is useful for things like a dead letter exchange, when the exchange may not be used directly by publishers,
+but only when bound to other exchanges.
 
 To see how to use Java to configure the AMQP infrastructure, look at the Stock sample application,
 where there is the `@Configuration` class `AbstractStockRabbitConfiguration` which in turn has

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -147,6 +147,11 @@ See <<async-annotation-driven>> for more information.
 Spring AMQP now has first class support for the RabbitMQ Delayed Message Exchange plugin.
 See <<delayed-message-exchange>> for more information.
 
+===== Exchange internal flag
+
+Any `Exchange` definitions can now be marked as `internal` and `RabbitAdmin` will properly declare it on the Broker.
+See <<broker-configuration>> for more information.
+
 ===== CachingConnectionFactory Changes
 
 ====== CachingConnectionFactory Cache Statistics


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-602

* Add `internal` property to the `Exchange` abstraction
* Use the proper `Channel.exchangeDeclare()` method to address an `internal` option too.
* Expose `internal` attribute to the XML components for `Exchange`
* Add Documentation and tests