### PR TITLE
AMQP-621: Fix Consumer.basicCancel race condition

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1306,7 +1306,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					ConsumerChannelRegistry.registerConsumerChannel(this.consumer.getChannel(), getConnectionFactory());
 				}
 
-				while (isActive(this.consumer) || this.consumer.hasDelivery()) {
+				while (isActive(this.consumer) || this.consumer.hasDelivery() || !this.consumer.cancelled()) {
 					try {
 						boolean receivedOk = receiveAndExecute(this.consumer); // At least one message received
 						if (SimpleMessageListenerContainer.this.maxConcurrentConsumers != null) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -154,6 +154,7 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 	public void testDeleteOneQueue() throws Exception {
 		CountDownLatch latch = new CountDownLatch(20);
 		container = createContainer(new MessageListenerAdapter(new PojoListener(latch)), queue.getName(), queue1.getName());
+		container.setFailedDeclarationRetryInterval(100);
 		ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
 		container.setApplicationEventPublisher(publisher);
 		for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-621

The `SimpleMessageListenerContainer` has logic to initiate `BlockingQueueConsumer.basicCancel()` and mark `BlockingQueueConsumer` as inactive immediately.
But the `handleCancelOk` answer can come back from the Broker a bit late, in async manner.
During this time window we can still receive messages via `handleDelivery`.
With `prefetchCount = 1` we may end up with the deadlock on `handleDelivery` thread during that time window, when main consumer loop identifies consumer as inactive and exits for `stop` process
and can't do that because the `BlockingQueueConsumer.this.queue.put(new Delivery(consumerTag, envelope, properties, body))` operation blocks the consumer from any other operations.

* Fix the race condition via additional `BlockingQueueConsumer.cancelled()` state to let main loop to spin until `handleCancelOk` honoring any in-flight messages
* The `cancelled` state is based on the `cancelReceived` flag which is changed from the `handleCancelOk` as a Broker response for the `basicCancel`
and in the `handleCancel` event from the Broker as a reason of some unexpected state on Broker, e.g. consuming queue has been removed
* Protect message lost via `basicReject` in case of late arrival into `handleDelivery`, when the consumer has been cancelled already