### PR TITLE
AMQP-631: Add `ConnectionNameStrategy` for `CF`

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParser.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 /**
  * @author Dave Syer
  * @author Gary Russell
+ * @author Artem Bilan
  */
 class ConnectionFactoryParser extends AbstractSingleBeanDefinitionParser {
 
@@ -106,7 +107,7 @@ class ConnectionFactoryParser extends AbstractSingleBeanDefinitionParser {
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, THREAD_FACTORY, "connectionThreadFactory");
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, FACTORY_TIMEOUT, "channelCheckoutTimeout");
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, CONNECTION_LIMIT);
-
+		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, "connection-name-strategy");
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -71,7 +71,7 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	private volatile int closeTimeout = DEFAULT_CLOSE_TIMEOUT;
 
 	private ConnectionNameStrategy connectionNameStrategy =
-			connectionFactory -> (this.beanName != null ? this.beanName : getClass()) +
+			connectionFactory -> (this.beanName != null ? this.beanName : "SpringAMQP") +
 					"#" + this.defaultConnectionNameStrategyCounter.getAndIncrement();
 
 	private volatile String beanName;
@@ -283,8 +283,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	}
 
 	/**
-	 * Provide a {@link ConnectionNameStrategy} to build the name for target RabbitMQ connection.
-	 * The {@link #beanName} together with the counter is used by default.
+	 * Provide a {@link ConnectionNameStrategy} to build the name for the target RabbitMQ connection.
+	 * The {@link #beanName} together with a counter is used by default.
 	 * @param connectionNameStrategy the {@link ConnectionNameStrategy} to use.
 	 * @since 2.0
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -44,6 +45,7 @@ import com.rabbitmq.client.Address;
  * @author Dave Syer
  * @author Gary Russell
  * @author Steve Powell
+ * @author Artem Bilan
  *
  */
 public abstract class AbstractConnectionFactory implements ConnectionFactory, DisposableBean, BeanNameAware {
@@ -58,6 +60,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	private final CompositeChannelListener channelListener = new CompositeChannelListener();
 
+	private final AtomicInteger defaultConnectionNameStrategyCounter = new AtomicInteger();
+
 	private volatile ExecutorService executorService;
 
 	private volatile Address[] addresses;
@@ -65,6 +69,10 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	public static final int DEFAULT_CLOSE_TIMEOUT = 30000;
 
 	private volatile int closeTimeout = DEFAULT_CLOSE_TIMEOUT;
+
+	private ConnectionNameStrategy connectionNameStrategy =
+			connectionFactory -> (this.beanName != null ? this.beanName : getClass()) +
+					"#" + this.defaultConnectionNameStrategyCounter.getAndIncrement();
 
 	private volatile String beanName;
 
@@ -87,7 +95,7 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	}
 
 	/**
-	 * Return the user name from the unerlying rabbit connection factory.
+	 * Return the user name from the underlying rabbit connection factory.
 	 * @return the user name.
 	 * @since 1.6
 	 */
@@ -126,11 +134,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 		try {
 			this.rabbitConnectionFactory.setUri(uri);
 		}
-		catch (URISyntaxException use) {
+		catch (URISyntaxException | GeneralSecurityException use) {
 			this.logger.info(BAD_URI, use);
-		}
-		catch (GeneralSecurityException gse) {
-			this.logger.info(BAD_URI, gse);
 		}
 	}
 
@@ -143,11 +148,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 		try {
 			this.rabbitConnectionFactory.setUri(uri);
 		}
-		catch (URISyntaxException use) {
+		catch (URISyntaxException | GeneralSecurityException use) {
 			this.logger.info(BAD_URI, use);
-		}
-		catch (GeneralSecurityException gse) {
-			this.logger.info(BAD_URI, gse);
 		}
 	}
 
@@ -270,7 +272,6 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	/**
 	 * How long to wait (milliseconds) for a response to a connection close
 	 * operation from the broker; default 30000 (30 seconds).
-	 *
 	 * @param closeTimeout the closeTimeout to set.
 	 */
 	public void setCloseTimeout(int closeTimeout) {
@@ -281,6 +282,16 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 		return this.closeTimeout;
 	}
 
