### PR TITLE
AMQP-619: Populate Bean CL into JSON converters

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJavaTypeMapper.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.amqp.core.MessageProperties;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.util.ClassUtils;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -31,7 +33,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  * @author Andreas Asplund
  * @author Gary Russell
  */
-public abstract class AbstractJavaTypeMapper {
+public abstract class AbstractJavaTypeMapper implements BeanClassLoaderAware {
 
 	public static final String DEFAULT_CLASSID_FIELD_NAME = "__TypeId__";
 
@@ -42,6 +44,8 @@ public abstract class AbstractJavaTypeMapper {
 	private final Map<String, Class<?>> idClassMapping = new HashMap<String, Class<?>>();
 
 	private final Map<Class<?>, String> classIdMapping = new HashMap<Class<?>, String>();
+
+	private ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
 
 	public String getClassIdFieldName() {
 		return DEFAULT_CLASSID_FIELD_NAME;
@@ -58,6 +62,15 @@ public abstract class AbstractJavaTypeMapper {
 	public void setIdClassMapping(Map<String, Class<?>> idClassMapping) {
 		this.idClassMapping.putAll(idClassMapping);
 		createReverseMap();
+	}
+
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	protected ClassLoader getClassLoader() {
+		return this.classLoader;
 	}
 
 	protected void addHeader(MessageProperties properties, String headerName, Class<?> clazz) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJsonMessageConverter.java
@@ -16,6 +16,9 @@
 
 package org.springframework.amqp.support.converter;
 
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.util.ClassUtils;
+
 /**
  *
  * @author Mark Pollack
@@ -23,13 +26,18 @@ package org.springframework.amqp.support.converter;
  * @author Dave Syer
  * @author Sam Nelson
  * @author Andreas Asplund
+ * @author Artem Bilan
  */
-public abstract class AbstractJsonMessageConverter extends AbstractMessageConverter {
+public abstract class AbstractJsonMessageConverter extends AbstractMessageConverter
+		implements BeanClassLoaderAware {
+
 	public static final String DEFAULT_CHARSET = "UTF-8";
 
 	private volatile String defaultCharset = DEFAULT_CHARSET;
 
 	private ClassMapper classMapper = null;
+
+	private ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
 
 	public ClassMapper getClassMapper() {
 		return this.classMapper;
@@ -54,4 +62,14 @@ public abstract class AbstractJsonMessageConverter extends AbstractMessageConver
     public String getDefaultCharset() {
         return this.defaultCharset;
     }
+
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	protected ClassLoader getClassLoader() {
+		return this.classLoader;
+	}
+
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -115,7 +115,7 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 
 		try {
 			return TypeFactory.defaultInstance()
-					.constructType(ClassUtils.forName(classId, getClass().getClassLoader()));
+					.constructType(ClassUtils.forName(classId, getClassLoader()));
 		}
 		catch (ClassNotFoundException e) {
 			throw new MessageConversionException("failed to resolve class name. Class not found [" + classId + "]", e);

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJavaTypeMapper.java
@@ -65,8 +65,7 @@ public class DefaultJavaTypeMapper extends AbstractJavaTypeMapper implements Jav
 		}
 
 		try {
-			return TypeFactory.defaultInstance().constructType(ClassUtils.forName(classId, getClass()
-					.getClassLoader()));
+			return TypeFactory.defaultInstance().constructType(ClassUtils.forName(classId, getClassLoader()));
 		}
 		catch (ClassNotFoundException e) {
 			throw new MessageConversionException(

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Sam Nelson
  * @author Andreas Asplund
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter {
 
@@ -107,6 +108,14 @@ public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter {
 		}
 		else {
 			throw new IllegalStateException("Type precedence is available with the DefaultJackson2JavaTypeMapper");
+		}
+	}
+
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		super.setBeanClassLoader(classLoader);
+		if (!this.typeMapperSet) {
+			((DefaultJackson2JavaTypeMapper) this.javaTypeMapper).setBeanClassLoader(classLoader);
 		}
 	}
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/JsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/JsonMessageConverter.java
@@ -37,6 +37,7 @@ import org.springframework.amqp.core.MessageProperties;
  * @author Dave Syer
  * @author Sam Nelson
  * @author Andreas Asplund
+ * @author Artem Bilan
  */
 public class JsonMessageConverter extends AbstractJsonMessageConverter {
 
@@ -45,6 +46,8 @@ public class JsonMessageConverter extends AbstractJsonMessageConverter {
 	private ObjectMapper jsonObjectMapper = new ObjectMapper();
 
 	private JavaTypeMapper javaTypeMapper = new DefaultJavaTypeMapper();
+
+	private boolean typeMapperSet;
 
 	public JsonMessageConverter() {
 		super();
@@ -57,6 +60,7 @@ public class JsonMessageConverter extends AbstractJsonMessageConverter {
 
 	public void setJavaTypeMapper(JavaTypeMapper javaTypeMapper) {
 		this.javaTypeMapper = javaTypeMapper;
+		this.typeMapperSet = true;
 	}
 
 	/**
@@ -69,6 +73,14 @@ public class JsonMessageConverter extends AbstractJsonMessageConverter {
 	 */
 	public void setJsonObjectMapper(ObjectMapper jsonObjectMapper) {
 		this.jsonObjectMapper = jsonObjectMapper;
+	}
+
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		super.setBeanClassLoader(classLoader);
+		if (!this.typeMapperSet) {
+			((DefaultJavaTypeMapper) this.javaTypeMapper).setBeanClassLoader(classLoader);
+		}
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.springframework.amqp.utils.test.TestUtils.getPropertyValue;
 
 import java.io.Serializable;
 import java.lang.annotation.ElementType;
@@ -78,6 +79,7 @@ import org.springframework.amqp.rabbit.test.MessageTestUtils;
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.ConsumerTagStrategy;
 import org.springframework.amqp.support.converter.DefaultClassMapper;
+import org.springframework.amqp.support.converter.DefaultJackson2JavaTypeMapper;
 import org.springframework.amqp.support.converter.Jackson2JavaTypeMapper.TypePrecedence;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
@@ -85,9 +87,12 @@ import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -482,6 +487,12 @@ public class EnableRabbitIntegrationTests {
 				"{ \"bar\" : \"baz\" }", messagePostProcessor);
 		assertThat(returned, instanceOf(byte[].class));
 		assertEquals("\"GenericMessageLinkedHashMap\"", new String((byte[]) returned));
+
+		Jackson2JsonMessageConverter jsonConverter = ctx.getBean(Jackson2JsonMessageConverter.class);
+
+		DefaultJackson2JavaTypeMapper mapper = TestUtils.getPropertyValue(jsonConverter, "javaTypeMapper",
+				DefaultJackson2JavaTypeMapper.class);
+		Mockito.verify(mapper).setBeanClassLoader(ctx.getClassLoader());
 
 		ctx.close();
 	}
@@ -1233,7 +1244,11 @@ public class EnableRabbitIntegrationTests {
 
 		@Bean
 		public Jackson2JsonMessageConverter jsonConverter() {
-			return new Jackson2JsonMessageConverter();
+			Jackson2JsonMessageConverter jackson2JsonMessageConverter = new Jackson2JsonMessageConverter();
+			DefaultJackson2JavaTypeMapper mapper = Mockito.spy(TestUtils.getPropertyValue(jackson2JsonMessageConverter,
+					"javaTypeMapper", DefaultJackson2JavaTypeMapper.class));
+			new DirectFieldAccessor(jackson2JsonMessageConverter).setPropertyValue("javaTypeMapper", mapper);
+			return jackson2JsonMessageConverter;
 		}
 
 		@Bean


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-619

Previously `DefaultJackson2JavaTypeMapper` used `getClass().getClassLoader()` to load class by its name from `MessageProperties`.
Sometimes it causes problems if we are based on the reloadable context like Spring Boot DevTools.

* Implement `BeanClassLoaderAware` in the `AbstractJavaTypeMapper` and `AbstractJsonMessageConverter`
* Delegate `classLoader` from the `AbstractJsonMessageConverter` bean to its internal `AbstractJavaTypeMapper` instance
* Use populated `classLoader` to instantiate classes for `Type` `MessageProperties`
* Add mock test to verify that BeanClassLoader is populated into internal `AbstractJavaTypeMapper`

The solution verified with provided in the JIRA application via local artifacts `install`