### PR TITLE
RabbitTemplateIntegrationTests: fix timing issue

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -149,6 +149,9 @@ public class RabbitTemplateIntegrationTests {
 
 	private static final Queue REPLY_QUEUE = new Queue("test.reply.queue");
 
+	@Rule
+	public BrokerRunning brokerIsRunning = BrokerRunning.isRunningWithEmptyQueues(ROUTE, REPLY_QUEUE.getName());
+
 	private RabbitTemplate template;
 
 	@Autowired
@@ -175,9 +178,6 @@ public class RabbitTemplateIntegrationTests {
 		((DisposableBean) template.getConnectionFactory()).destroy();
 		this.brokerIsRunning.removeTestQueues();
 	}
-
-	@Rule
-	public BrokerRunning brokerIsRunning = BrokerRunning.isRunningWithEmptyQueues(ROUTE, REPLY_QUEUE.getName());
 
 	@Test
 	public void testReceiveNonBlocking() throws Exception {
@@ -1221,6 +1221,7 @@ public class RabbitTemplateIntegrationTests {
 		this.template.setRoutingKey(ROUTE);
 		this.template.setReplyAddress(REPLY_QUEUE.getName());
 		this.template.setReplyTimeout(10000);
+		this.template.setReceiveTimeout(10000);
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(this.template.getConnectionFactory());


### PR DESCRIPTION
https://build.spring.io/browse/AMQP-MEIGHT-711

The `RabbitTemplateIntegrationTests.testSymmetricalReceiveAndReply()` use `this.template.receive()` which is based on the `receiveTimeout`.
Since `receiveTimeout == 0` by default that means "receive-no-wait".
and there is no guaranty that the message appears in the queue exactly after the previous `receiveAndReply()`.
The existing `this.template.setReplyTimeout(10000);`in the test does not make effect for the `receive()` operations.

* Specify `this.template.setReceiveTimeout(10000);` to meet test requirements and have some time window to wait for the message in the queue.