### PR TITLE
AMQP-616: Support Direct ReplyTo in Async Template

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AsyncAmqpTemplate.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AsyncAmqpTemplate.java
@@ -34,7 +34,7 @@ public interface AsyncAmqpTemplate {
 	 * @param message the message.
 	 * @return the {@link AmqpMessageFuture}.
 	 */
-	AmqpMessageFuture sendAndReceive(Message message);
+	ListenableFuture<Message> sendAndReceive(Message message);
 
 	/**
 	 * Send a message to the default exchange with the supplied routing key. If the message
@@ -43,7 +43,7 @@ public interface AsyncAmqpTemplate {
 	 * @param message the message.
 	 * @return the {@link AmqpMessageFuture}.
 	 */
-	AmqpMessageFuture sendAndReceive(String routingKey, Message message);
+	ListenableFuture<Message> sendAndReceive(String routingKey, Message message);
 
 	/**
 	 * Send a message to the supplied exchange and routing key. If the message
@@ -53,7 +53,7 @@ public interface AsyncAmqpTemplate {
 	 * @param message the message.
 	 * @return the {@link AmqpMessageFuture}.
 	 */
-	AmqpMessageFuture sendAndReceive(String exchange, String routingKey, Message message);
+	ListenableFuture<Message> sendAndReceive(String exchange, String routingKey, Message message);
 
 	/**
 	 * Convert the object to a message and send it to the default exchange with the
@@ -62,7 +62,7 @@ public interface AsyncAmqpTemplate {
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(Object object);
+	<C> ListenableFuture<C> convertSendAndReceive(Object object);
 
 	/**
 	 * Convert the object to a message and send it to the default exchange with the
@@ -72,7 +72,7 @@ public interface AsyncAmqpTemplate {
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(String routingKey, Object object);
+	<C> ListenableFuture<C> convertSendAndReceive(String routingKey, Object object);
 
 	/**
 	 * Convert the object to a message and send it to the provided exchange and
@@ -83,7 +83,7 @@ public interface AsyncAmqpTemplate {
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object);
+	<C> ListenableFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object);
 
 	/**
 	 * Convert the object to a message and send it to the default exchange with the
@@ -94,7 +94,7 @@ public interface AsyncAmqpTemplate {
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(Object object, MessagePostProcessor messagePostProcessor);
+	<C> ListenableFuture<C> convertSendAndReceive(Object object, MessagePostProcessor messagePostProcessor);
 
 	/**
 	 * Convert the object to a message and send it to the default exchange with the
@@ -106,7 +106,7 @@ public interface AsyncAmqpTemplate {
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(String routingKey, Object object,
+	<C> ListenableFuture<C> convertSendAndReceive(String routingKey, Object object,
 			MessagePostProcessor messagePostProcessor);
 
 	/**
@@ -120,23 +120,7 @@ public interface AsyncAmqpTemplate {
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object,
+	<C> ListenableFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object,
 			MessagePostProcessor messagePostProcessor);
-
-	/**
-	 * Return type from {@code sendAndReceive()} methods.
-	 *
-	 */
-	interface AmqpMessageFuture extends ListenableFuture<Message> {
-
-	}
-
-	/**
-	 * Return type from {@code convertSendAndReceive()} methods.
-	 *
-	 */
-	interface AmqpConverterFuture<C> extends ListenableFuture<C> {
-
-	}
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AsyncAmqpTemplate.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AsyncAmqpTemplate.java
@@ -58,55 +58,55 @@ public interface AsyncAmqpTemplate {
 	/**
 	 * Convert the object to a message and send it to the default exchange with the
 	 * default routing key.
-	 * @param message the message.
+	 * @param object the object to convert.
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(Object message);
+	<C> AmqpConverterFuture<C> convertSendAndReceive(Object object);
 
 	/**
 	 * Convert the object to a message and send it to the default exchange with the
 	 * provided routing key.
 	 * @param routingKey the routing key.
-	 * @param message the message.
+	 * @param object the object to convert.
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(String routingKey, Object message);
+	<C> AmqpConverterFuture<C> convertSendAndReceive(String routingKey, Object object);
 
 	/**
 	 * Convert the object to a message and send it to the provided exchange and
 	 * routing key.
 	 * @param exchange the exchange.
 	 * @param routingKey the routing key.
-	 * @param message the message.
+	 * @param object the object to convert.
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(String exchange, String routingKey, Object message);
+	<C> AmqpConverterFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object);
 
 	/**
 	 * Convert the object to a message and send it to the default exchange with the
 	 * default routing key after invoking the {@link MessagePostProcessor}.
 	 * If the post processor adds a correlationId property, it must be unique.
-	 * @param message the message.
+	 * @param object the object to convert.
 	 * @param messagePostProcessor the post processor.
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(Object message, MessagePostProcessor messagePostProcessor);
+	<C> AmqpConverterFuture<C> convertSendAndReceive(Object object, MessagePostProcessor messagePostProcessor);
 
 	/**
 	 * Convert the object to a message and send it to the default exchange with the
 	 * provided routing key after invoking the {@link MessagePostProcessor}.
 	 * If the post processor adds a correlationId property, it must be unique.
 	 * @param routingKey the routing key.
-	 * @param message the message.
+	 * @param object the object to convert.
 	 * @param messagePostProcessor the post processor.
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(String routingKey, Object message,
+	<C> AmqpConverterFuture<C> convertSendAndReceive(String routingKey, Object object,
 			MessagePostProcessor messagePostProcessor);
 
 	/**
@@ -115,12 +115,12 @@ public interface AsyncAmqpTemplate {
 	 * If the post processor adds a correlationId property, it must be unique.
 	 * @param exchange the exchange
 	 * @param routingKey the routing key.
-	 * @param message the message.
+	 * @param object the object to convert.
 	 * @param messagePostProcessor the post processor.
 	 * @param <C> the expected result type.
 	 * @return the {@link AmqpConverterFuture}.
 	 */
-	<C> AmqpConverterFuture<C> convertSendAndReceive(String exchange, String routingKey, Object message,
+	<C> AmqpConverterFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object,
 			MessagePostProcessor messagePostProcessor);
 
 	/**

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AsyncAmqpTemplate.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AsyncAmqpTemplate.java
@@ -32,7 +32,7 @@ public interface AsyncAmqpTemplate {
 	 * Send a message to the default exchange with the default routing key. If the message
 	 * contains a correlationId property, it must be unique.
 	 * @param message the message.
-	 * @return the {@link AmqpMessageFuture}.
+	 * @return the {@link ListenableFuture}.
 	 */
 	ListenableFuture<Message> sendAndReceive(Message message);
 
@@ -41,7 +41,7 @@ public interface AsyncAmqpTemplate {
 	 * contains a correlationId property, it must be unique.
 	 * @param routingKey the routing key.
 	 * @param message the message.
-	 * @return the {@link AmqpMessageFuture}.
+	 * @return the {@link ListenableFuture}.
 	 */
 	ListenableFuture<Message> sendAndReceive(String routingKey, Message message);
 
@@ -51,7 +51,7 @@ public interface AsyncAmqpTemplate {
 	 * @param exchange the exchange.
 	 * @param routingKey the routing key.
 	 * @param message the message.
-	 * @return the {@link AmqpMessageFuture}.
+	 * @return the {@link ListenableFuture}.
 	 */
 	ListenableFuture<Message> sendAndReceive(String exchange, String routingKey, Message message);
 
@@ -60,7 +60,7 @@ public interface AsyncAmqpTemplate {
 	 * default routing key.
 	 * @param object the object to convert.
 	 * @param <C> the expected result type.
-	 * @return the {@link AmqpConverterFuture}.
+	 * @return the {@link ListenableFuture}.
 	 */
 	<C> ListenableFuture<C> convertSendAndReceive(Object object);
 
@@ -70,7 +70,7 @@ public interface AsyncAmqpTemplate {
 	 * @param routingKey the routing key.
 	 * @param object the object to convert.
 	 * @param <C> the expected result type.
-	 * @return the {@link AmqpConverterFuture}.
+	 * @return the {@link ListenableFuture}.
 	 */
 	<C> ListenableFuture<C> convertSendAndReceive(String routingKey, Object object);
 
@@ -81,7 +81,7 @@ public interface AsyncAmqpTemplate {
 	 * @param routingKey the routing key.
 	 * @param object the object to convert.
 	 * @param <C> the expected result type.
-	 * @return the {@link AmqpConverterFuture}.
+	 * @return the {@link ListenableFuture}.
 	 */
 	<C> ListenableFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object);
 
@@ -92,7 +92,7 @@ public interface AsyncAmqpTemplate {
 	 * @param object the object to convert.
 	 * @param messagePostProcessor the post processor.
 	 * @param <C> the expected result type.
-	 * @return the {@link AmqpConverterFuture}.
+	 * @return the {@link ListenableFuture}.
 	 */
 	<C> ListenableFuture<C> convertSendAndReceive(Object object, MessagePostProcessor messagePostProcessor);
 
@@ -104,7 +104,7 @@ public interface AsyncAmqpTemplate {
 	 * @param object the object to convert.
 	 * @param messagePostProcessor the post processor.
 	 * @param <C> the expected result type.
-	 * @return the {@link AmqpConverterFuture}.
+	 * @return the {@link ListenableFuture}.
 	 */
 	<C> ListenableFuture<C> convertSendAndReceive(String routingKey, Object object,
 			MessagePostProcessor messagePostProcessor);
@@ -118,7 +118,7 @@ public interface AsyncAmqpTemplate {
 	 * @param object the object to convert.
 	 * @param messagePostProcessor the post processor.
 	 * @param <C> the expected result type.
-	 * @return the {@link AmqpConverterFuture}.
+	 * @return the {@link ListenableFuture}.
 	 */
 	<C> ListenableFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object,
 			MessagePostProcessor messagePostProcessor);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -622,9 +622,8 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 				this.timeoutTask.cancel(true);
 			}
 			AsyncRabbitTemplate.this.pending.remove(this.correlationId);
-			if (RabbitFuture.this.channel != null) {
-				AsyncRabbitTemplate.this.directReplyToContainer.releaseConsumerFor(RabbitFuture.this.channel, false,
-						null);
+			if (this.channel != null && AsyncRabbitTemplate.this.directReplyToContainer != null) {
+				AsyncRabbitTemplate.this.directReplyToContainer.releaseConsumerFor(this.channel, false, null);
 			}
 			return super.cancel(mayInterruptIfRunning);
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1391,7 +1391,8 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	protected final void publishConsumerFailedEvent(String reason, boolean fatal, Throwable t) {
 		if (this.applicationEventPublisher != null) {
 			this.applicationEventPublisher
-					.publishEvent(new ListenerContainerConsumerFailedEvent(this, reason, t, fatal));
+					.publishEvent(t == null ? new ListenerContainerConsumerTerminatedEvent(this, reason) :
+							new ListenerContainerConsumerFailedEvent(this, reason, t, fatal));
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -226,7 +226,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @param acknowledgeMode the acknowledge mode to set. Defaults to {@link AcknowledgeMode#AUTO}
 	 * @see AcknowledgeMode
 	 */
-	public void setAcknowledgeMode(AcknowledgeMode acknowledgeMode) {
+	public final void setAcknowledgeMode(AcknowledgeMode acknowledgeMode) {
 		this.acknowledgeMode = acknowledgeMode;
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -588,6 +588,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 
 	/**
 	 * Called whenever a consumer is removed.
+	 * @param the consumer.
 	 */
 	protected void consumerRemoved(SimpleConsumer consumer) {
 		// default empty

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
@@ -25,6 +25,7 @@ import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
+import org.springframework.util.Assert;
 
 import com.rabbitmq.client.Channel;
 
@@ -190,7 +191,7 @@ public class DirectReplyToMessageListenerContainer extends DirectMessageListener
 	public void releaseConsumerFor(Channel channel, boolean cancelConsumer, String message) {
 		SimpleConsumer consumer = this.inUseConsumerChannels.remove(channel);
 		if (consumer != null && cancelConsumer) {
-			this.logger.error("Consumer canceled by client" + consumer);
+			Assert.isTrue(message != null, "A 'message' is required when 'cancelConsumer' is 'true'");
 			consumer.cancelConsumer("Consumer " + this + " canceled due to " + message);
 		}
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.Address;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+
+import com.rabbitmq.client.Channel;
+
+/**
+ * Listener container for Direct ReplyTo only listens to the pseudo queue
+ * {@link Address#AMQ_RABBITMQ_REPLY_TO} with a single consumer.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class DirectReplyToMessageListenerContainer extends DirectMessageListenerContainer {
+
+	public DirectReplyToMessageListenerContainer(ConnectionFactory connectionFactory) {
+		super(connectionFactory);
+		setQueueNames(Address.AMQ_RABBITMQ_REPLY_TO);
+		setAcknowledgeMode(AcknowledgeMode.NONE);
+	}
+
+	@Override
+	public void setConsumersPerQueue(int consumersPerQueue) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setMonitorInterval(long monitorInterval) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setQueues(Queue... queues) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void addQueueNames(String... queueNames) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void addQueues(Queue... queues) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean removeQueueNames(String... queueNames) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean removeQueues(Queue... queues) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Get the channel associated with the single direct reply-to consumer.
+	 * If the consumer has exited, the container will be stopped.
+	 * @return the channel or null if there is no consumer.
+	 */
+	public Channel getChannel() {
+		synchronized (this.consumersMonitor) {
+			if (this.consumers.size() == 1) {
+				return this.consumers.get(0).getChannel();
+			}
+			else {
+				stop();
+				return null;
+			}
+		}
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ListenerContainerConsumerTerminatedEvent.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ListenerContainerConsumerTerminatedEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import org.springframework.amqp.event.AmqpEvent;
+
+/**
+ * Published when a listener consumer is terminated.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class ListenerContainerConsumerTerminatedEvent extends AmqpEvent {
+
+	private static final long serialVersionUID = -8122166328567190605L;
+
+	private final String reason;
+
+	/**
+	 * Construct an instance with the provided arguments.
+	 * @param source the source container.
+	 * @param reason the reason.
+	 */
+	public ListenerContainerConsumerTerminatedEvent(Object source, String reason) {
+		super(source);
+		this.reason = reason;
+	}
+
+	public String getReason() {
+		return this.reason;
+	}
+
+	@Override
+	public String toString() {
+		return "ListenerContainerConsumerTerminatedEvent [reason=" + this.reason + ", container=" + this.source + "]";
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
@@ -292,7 +292,7 @@ public class DirectMessageListenerContainerTests {
 		brokerRunning.getAdmin().deleteQueue(EQ2);
 		assertTrue(latch2.await(10, TimeUnit.SECONDS));
 		assertNotNull(failEvent.get());
-		assertThat(failEvent.get(), instanceOf(ListenerContainerConsumerFailedEvent.class));
+		assertThat(failEvent.get(), instanceOf(ListenerContainerConsumerTerminatedEvent.class));
 		container.stop();
 		cf.destroy();
 	}
@@ -489,7 +489,7 @@ public class DirectMessageListenerContainerTests {
 		Channel channel = container.getChannel();
 		final CountDownLatch latch = new CountDownLatch(1);
 		container.setApplicationEventPublisher(e -> {
-			if (e instanceof ListenerContainerConsumerFailedEvent) {
+			if (e instanceof ListenerContainerConsumerTerminatedEvent) {
 				latch.countDown();
 			}
 		});

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
@@ -479,6 +479,23 @@ public class DirectMessageListenerContainerTests {
 		cf.destroy();
 	}
 
+	@Test
+	public void testReplyToReleaseWithCancel() throws Exception {
+		CachingConnectionFactory cf = new CachingConnectionFactory("localhost");
+		DirectReplyToMessageListenerContainer container = new DirectReplyToMessageListenerContainer(cf);
+		container.afterPropertiesSet();
+		container.start();
+		Channel channel = container.getChannel();
+		final CountDownLatch latch = new CountDownLatch(1);
+		container.setApplicationEventPublisher(e -> {
+			if (e instanceof ListenerContainerConsumerFailedEvent) {
+				latch.countDown();
+			}
+		});
+		container.releaseConsumerFor(channel, true, "foo");
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+	}
+
 	private boolean consumersOnQueue(String queue, int expected) throws Exception {
 		int n = 0;
 		RabbitAdmin admin = brokerRunning.getAdmin();

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2891,6 +2891,18 @@ If a timeout occurs, the future will be completed with an `AmqpReplyTimeoutExcep
 The template implements `SmartLifecycle`; stopping the template while there are pending replies will cause the
 pending `Future` s to be canceled.
 
+Starting with _version 2.0_, the async template now supports https://www.rabbitmq.com/direct-reply-to.html[Direct reply-to] instead of a configured reply queue.
+To enable this feature, use one of the following constructors:
+
+[source, java]
+----
+public AsyncRabbitTemplate(ConnectionFactory connectionFactory, String exchange, String routingKey)
+
+public AsyncRabbitTemplate(RabbitTemplate template)
+----
+
+See <<direct-reply-to>> to use Direct reply-to with the synchronous `RabbitTemplate`.
+
 [[remoting]]
 ===== Spring Remoting with AMQP
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -15,6 +15,8 @@ IMPORTANT: Previously, a non-transactional `RabbitTemplate` participated in an e
 This was a serious bug; however, users might have relied on this behavior.
 Starting with _version 1.6.2_, you must set the `channelTransacted` boolean on the template for it to participate in the container transaction.
 
+The `AsyncRabbitTemplate` now supports Direct reply-to; see <<async-template>> for more information.
+
 ===== Listener Adapter
 
 A convenient `FunctionalInterface` is available for using lambdas with the `MessageListenerAdapter`.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-616

As an alternative to using a SMLC reply-container for the async template,
instead, use a specially configured DMLC to listen on the channels amq.rabbitmq.reply-to
pseudo queue.

Cache these containers for reuse.

When retrieving a container from the cache, check that it's still valid before using.