### PR TITLE
AMQP-648: Fix Race in handleCancel (SMLC)

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -314,6 +314,7 @@ public class BlockingQueueConsumer {
 
 	protected void basicCancel() {
 		for (String consumerTag : this.consumerTags.keySet()) {
+			removeConsumer(consumerTag);
 			try {
 				this.channel.basicCancel(consumerTag);
 			}
@@ -326,7 +327,6 @@ public class BlockingQueueConsumer {
 				if (logger.isTraceEnabled()) {
 					logger.trace(this.channel + " is already closed");
 				}
-				break;
 			}
 		}
 		this.abortStarted = System.currentTimeMillis();
@@ -654,6 +654,22 @@ public class BlockingQueueConsumer {
 	}
 
 	/**
+	 * Remove the consumer and set cancelled if all are gone.
+	 * @param consumerTag the tag to remove.
+	 * @return true if consumers remain.
+	 */
+	private boolean removeConsumer(String consumerTag) {
+		this.consumerTags.remove(consumerTag);
+		if (this.consumerTags.isEmpty()) {
+			this.cancelled.set(true);
+			return false;
+		}
+		else {
+			return true;
+		}
+	}
+
+	/**
 	 * Perform a commit or message acknowledgement, as appropriate.
 	 * @param locallyTransacted Whether the channel is locally transacted.
 	 * @throws IOException Any IOException.
@@ -743,11 +759,7 @@ public class BlockingQueueConsumer {
 						+ BlockingQueueConsumer.this.consumerTags.get(consumerTag)
 						+ "); " + BlockingQueueConsumer.this);
 			}
-			BlockingQueueConsumer.this.consumerTags.remove(consumerTag);
-			if (BlockingQueueConsumer.this.consumerTags.isEmpty()) {
-				BlockingQueueConsumer.this.cancelled.set(true);
-			}
-			else {
+			if (removeConsumer(consumerTag)) {
 				basicCancel();
 			}
 		}
@@ -758,10 +770,6 @@ public class BlockingQueueConsumer {
 				logger.debug("Received cancelOk for tag " + consumerTag + " ("
 						+ BlockingQueueConsumer.this.consumerTags.get(consumerTag)
 						+ "); " + BlockingQueueConsumer.this);
-			}
-			BlockingQueueConsumer.this.consumerTags.remove(consumerTag);
-			if (BlockingQueueConsumer.this.consumerTags.isEmpty()) {
-				BlockingQueueConsumer.this.cancelled.set(true);
 			}
 		}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-648

The `cancelled` boolean is set when there are no more consumers in `handleCancelOk`.

Consider a case where a container is configured for multiple queues; one queue is deleted
from the broker. In `handleCancel`, we attempt to cancel the rest of the consumers so the
container can recover.

However, if those cancels fail (e.g. if the broker goes down), we'll never finalize the
consumer.

Move the consumer removal (and setting `cancelled`) to `basicCancel` instead. We don't really
care whether or not we get the `cancelOk`s.

Add mock test - also tested with the SI sample modified for 2 queues
- set a breakpoint in `handleCancel`
- delete a queue
- stop/start rabbitmq
- release the breakpoint
- container recovers

__backport to 1.6.x__