### PR TITLE
AMQP-623: Don't eat errors in AbstractAdaptableML

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
@@ -49,15 +49,7 @@ public class MessageListenerAdapterTests {
 	public void init() {
 		this.messageProperties = new MessageProperties();
 		this.messageProperties.setContentType(MessageProperties.CONTENT_TYPE_TEXT_PLAIN);
-		this.adapter = new MessageListenerAdapter() {
-			@Override
-			protected void handleListenerException(Throwable ex) {
-				if (ex instanceof RuntimeException) {
-					throw (RuntimeException) ex;
-				}
-				throw new IllegalStateException(ex);
-			};
-		};
+		this.adapter = new MessageListenerAdapter();
 		this.adapter.setMessageConverter(new SimpleMessageConverter());
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-623

Previously the `AbstractAdaptableMessageListener.onMessage()` just logged target listener errors without any re-throws to the container.
That makes any default listeners (`MessagingMessageListenerAdapter`) not so useful for MAQP protocol handling.

* Do not use `handleListenerException(Throwable ex)` in the `AbstractAdaptableMessageListener#onMessage(Message)` for consistency with `onMessage(Message, Channel)`.
Any custom implementation may decide to override those method and use `handleListenerException(Throwable ex)` at their own risk.