### PR TITLE
AMQP-614: implemented builder for `Queue` objects.

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/QueueBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/QueueBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.core;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builds a Spring AMQP Queue using a fluent API.
+ *
+ * @author Maciej Walkowiak
+ * @since 1.6.0
+ *
+ */
+public final class QueueBuilder {
+
+	private final String name;
+
+	private boolean durable;
+
+	private boolean exclusive;
+
+	private boolean autoDelete;
+
+	private Map<String, Object> arguments;
+
+	/**
+	 * Creates builder for durable queue.
+	 *
+	 * @param name the name of the queue.
+	 * @return The Builder.
+	 */
+	public static QueueBuilder durable(String name) {
+		return new QueueBuilder(name).durable();
+	}
+
+	/**
+	 * Creates builder for non-durable (transient) queue.
+	 *
+	 * @param name the name of the queue.
+	 * @return The Builder.
+	 */
+	public static QueueBuilder nonDurable(final String name) {
+		return new QueueBuilder(name);
+	}
+
+	private QueueBuilder(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * The final queue will be durable.
+	 * @return The Builder.
+	 */
+	public QueueBuilder durable() {
+		this.durable = true;
+		return this;
+	}
+
+	/**
+	 * The final queue will be exclusive.
+	 * @return The Builder.
+	 */
+	public QueueBuilder exclusive() {
+		this.exclusive = true;
+		return this;
+	}
+
+	/**
+	 * The final queue will auto delete.
+	 * @return The Builder.
+	 */
+	public QueueBuilder autoDelete() {
+		this.autoDelete = true;
+		return this;
+	}
+
+	/**
+	 * The final queue will contain argument used to declare a queue.
+	 *
+	 * @param key argument name
+	 * @param value argument value
+	 * @return The Builder.
+	 */
+	public QueueBuilder withArgument(String key, Object value) {
+		this.getOrCreateArguments().put(key, value);
+		return this;
+	}
+
+	/**
+	 * The final queue will contain arguments used to declare a queue.
+	 *
+	 * @param arguments arguments map
+	 * @return The Builder.
+	 */
+	public QueueBuilder withArguments(Map<String, Object> arguments) {
+		this.getOrCreateArguments().putAll(arguments);
+		return this;
+	}
+
+	private Map<String, Object> getOrCreateArguments() {
+		if (this.arguments == null) {
+			this.arguments = new HashMap<String, Object>();
+		}
+		return this.arguments;
+	}
+
+	/**
+	 * Builds a final queue.
+	 * @return The Queue.
+	 */
+	public Queue build() {
+		return new Queue(this.name, this.durable, this.exclusive, this.autoDelete, this.arguments);
+	}
+}

--- a/spring-amqp/src/test/java/org/springframework/amqp/core/QueueBuilderTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/core/QueueBuilderTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.core;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link QueueBuilder}
+ *
+ * @author Maciej Walkowiak
+ * @since 1.6.0
+ */
+public class QueueBuilderTests {
+
+	@Test
+	public void buildsDurableQueue() {
+		Queue queue = QueueBuilder.durable("name").build();
+
+		assertTrue(queue.isDurable());
+		assertEquals("name", queue.getName());
+	}
+
+	@Test
+	public void buildsNonDurableQueue() {
+		Queue queue = QueueBuilder.nonDurable("name").build();
+
+		assertFalse(queue.isDurable());
+		assertEquals("name", queue.getName());
+	}
+
+	@Test
+	public void buildsAutoDeleteQueue() {
+		Queue queue = QueueBuilder.durable("name").autoDelete().build();
+
+		assertTrue(queue.isAutoDelete());
+	}
+
+	@Test
+	public void buildsExclusiveQueue() {
+		Queue queue = QueueBuilder.durable("name").exclusive().build();
+
+		assertTrue(queue.isExclusive());
+	}
+
+	@Test
+	public void addsArguments() {
+		Queue queue = QueueBuilder.durable("name")
+				.withArgument("key1", "value1")
+				.withArgument("key2", "value2")
+				.build();
+
+		assertThat(queue.getArguments(), hasEntry("key1", (Object) "value1"));
+		assertThat(queue.getArguments(), hasEntry("key2", (Object) "value2"));
+	}
+
+	@Test
+	public void addsMultipleArgumentsAtOnce() {
+		Map<String, Object> arguments = new HashMap<String, Object>();
+		arguments.put("key1", "value1");
+		arguments.put("key2", "value2");
+
+		Queue queue = QueueBuilder.durable("name").withArguments(arguments).build();
+
+		assertThat(queue.getArguments(), hasEntry("key1", (Object) "value1"));
+		assertThat(queue.getArguments(), hasEntry("key2", (Object) "value2"));
+	}
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/FixedReplyQueueDeadLetterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/FixedReplyQueueDeadLetterTests.java
@@ -19,8 +19,6 @@ package org.springframework.amqp.rabbit.core;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -32,6 +30,7 @@ import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.FixedReplyQueueDeadLetterTests.FixedReplyQueueDeadLetterConfig;
@@ -163,7 +162,9 @@ public class FixedReplyQueueDeadLetterTests {
 		 */
 		@Bean
 		public Queue requestQueue() {
-			return new Queue("dlx.test.requestQ", false, false, true);
+			return QueueBuilder.nonDurable("dlx.test.requestQ")
+					.autoDelete()
+					.build();
 		}
 
 		/**
@@ -171,9 +172,10 @@ public class FixedReplyQueueDeadLetterTests {
 		 */
 		@Bean
 		public Queue replyQueue() {
-			Map<String, Object> args = new HashMap<String, Object>();
-			args.put("x-dead-letter-exchange", "reply.dlx");
-			return new Queue("dlx.test.replyQ", false, false, true, args);
+			return QueueBuilder.nonDurable("dlx.test.replyQ")
+				    .autoDelete()
+				    .withArgument("x-dead-letter-exchange", "reply.dlx")
+				    .build();
 		}
 
 		/**
@@ -181,7 +183,9 @@ public class FixedReplyQueueDeadLetterTests {
 		 */
 		@Bean
 		public Queue dlq() {
-			return new Queue("dlx.test.DLQ", false, false, true);
+			return QueueBuilder.nonDurable("dlx.test.DLQ")
+					.autoDelete()
+					.build();
 		}
 
 		@Bean

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplateTests.java
@@ -38,6 +38,7 @@ import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Exchange;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.test.BrokerRunning;
 
@@ -165,9 +166,14 @@ public class RabbitManagementTemplateTests {
 	public void testSpecificQueue() throws Exception {
 		RabbitAdmin admin = new RabbitAdmin(connectionFactory);
 		Map<String, Object> args = Collections.<String, Object>singletonMap("foo", "bar");
-		Queue queue1 = new Queue(UUID.randomUUID().toString(), false, false, true, args);
+		Queue queue1 = QueueBuilder.nonDurable(UUID.randomUUID().toString())
+				.autoDelete()
+				.withArguments(args)
+				.build();
 		admin.declareQueue(queue1);
-		Queue queue2 = new Queue(UUID.randomUUID().toString(), true, false, false, args);
+		Queue queue2 = QueueBuilder.durable(UUID.randomUUID().toString())
+				.withArguments(args)
+				.build();
 		admin.declareQueue(queue2);
 		Channel channel = this.connectionFactory.createConnection().createChannel(false);
 		String consumer = channel.basicConsume(queue1.getName(), false, "", false, true, null, new DefaultConsumer(channel));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -55,6 +54,7 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageBuilder;
 import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -215,9 +215,10 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		container.setMessageListener(messageListener);
 
 		RabbitAdmin admin = new RabbitAdmin(template.getConnectionFactory());
-		Map<String, Object> args = new HashMap<String, Object>();
-		args.put("x-dead-letter-exchange", "test.DLE");
-		Queue queue = new Queue("", false, false, true, args);
+		Queue queue = QueueBuilder.nonDurable("")
+				.autoDelete()
+				.withArgument("x-dead-letter-exchange", "test.DLE")
+				.build();
 		String testQueueName = admin.declareQueue(queue);
 		// Create a DeadLetterExchange and bind a queue to it with the original routing key
 		DirectExchange dle = new DirectExchange("test.DLE", false, true);


### PR DESCRIPTION
As mentioned in [AMPQ-614](https://jira.spring.io/browse/AMQP-614) I find it much more readable to create `Queue` objects with builder than with using constructor with multiple `boolean` parameters. It's also much elegant if there are more then a single additional parameter.

I did not change all usages or constructors in tests but if you are willing to merge this one I can change all of them.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
