### PR TITLE
AMQP-625: Fix onClose notification for CachingConnectionFactory

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -549,6 +549,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 					if (!this.checkoutPermits.containsKey(this.connection)) {
 						this.checkoutPermits.put(this.connection, new Semaphore(this.channelCacheSize));
 					}
+					this.connection.closeNotified.set(false);
 					getConnectionListener().onCreate(this.connection);
 				}
 				return this.connection;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-625
Previouly using `CachingConnectionFactory` with `CacheMode.CHANNEL`
the connection listener `onClose` method was being notified just on the first 
time that the connection is closed.
Now every time when the connection is closed the connection listener is 
notified.