+	/**
+	 * Provide a {@link ConnectionNameStrategy} to build the name for target RabbitMQ connection.
+	 * The {@link #beanName} together with the counter is used by default.
+	 * @param connectionNameStrategy the {@link ConnectionNameStrategy} to use.
+	 * @since 2.0
+	 */
+	public void setConnectionNameStrategy(ConnectionNameStrategy connectionNameStrategy) {
+		this.connectionNameStrategy = connectionNameStrategy;
+	}
+
 	@Override
 	public void setBeanName(String name) {
 		this.beanName = name;
@@ -288,29 +299,30 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	protected final Connection createBareConnection() {
 		try {
-			Connection connection;
+			String connectionName = this.connectionNameStrategy.obtainNewConnectionName(this);
+
+			com.rabbitmq.client.Connection rabbitConnection;
 			if (this.addresses != null) {
-				connection = new SimpleConnection(this.rabbitConnectionFactory.newConnection(this.executorService, this.addresses),
-									this.closeTimeout);
+				rabbitConnection = this.rabbitConnectionFactory.newConnection(this.executorService, this.addresses,
+						connectionName);
+
 			}
 			else {
-				connection = new SimpleConnection(this.rabbitConnectionFactory.newConnection(this.executorService),
-									this.closeTimeout);
+				rabbitConnection = this.rabbitConnectionFactory.newConnection(this.executorService, connectionName);
 			}
+
+			Connection connection = new SimpleConnection(rabbitConnection, this.closeTimeout);
 			if (this.logger.isInfoEnabled()) {
 				this.logger.info("Created new connection: " + connection);
 			}
 			return connection;
 		}
-		catch (IOException e) {
-			throw RabbitExceptionTranslator.convertRabbitAccessException(e);
-		}
-		catch (TimeoutException e) {
+		catch (IOException | TimeoutException e) {
 			throw RabbitExceptionTranslator.convertRabbitAccessException(e);
 		}
 	}
 
-	protected final  String getDefaultHostName() {
+	protected final String getDefaultHostName() {
 		String temp;
 		try {
 			InetAddress localMachine = InetAddress.getLocalHost();

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionNameStrategy.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionNameStrategy.java
@@ -16,8 +16,6 @@
 
 package org.springframework.amqp.rabbit.connection;
 
-import com.rabbitmq.client.Address;
-
 /**
  * A strategy to build an application-specific connection name,
  * which can be displayed in the management UI if RabbitMQ server supports it.
@@ -27,7 +25,7 @@ import com.rabbitmq.client.Address;
  *
  * @author Artem Bilan
  * @since 2.0
- * @see com.rabbitmq.client.ConnectionFactory#newConnection(Address[], String)
+ * @see com.rabbitmq.client.ConnectionFactory#newConnection(com.rabbitmq.client.Address[], String)
  */
 @FunctionalInterface
 public interface ConnectionNameStrategy {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionNameStrategy.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionNameStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import com.rabbitmq.client.Address;
+
+/**
+ * A strategy to build an application-specific connection name,
+ * which can be displayed in the management UI if RabbitMQ server supports it.
+ * The value doesn't have to be unique and cannot be used
+ * as a connection identifier e.g. in HTTP API requests.
+ * The value is supposed to be human-readable.
+ *
+ * @author Artem Bilan
+ * @since 2.0
+ * @see com.rabbitmq.client.ConnectionFactory#newConnection(Address[], String)
+ */
+@FunctionalInterface
+public interface ConnectionNameStrategy {
+
+	String obtainNewConnectionName(ConnectionFactory connectionFactory);
+
+}

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
@@ -399,7 +399,7 @@
 		<xsd:attribute name="ignore-declaration-exceptions">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	Specifies whether exceptions encountered while declraring this element should be ignored.
+	Specifies whether exceptions encountered while declaring this element should be ignored.
 	If 'false', the equivalent setting on the rabbit admin applies.
 	Default value is 'false'.
 				]]></xsd:documentation>
@@ -1384,7 +1384,7 @@
 			<xsd:attribute name="virtual-host" type="xsd:string" use="optional">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	Virtual host name to connect to broker.  Default is "/".  Virtual hosts are logical partitions of the broker with separate queues, excchanges, users, etc.
+	Virtual host name to connect to broker.  Default is "/".  Virtual hosts are logical partitions of the broker with separate queues, exchanges, users, etc.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -1503,6 +1503,19 @@
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type type="java.util.concurrent.ThreadFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-name-strategy">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to a 'ConnectionNameStrategy' to provide client-specific target RabbitMQ connection name.
+	It can be displayed in the management UI if RabbitMQ server supports it.
+				]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.rabbit.connection.ConnectionNameStrategy" />
 						</tool:annotation>
 					</xsd:appinfo>
 				</xsd:annotation>

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
@@ -1510,7 +1510,7 @@
 			<xsd:attribute name="connection-name-strategy">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	Reference to a 'ConnectionNameStrategy' to provide client-specific target RabbitMQ connection name.
+	Reference to a 'ConnectionNameStrategy' to provide client-specific name for the target RabbitMQ connection.
 	It can be displayed in the management UI if RabbitMQ server supports it.
 				]]></xsd:documentation>
 					<xsd:appinfo>

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
@@ -140,7 +140,7 @@ public class AsyncRabbitTemplateTests {
 		this.fooMessage.getMessageProperties().setCorrelationId("foo");
 		ListenableFuture<Message> future = this.template.sendAndReceive(this.fooMessage);
 		Message result = checkMessageResult(future, "FOO");
-		assertEquals("foo", new String(result.getMessageProperties().getCorrelationId()));
+		assertEquals("foo", result.getMessageProperties().getCorrelationId());
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionNameStrategy;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -41,6 +42,7 @@ import com.rabbitmq.client.ConnectionFactory;
  *
  * @author Dave Syer
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
 public final class ConnectionFactoryParserTests {
@@ -68,6 +70,8 @@ public final class ConnectionFactoryParserTests {
 		assertEquals(CachingConnectionFactory.CacheMode.CHANNEL, connectionFactory.getCacheMode());
 		assertEquals(234L, TestUtils.getPropertyValue(connectionFactory, "channelCheckoutTimeout"));
 		assertEquals(456,  TestUtils.getPropertyValue(connectionFactory, "connectionLimit"));
+		assertSame(beanFactory.getBean(ConnectionNameStrategy.class),
+				TestUtils.getPropertyValue(connectionFactory, "connectionNameStrategy"));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
@@ -3,17 +3,20 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:task="http://www.springframework.org/schema/task"
-	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
 		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:connection-factory id="kitchenSink" host="foo" virtual-host="/bar"
 		channel-cache-size="10" port="6888" username="user" password="password"
 		publisher-confirms="true" publisher-returns="true" connection-timeout="789"
 		factory-timeout="234" connection-limit="456"
-		requested-heartbeat="123"/>
+		requested-heartbeat="123"
+		connection-name-strategy="connectionNameStrategy"/>
+
+	<bean id="connectionNameStrategy" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.amqp.rabbit.connection.ConnectionNameStrategy"/>
+	</bean>
 
 	<rabbit:connection-factory id="native" connection-factory="connectionFactory" channel-cache-size="10" />
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -348,7 +348,7 @@ connectionFactory.setConnectionNameStrategy(connectionFactory -> "MY_CONNECTION"
 ----
 
 The `ConnectionFactory` argument can be used to distinguish target connection names by some logic.
-By default a `beanName` of the `AbstractConnectionFactory` and internal counter are used to generate `connection_name`.
+By default a `beanName` of the `AbstractConnectionFactory` and an internal counter are used to generate `connection_name`.
 The `<rabbit:connection-factory>` namespace component is also supplied with the `connection-name-strategy` attribute.
 
 [[connection-factory]]

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -336,6 +336,21 @@ Here's an example with a custom thread factory that prefixes thread names with `
 
 ----
 
+Starting with _version 2.0_ a `ConnectionNameStrategy` is provided for the injection into the `AbstractionConnectionFactory`.
+The generated name is used for the application-specific identification of the target RabbitMQ connection.
+The connection name is displayed in the management UI if RabbitMQ server supports it.
+This value doesn't have to be unique and cannot be used as a connection identifier e.g. in HTTP API requests.
+This value is supposed to be human-readable and is a part of `ClientProperties` under `connection_name` key.
+Can be used as a simple Lambda:
+[source, java]
+----
+connectionFactory.setConnectionNameStrategy(connectionFactory -> "MY_CONNECTION");
+----
+
+The `ConnectionFactory` argument can be used to distinguish target connection names by some logic.
+By default a `beanName` of the `AbstractConnectionFactory` and internal counter are used to generate `connection_name`.
+The `<rabbit:connection-factory>` namespace component is also supplied with the `connection-name-strategy` attribute.
+
 [[connection-factory]]
 ===== Configuring the Underlying Client Connection Factory
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -30,6 +30,9 @@ This property only applies when using `basicGet` (e.g. from `RabbitTemplate.rece
 The connection and channel listener interfaces now provide a mechanism to obtain information about exceptions.
 See <<connection-channel-listeners>> and <<publishing-is-async>> for more information.
 
+A new `ConnectionNameStrategy` is now provided to populate the application-specific identification of the target RabbitMQ connection from the `AbstractConnectionFactory`.
+See <<connections>> for more information.
+
 ===== Retry Changes
 
 The `MissingMessageIdAdvice` is no longer provided; it's functionality is now built-in; see <<retry>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-631

To allow to identify application connections in the Broker or other monitoring and tracing tools, the Rabbit Connection can be supplied with `connection_name` property.

* Introduce `ConnectionNameStrategy` for injection into the `AbstractConnectionFactory` which is used to generate name for the underlying `rabbitConnectionFactory.newConnection()` operation