### PR TITLE
AMQP-641: DirectMLContainer Add ErrorHandler

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/utils/MapBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/utils/MapBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@code Builder} pattern implementation for a {@link Map}.
+ *
+ * @author Artem Bilan
+ * @author Gary Russell
+ * @since 2.0
+ */
+public class MapBuilder<B extends MapBuilder<B, K, V>, K, V> {
+
+	private final Map<K, V> map = new HashMap<K, V>();
+
+	public B put(K key, V value) {
+		this.map.put(key, value);
+		return _this();
+	}
+
+	public Map<K, V> get() {
+		return this.map;
+	}
+
+	@SuppressWarnings("unchecked")
+	protected final B _this() {
+		return (B) this;
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -887,12 +887,12 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 *
 	 * @param channel the Rabbit Channel to operate on
 	 * @param messageIn the received Rabbit Message
-	 * @throws Throwable Any Throwable.
+	 * @throws Exception Any Exception.
 	 *
 	 * @see #invokeListener
 	 * @see #handleListenerException
 	 */
-	protected void executeListener(Channel channel, Message messageIn) throws Throwable {
+	protected void executeListener(Channel channel, Message messageIn) throws Exception {
 		if (!isRunning()) {
 			if (logger.isWarnEnabled()) {
 				logger.warn("Rejecting received message because the listener container has been stopped: " + messageIn);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -373,7 +373,6 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		Connection connection = getConnectionFactory().createConnection();
 		Channel channel = connection.createChannel(isChannelTransacted());
 		channel.basicQos(getPrefetchCount());
-		RabbitUtils.setPhysicalCloseRequired(true);
 		SimpleConsumer consumer = new SimpleConsumer(channel, queue);
 		channel.basicConsume(queue, getAcknowledgeMode().isAutoAck(),
 				(getConsumerTagStrategy() != null
@@ -508,7 +507,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 				DirectMessageListenerContainer.this.cancellationLock.release(this);
 				DirectMessageListenerContainer.this.consumers.remove(this);
 			}
+			RabbitUtils.setPhysicalCloseRequired(true);
 			RabbitUtils.closeChannel(getChannel());
+			RabbitUtils.setPhysicalCloseRequired(false);
 		}
 
 		@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -454,14 +454,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 				this.logger.debug(this + " received " + message);
 			}
 			try {
-				if (!isRunning()) {
-					if (this.logger.isWarnEnabled()) {
-						this.logger.warn("Rejecting received message because the listener container has been stopped: "
-								+ message);
-					}
-					throw new MessageRejectedWhileStoppingException();
-				}
-				invokeListener(getChannel(), message);
+				executeListener(getChannel(), message);
 				if (this.ackRequired) {
 					getChannel().basicAck(envelope.getDeliveryTag(), false);
 				}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/ArgumentBuilder.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/ArgumentBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.support;
+
+import org.springframework.amqp.utils.MapBuilder;
+
+/**
+ * A builder for argument maps.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class ArgumentBuilder extends MapBuilder<ArgumentBuilder, String, Object> {
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
@@ -165,7 +165,7 @@ public class DirectMessageListenerContainerTests {
 		container.removeQueueNames(Q1, Q2, "junk");
 		assertTrue(consumersOnQueue(Q1, 0));
 		assertTrue(consumersOnQueue(Q2, 0));
-		assertEquals(0, TestUtils.getPropertyValue(container, "consumers", List.class).size());
+		assertTrue(activeConsumerCount(container, 0));
 		container.stop();
 		cf.destroy();
 	}
@@ -204,7 +204,7 @@ public class DirectMessageListenerContainerTests {
 		container.stop();
 		assertTrue(consumersOnQueue(Q1, 0));
 		assertTrue(consumersOnQueue(Q2, 0));
-		assertEquals(0, TestUtils.getPropertyValue(container, "consumers", List.class).size());
+		assertTrue(activeConsumerCount(container, 0));
 		assertEquals(0, TestUtils.getPropertyValue(container, "consumersByQueue", MultiValueMap.class).size());
 		cf.destroy();
 	}
@@ -285,6 +285,15 @@ public class DirectMessageListenerContainerTests {
 			Thread.sleep(100);
 		}
 		return admin.getQueueProperties(queue).get(RabbitAdmin.QUEUE_CONSUMER_COUNT).equals(count);
+	}
+
+	private boolean activeConsumerCount(AbstractMessageListenerContainer container, int expected) throws Exception {
+		int n = 0;
+		List<?> consumers = TestUtils.getPropertyValue(container, "consumers", List.class);
+		while (n++ < 100 && consumers.size() != expected) {
+			Thread.sleep(100);
+		}
+		return consumers.size() == expected;
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-641

Simply change `invokeListener` to `executeListener` which encapsulates
error handling (and message post processing and de-batching logic).