### PR TITLE
AMQP-636: Queue Declaration and Recovery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ subprojects { subproject ->
 
 		springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.0.0.BUILD-SNAPSHOT'
 
-		springRetryVersion = '1.2.0.BUILD-SNAPSHOT'
+		springRetryVersion = '1.1.4.RELEASE'
 	}
 
 	eclipse {

--- a/spring-amqp/src/main/java/org/springframework/amqp/AmqpConnectException.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/AmqpConnectException.java
@@ -23,12 +23,27 @@ import java.net.ConnectException;
  * remote process dies or there is a network issue.
  *
  * @author Dave Syer
+ * @author Gary Russell
  */
 @SuppressWarnings("serial")
 public class AmqpConnectException extends AmqpException {
 
+	/**
+	 * Construct an instance with the supplied message and cause.
+	 * @param cause the cause.
+	 */
 	public AmqpConnectException(Exception cause) {
 		super(cause);
+	}
+
+	/**
+	 * Construct an instance with the supplied message and cause.
+	 * @param message the message.
+	 * @param cause the cause.
+	 * @since 2.0
+	 */
+	public AmqpConnectException(String message, Throwable cause) {
+		super(message, cause);
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -125,7 +125,8 @@ public class BlockingQueueConsumer {
 
 	private long retryDeclarationInterval = 60000;
 
-	private long failedDeclarationRetryInterval = 5000;
+	private long failedDeclarationRetryInterval =
+			AbstractMessageListenerContainer.DEFAULT_FAILED_DECLARATION_RETRY_INTERVAL;
 
 	private int declarationRetries = 3;
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -415,7 +415,14 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 
 	private void checkMissingQueues(String[] queueNames) {
 		if (isMissingQueuesFatal()) {
-			RabbitAdmin checkAdmin = new RabbitAdmin(getConnectionFactory());
+			RabbitAdmin checkAdmin = getRabbitAdmin();
+			if (checkAdmin == null) {
+				/*
+				 * Checking queue existence doesn't require an admin in the context or injected into
+				 * the container. If there's no such admin, just create a local one here.
+				 */
+				checkAdmin = new RabbitAdmin(getConnectionFactory());
+			}
 			for (String queue : queueNames) {
 				Properties queueProperties = checkAdmin.getQueueProperties(queue);
 				if (queueProperties == null && isMissingQueuesFatal()) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -47,14 +47,11 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactoryUtils;
 import org.springframework.amqp.rabbit.connection.ConsumerChannelRegistry;
 import org.springframework.amqp.rabbit.connection.RabbitResourceHolder;
 import org.springframework.amqp.rabbit.connection.RabbitUtils;
-import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.listener.exception.FatalListenerExecutionException;
 import org.springframework.amqp.rabbit.listener.exception.FatalListenerStartupException;
 import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
 import org.springframework.amqp.rabbit.support.ConsumerCancelledException;
-import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
 import org.springframework.amqp.rabbit.support.ListenerContainerAware;
-import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
 import org.springframework.amqp.support.ConditionalExceptionLogger;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -67,7 +64,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.util.backoff.BackOff;
 import org.springframework.util.backoff.BackOffExecution;
-import org.springframework.util.backoff.FixedBackOff;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ShutdownSignalException;
@@ -114,28 +110,12 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	private long receiveTimeout = DEFAULT_RECEIVE_TIMEOUT;
 
-	private BackOff recoveryBackOff = new FixedBackOff(DEFAULT_RECOVERY_INTERVAL, FixedBackOff.UNLIMITED_ATTEMPTS);
-
 	// Map entry value, when false, signals the consumer to terminate
 	private Map<BlockingQueueConsumer, Boolean> consumers;
 
 	private final ActiveObjectCounter<BlockingQueueConsumer> cancellationLock = new ActiveObjectCounter<BlockingQueueConsumer>();
 
-	private volatile MessagePropertiesConverter messagePropertiesConverter = new DefaultMessagePropertiesConverter();
-
-	private volatile RabbitAdmin rabbitAdmin;
-
-	private volatile boolean missingQueuesFatal = true;
-
-	private volatile boolean missingQueuesFatalSet;
-
-	private volatile boolean autoDeclare = true;
-
-	private volatile boolean mismatchedQueuesFatal = false;
-
 	private Integer declarationRetries;
-
-	private Long failedDeclarationRetryInterval;
 
 	private Long retryDeclarationInterval;
 
@@ -155,29 +135,6 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	public SimpleMessageListenerContainer(ConnectionFactory connectionFactory) {
 		setConnectionFactory(connectionFactory);
 	}
-
-	/**
-	 * Specify the interval between recovery attempts, in <b>milliseconds</b>.
-	 * The default is 5000 ms, that is, 5 seconds.
-	 * @param recoveryInterval The recovery interval.
-	 */
-	public void setRecoveryInterval(long recoveryInterval) {
-		this.recoveryBackOff = new FixedBackOff(recoveryInterval, FixedBackOff.UNLIMITED_ATTEMPTS);
-	}
-
-	/**
-	 * Specify the {@link BackOff} for interval between recovery attempts.
-	 * The default is 5000 ms, that is, 5 seconds.
-	 * With the {@link BackOff} you can supply the {@code maxAttempts} for recovery before
-	 * the {@link #stop()} will be performed.
-	 * @param recoveryBackOff The BackOff to recover.
-	 * @since 1.5
-	 */
-	public void setRecoveryBackOff(BackOff recoveryBackOff) {
-		Assert.notNull(recoveryBackOff, "'recoveryBackOff' must not be null.");
-		this.recoveryBackOff = recoveryBackOff;
-	}
-
 
 	/**
 	 * Specify the number of concurrent consumers to create. Default is 1.
@@ -340,56 +297,16 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
-	 * Set the {@link MessagePropertiesConverter} for this listener container.
-	 * @param messagePropertiesConverter The properties converter.
+	 * {@inheritDoc}
+	 * <p>
+	 * When true, if the queues are removed while the container is running, the container
+	 * is stopped.
+	 * <p>
+	 * Defaults to true for this container.
 	 */
-	public void setMessagePropertiesConverter(MessagePropertiesConverter messagePropertiesConverter) {
-		Assert.notNull(messagePropertiesConverter, "messagePropertiesConverter must not be null");
-		this.messagePropertiesConverter = messagePropertiesConverter;
-	}
-
-	protected RabbitAdmin getRabbitAdmin() {
-		return this.rabbitAdmin;
-	}
-
-	/**
-	 * Set the {@link RabbitAdmin}, used to declare any auto-delete queues, bindings
-	 * etc when the container is started. Only needed if those queues use conditional
-	 * declaration (have a 'declared-by' attribute). If not specified, an internal
-	 * admin will be used which will attempt to declare all elements not having a
-	 * 'declared-by' attribute.
-	 * @param rabbitAdmin The admin.
-	 */
-	public void setRabbitAdmin(RabbitAdmin rabbitAdmin) {
-		this.rabbitAdmin = rabbitAdmin;
-	}
-
-	/**
-	 * If all of the configured queue(s) are not available on the broker, this setting
-	 * determines whether the condition is fatal (default true). When true, and
-	 * the queues are missing during startup, the context refresh() will fail. If
-	 * the queues are removed while the container is running, the container is
-	 * stopped.
-	 * <p> When false, the condition is not considered fatal and the container will
-	 * continue to attempt to start the consumers according to the {@link #setRecoveryInterval(long)}.
-	 * Note that each consumer will make 3 attempts (at 5 second intervals) on each
-	 * recovery attempt.
-	 * @param missingQueuesFatal the missingQueuesFatal to set.
-	 * @since 1.3.5
-	 */
+	@Override
 	public void setMissingQueuesFatal(boolean missingQueuesFatal) {
-		this.missingQueuesFatal = missingQueuesFatal;
-		this.missingQueuesFatalSet = true;
-	}
-
-	/**
-	 * Prevent the container from starting if any of the queues defined in the context have
-	 * mismatched arguments (TTL etc). Default false.
-	 * @param mismatchedQueuesFatal true to fail initialization when this condition occurs.
-	 * @since 1.6
-	 */
-	public void setMismatchedQueuesFatal(boolean mismatchedQueuesFatal) {
-		this.mismatchedQueuesFatal = mismatchedQueuesFatal;
+		super.setMissingQueuesFatal(missingQueuesFatal);
 	}
 
 	@Override
@@ -402,15 +319,6 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	public void setQueues(Queue... queues) {
 		super.setQueues(queues);
 		this.queuesChanged();
-	}
-
-	/**
-	 * @param autoDeclare the boolean flag to indicate an redeclaration operation.
-	 * @since 1.4
-	 * @see #redeclareElementsIfNecessary
-	 */
-	public void setAutoDeclare(boolean autoDeclare) {
-		this.autoDeclare = autoDeclare;
 	}
 
 	/**
@@ -484,16 +392,6 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
-	 * Set the interval between passive queue declaration attempts in milliseconds.
-	 * @param failedDeclarationRetryInterval the interval, default 5000.
-	 * @see #setDeclarationRetries(int)
-	 * @since 1.3.9
-	 */
-	public void setFailedDeclarationRetryInterval(long failedDeclarationRetryInterval) {
-		this.failedDeclarationRetryInterval = failedDeclarationRetryInterval;
-	}
-
-	/**
 	 * When consuming multiple queues, set the interval between declaration attempts when only
 	 * a subset of the queues were available (milliseconds).
 	 * @param retryDeclarationInterval the interval, default 60000.
@@ -549,7 +447,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 */
 	@Override
 	protected void doInitialize() throws Exception {
-		checkMissingQueuesFatal();
+		checkMissingQueuesFatalFromProperty();
 	}
 
 	@ManagedMetric(metricType = MetricType.GAUGE)
@@ -585,27 +483,6 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 						+ Arrays.asList(queueNames));
 			}
 		}
-		if (this.rabbitAdmin == null && this.getApplicationContext() != null) {
-			Map<String, RabbitAdmin> admins = this.getApplicationContext().getBeansOfType(RabbitAdmin.class);
-			if (admins.size() == 1) {
-				this.rabbitAdmin = admins.values().iterator().next();
-			}
-			else {
-				if (this.autoDeclare || this.mismatchedQueuesFatal) {
-					if (logger.isDebugEnabled()) {
-						logger.debug("For 'autoDeclare' and 'mismatchedQueuesFatal' to work, there must be exactly one "
-								+ "RabbitAdmin in the context or you must inject one into this container; found: "
-								+ admins.size() + " for container " + this.toString());
-					}
-				}
-				if (this.mismatchedQueuesFatal) {
-					throw new IllegalStateException("When 'mismatchedQueuesFatal' is 'true', there must be exactly "
-							+ "one RabbitAdmin in the context or you must inject one into this container; found: "
-							+ admins.size() + " for container " + this.toString());
-				}
-			}
-		}
-		checkMismatchedQueues();
 		super.doStart();
 		synchronized (this.consumersMonitor) {
 			int newConsumers = initializeConsumers();
@@ -702,40 +579,21 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		return count;
 	}
 
-	private void checkMissingQueuesFatal() {
-		if (!this.missingQueuesFatalSet) {
+	private void checkMissingQueuesFatalFromProperty() {
+		if (!isMissingQueuesFatalSet()) {
 			try {
 				ApplicationContext applicationContext = getApplicationContext();
 				if (applicationContext != null) {
 					Properties properties = applicationContext.getBean("spring.amqp.global.properties", Properties.class);
 					String missingQueuesFatal = properties.getProperty("smlc.missing.queues.fatal");
 					if (StringUtils.hasText(missingQueuesFatal)) {
-						this.missingQueuesFatal = Boolean.parseBoolean(missingQueuesFatal);
+						setMissingQueuesFatal(Boolean.parseBoolean(missingQueuesFatal));
 					}
 				}
 			}
 			catch (BeansException be) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("No global properties bean");
-				}
-			}
-		}
-	}
-
-	private void checkMismatchedQueues() {
-		if (this.mismatchedQueuesFatal && this.rabbitAdmin != null) {
-			try {
-				this.rabbitAdmin.initialize();
-			}
-			catch (AmqpConnectException e) {
-				logger.info("Broker not available; cannot check queue declarations");
-			}
-			catch (AmqpIOException e) {
-				if (RabbitUtils.isMismatchedQueueArgs(e)) {
-					throw new FatalListenerStartupException("Mismatched queues", e);
-				}
-				else {
-					logger.info("Failed to get connection during start(): " + e);
 				}
 			}
 		}
@@ -827,14 +685,14 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		// There's no point prefetching less than the tx size, otherwise the consumer will stall because the broker
 		// didn't get an ack for delivered messages
 		int actualPrefetchCount = getPrefetchCount() > this.txSize ? getPrefetchCount() : this.txSize;
-		consumer = new BlockingQueueConsumer(getConnectionFactory(), this.messagePropertiesConverter,
+		consumer = new BlockingQueueConsumer(getConnectionFactory(), getMessagePropertiesConverter(),
 				this.cancellationLock, getAcknowledgeMode(), isChannelTransacted(), actualPrefetchCount,
 				isDefaultRequeueRejected(), getConsumerArguments(), isExclusive(), queues);
 		if (this.declarationRetries != null) {
 			consumer.setDeclarationRetries(this.declarationRetries);
 		}
-		if (this.failedDeclarationRetryInterval != null) {
-			consumer.setFailedDeclarationRetryInterval(this.failedDeclarationRetryInterval);
+		if (getFailedDeclarationRetryInterval() > 0) {
+			consumer.setFailedDeclarationRetryInterval(getFailedDeclarationRetryInterval());
 		}
 		if (this.retryDeclarationInterval != null) {
 			consumer.setRetryDeclarationInterval(this.retryDeclarationInterval);
@@ -842,7 +700,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		if (getConsumerTagStrategy() != null) {
 			consumer.setTagStrategy(getConsumerTagStrategy());
 		}
-		consumer.setBackOffExecution(this.recoveryBackOff.start());
+		consumer.setBackOffExecution(getRecoveryBackOff().start());
 		consumer.setShutdownTimeout(getShutdownTimeout());
 		return consumer;
 	}
@@ -870,53 +728,6 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				}
 				getTaskExecutor().execute(new AsyncMessageProcessingConsumer(consumer));
 			}
-		}
-	}
-
-	/**
-	 * Use {@link RabbitAdmin#initialize()} to redeclare everything if necessary.
-	 * Since auto deletion of a queue can cause upstream elements
-	 * (bindings, exchanges) to be deleted too, everything needs to be redeclared if
-	 * a queue is missing.
-	 * Declaration is idempotent so, aside from some network chatter, there is no issue,
-	 * and we only will do it if we detect our queue is gone.
-	 * <p>
-	 * In general it makes sense only for the 'auto-delete' or 'expired' queues,
-	 * but with the server TTL policy we don't have ability to determine 'expiration'
-	 * option for the queue.
-	 * <p>
-	 * Starting with version 1.6, if
-	 * {@link #setMismatchedQueuesFatal(boolean) mismatchedQueuesFatal} is true,
-	 * the declarations are always attempted during restart so the listener will
-	 * fail with a fatal error if mismatches occur.
-	 */
-	private synchronized void redeclareElementsIfNecessary() {
-		if (this.rabbitAdmin == null) {
-			return;
-		}
-		try {
-			ApplicationContext applicationContext = this.getApplicationContext();
-			if (applicationContext != null) {
-				Set<String> queueNames = this.getQueueNamesAsSet();
-				Map<String, Queue> queueBeans = applicationContext.getBeansOfType(Queue.class);
-				for (Entry<String, Queue> entry : queueBeans.entrySet()) {
-					Queue queue = entry.getValue();
-					if (this.mismatchedQueuesFatal || (queueNames.contains(queue.getName()) &&
-							this.rabbitAdmin.getQueueProperties(queue.getName()) == null)) {
-						if (logger.isDebugEnabled()) {
-							logger.debug("Redeclaring context exchanges, queues, bindings.");
-						}
-						this.rabbitAdmin.initialize();
-						return;
-					}
-				}
-			}
-		}
-		catch (Exception e) {
-			if (RabbitUtils.isMismatchedQueueArgs(e)) {
-				throw new FatalListenerStartupException("Mismatched queues", e);
-			}
-			logger.error("Failed to check/redeclare auto-delete queue(s).", e);
 		}
 	}
 
@@ -1062,14 +873,12 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			try {
 
 				try {
-					if (SimpleMessageListenerContainer.this.autoDeclare) {
-						SimpleMessageListenerContainer.this.redeclareElementsIfNecessary();
-					}
+					redeclareElementsIfNecessary();
 					this.consumer.start();
 					this.start.countDown();
 				}
 				catch (QueuesNotAvailableException e) {
-					if (SimpleMessageListenerContainer.this.missingQueuesFatal) {
+					if (isMissingQueuesFatal()) {
 						throw e;
 					}
 					else {
@@ -1157,7 +966,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				publishConsumerFailedEvent("Consumer thread interrupted, processing stopped", true, e);
 			}
 			catch (QueuesNotAvailableException ex) {
-				if (SimpleMessageListenerContainer.this.missingQueuesFatal) {
+				if (isMissingQueuesFatal()) {
 					logger.error("Consumer received fatal exception on startup", ex);
 					this.startupException = ex;
 					// Fatal, but no point re-throwing, so just abort.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/MissingMessageIdAdvice.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/MissingMessageIdAdvice.java
@@ -70,9 +70,7 @@ public class MissingMessageIdAdvice implements MethodInterceptor {
 		}
 		catch (Exception e) {
 			if (id != null && redelivered) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("Canceling delivery of retried message that has no ID");
-				}
+				logger.debug("Canceling delivery of retried message that has no ID");
 				throw new ListenerExecutionFailedException("Cannot retry message without an ID",
 						new AmqpRejectAndDontRequeueException(e), message);
 			}
@@ -82,6 +80,9 @@ public class MissingMessageIdAdvice implements MethodInterceptor {
 		}
 		finally {
 			if (id != null) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Removing " + id);
+				}
 				this.retryContextCache.remove(id);
 			}
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedDMLCTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedDMLCTests.java
@@ -27,8 +27,7 @@ public class LocallyTransactedDMLCTests extends LocallyTransactedTests {
 
 	@Override
 	protected AbstractMessageListenerContainer createContainer(AbstractConnectionFactory connectionFactory) {
-		AbstractMessageListenerContainer container = new DirectMessageListenerContainer(connectionFactory);
-		return container;
+		return new DirectMessageListenerContainer(connectionFactory);
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -501,10 +501,10 @@ public class SimpleMessageListenerContainerTests {
 		// Since backOff exhausting makes listenerContainer as invalid (calls stop()),
 		// it is enough to check the listenerContainer activity
 		int n = 0;
-		while (container.isActive() && n++ < 10) {
+		while (container.isActive() && n++ < 100) {
 			Thread.sleep(100);
 		}
-		assertThat(n, lessThanOrEqualTo(10));
+		assertThat(n, lessThanOrEqualTo(100));
 	}
 
 	private Answer<Object> messageToConsumer(final Channel mockChannel, final SimpleMessageListenerContainer container,

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/MissingIdRetryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/MissingIdRetryTests.java
@@ -18,16 +18,25 @@ package org.springframework.amqp.rabbit.retry;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.aopalliance.aop.Advice;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.Level;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
@@ -35,14 +44,18 @@ import org.springframework.amqp.rabbit.config.StatefulRetryOperationsInterceptor
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.BlockingQueueConsumer;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.test.BrokerRunning;
+import org.springframework.amqp.rabbit.test.Log4jLevelAdjuster;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.retry.RetryContext;
 import org.springframework.retry.policy.MapRetryContextCache;
 import org.springframework.retry.policy.RetryContextCache;
+import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
 /**
@@ -52,10 +65,17 @@ import org.springframework.retry.support.RetryTemplate;
  */
 public class MissingIdRetryTests {
 
+	private final Log logger = LogFactory.getLog(MissingIdRetryTests.class);
+
 	private volatile CountDownLatch latch;
 
 	@ClassRule
 	public static BrokerRunning brokerIsRunning = BrokerRunning.isRunning();
+
+	@Rule
+	public Log4jLevelAdjuster adjuster = new Log4jLevelAdjuster(Level.DEBUG, BlockingQueueConsumer.class,
+			MissingIdRetryTests.class,
+			RetryTemplate.class, SimpleRetryPolicy.class, MissingMessageIdAdvice.class);
 
 	@BeforeClass
 	@AfterClass
@@ -81,7 +101,7 @@ public class MissingIdRetryTests {
 
 		// use an external template so we can share his cache
 		RetryTemplate retryTemplate = new RetryTemplate();
-		RetryContextCache cache = new MapRetryContextCache();
+		RetryContextCache cache = spy(new MapRetryContextCache());
 		retryTemplate.setRetryContextCache(cache);
 		fb.setRetryOperations(retryTemplate);
 
@@ -102,6 +122,12 @@ public class MissingIdRetryTests {
 			while (n++ < 100 && map.size() != 0) {
 				Thread.sleep(100);
 			}
+			ArgumentCaptor putCaptor = ArgumentCaptor.forClass(Object.class);
+			ArgumentCaptor removeCaptor = ArgumentCaptor.forClass(Object.class);
+			verify(cache, atLeastOnce()).put(putCaptor.capture(), any(RetryContext.class));
+			verify(cache, atLeastOnce()).remove(removeCaptor.capture());
+			logger.debug("puts:" + putCaptor.getAllValues());
+			logger.debug("removes:" + removeCaptor.getAllValues());
 			assertEquals("Expected map.size() = 0, was: " + map.size(), 0, map.size());
 		}
 		finally {
@@ -145,7 +171,6 @@ public class MissingIdRetryTests {
 		Message message = new Message("Hello, world!".getBytes(), messageProperties);
 		template.send("retry.test.exchange", "retry.test.binding", message);
 		template.send("retry.test.exchange", "retry.test.binding", message);
-		assertTrue(latch.await(30, TimeUnit.SECONDS));
 		try {
 			assertTrue(latch.await(30, TimeUnit.SECONDS));
 			Map map = (Map) new DirectFieldAccessor(cache).getPropertyValue("map");

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/BrokerRunning.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/BrokerRunning.java
@@ -18,6 +18,7 @@ package org.springframework.amqp.rabbit.test;
 
 import static org.junit.Assert.fail;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -260,13 +261,11 @@ public final class BrokerRunning extends TestWatcher {
 	}
 
 	public void removeTestQueues(String... additionalQueues) {
+		logger.debug("deleting test queues: " + Arrays.toString(additionalQueues));
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
 		connectionFactory.setHost("localhost");
 		RabbitAdmin admin = new RabbitAdmin(connectionFactory);
 		for (Queue queue : this.queues) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("Deleting " + queue);
-			}
 			admin.deleteQueue(queue.getName());
 		}
 		if (additionalQueues != null) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/Log4jLevelAdjuster.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/Log4jLevelAdjuster.java
@@ -77,7 +77,9 @@ public class Log4jLevelAdjuster implements MethodRule {
 					logger.debug("++++++++++++++++++++++++++++ "
 							+ "Restoring log level setting for test " + method.getName());
 					for (Class<?> cls : Log4jLevelAdjuster.this.classes) {
-						((Logger) LogManager.getLogger(cls)).setLevel(oldLevels.get(cls));
+						if (!cls.equals(BrokerRunning.class)) {
+							((Logger) LogManager.getLogger(cls)).setLevel(oldLevels.get(cls));
+						}
 					}
 				}
 			}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-636

Reworked the add/adjust queues to not backout after a failure.
Now, failed consumers are moved to `consumersToRestart`.

The idle task is now a general monitor task which periodically
checks for dead consumers and attempts to restart them.