### PR TITLE
AMQP-644: Non-Fatal Exception Stopped Container

### DIFF
--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3497,6 +3497,8 @@ Starting with _version 1.3.2_, the default `ErrorHandler` is now a `ConditionalR
 - `o.s.messaging...MessageConversionException`
 - `o.s.messaging...MethodArgumentNotValidException`
 - `o.s.messaging...MethodArgumentTypeMismatchException`
+- `java.lang.NoSuchMethodException`
+- `java.lang.ClassCastException`
 
 The first can be thrown when converting the incoming message payload using a `MessageConverter`.
 The second may be thrown by the conversion service if additional conversion is required when mapping to a
@@ -3505,12 +3507,16 @@ The third may be thrown if validation (e.g. `@Valid`) is used in the listener an
 The fourth may be thrown if the inbound message was converted to a type that is not correct for the target method.
 For example, the parameter is declared as `Message<Foo>` but `Message<Bar>` is received.
 
+The fifth and sixth were added in _version 1.6.3_.
+
 An instance of this error handler can be configured with a `FatalExceptionStrategy` so users can provide their own rules
 for conditional message rejection, e.g.
 a delegate implementation to the `BinaryExceptionClassifier` from Spring Retry (<<async-listeners>>).
 In addition, the `ListenerExecutionFailedException` now has a `failedMessage` property which can be used in the decision.
 If the `FatalExceptionStrategy.isFatal()` method returns `true`, the error handler throws an `AmqpRejectAndDontRequeueException`.
-The default `FatalExceptionStrategy` logs a warning message.
+The default `FatalExceptionStrategy` logs a warning message when an exception is determined to be fatal.
+
+Since _version 1.6.3_ a convenient way to add user exceptions to the fatal list is to subclass `ConditionalRejectingErrorHandler.DefaultExceptionStrategy` and override the method `isUserCauseFatal(Throwable cause)` to return true for fatal exceptions.
 
 ==== Transactions
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-644

Previously, any `NoSuchMethodException` was container-fatal (the container was stopped)
on the assumption that the listener was mis-configured.

However, this could be a transient, data-related, problem so should be considered
message-fatal, not container-fatal.

Also added `ClassCastException` because when the `MessageListenerAdapter` delegate is a
lambda, we get this exception instead of a `NoSuchMethodException`.

__cherry-pick to 1.6.x__