### PR TITLE
AMQP-616: Direct ReplyTo Container Race Condition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ subprojects { subproject ->
 
 		springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.0.0.BUILD-SNAPSHOT'
 
-		springRetryVersion = '1.2.0.BUILD-SNAPSHOT'
+		springRetryVersion = '1.2.0.RC1'
 	}
 
 	eclipse {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -615,6 +615,8 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 
 		private volatile String consumerTag;
 
+		private volatile int epoch;
+
 		private SimpleConsumer(Connection connection, Channel channel, String queue) {
 			super(channel);
 			this.connection = connection;
@@ -629,6 +631,23 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		@Override
 		public String getConsumerTag() {
 			return this.consumerTag;
+		}
+
+		/**
+		 * Return the current epoch for this consumer; consumersMonitor must be held.
+		 * @return the epoch.
+		 */
+		int getEpoch() {
+			return this.epoch;
+		}
+
+		/**
+		 * Increment and return the current epoch for this consumer; consumersMonitor must
+		 * be held.
+		 * @return the epoch.
+		 */
+		int incrementAndGetEpoch() {
+			return ++this.epoch;
 		}
 
 		@Override

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
@@ -131,9 +131,9 @@ public class AsyncRabbitTemplateTests {
 
 	private void waitForEmpty() throws InterruptedException {
 		int n = 0;
-		while (n++ < 100 && TestUtils
-				.getPropertyValue(this.asyncDirectTemplate, "directReplyToContainer.inUseConsumerChannels", Map.class)
-				.size() > 0) {
+		Map<?, ?> inUse = TestUtils
+				.getPropertyValue(this.asyncDirectTemplate, "directReplyToContainer.inUseConsumerChannels", Map.class);
+		while (n++ < 100 && inUse.size() > 0) {
 			Thread.sleep(100);
 		}
 	}
@@ -178,12 +178,12 @@ public class AsyncRabbitTemplateTests {
 				.getPropertyValue(this.asyncDirectTemplate, "directReplyToContainer.inUseConsumerChannels", Map.class)
 				.size(), equalTo(0));
 		assertThat(TestUtils
-						.getPropertyValue(this.asyncDirectTemplate, "directReplyToContainer.consumerCount", Integer.class),
+					.getPropertyValue(this.asyncDirectTemplate, "directReplyToContainer.consumerCount", Integer.class),
 				equalTo(2));
 		this.asyncDirectTemplate.stop();
 		this.asyncDirectTemplate.start();
 		assertThat(TestUtils
-						.getPropertyValue(this.asyncDirectTemplate, "directReplyToContainer.consumerCount", Integer.class),
+					.getPropertyValue(this.asyncDirectTemplate, "directReplyToContainer.consumerCount", Integer.class),
 				equalTo(0));
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
@@ -57,6 +57,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerContainer.ChannelHolder;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.listener.adapter.ReplyingMessageListener;
 import org.springframework.amqp.rabbit.support.ArgumentBuilder;
@@ -486,14 +487,14 @@ public class DirectMessageListenerContainerTests {
 		container.setBeanName("releaseCancel");
 		container.afterPropertiesSet();
 		container.start();
-		Channel channel = container.getChannel();
+		ChannelHolder channelHolder = container.getChannelHolder();
 		final CountDownLatch latch = new CountDownLatch(1);
 		container.setApplicationEventPublisher(e -> {
 			if (e instanceof ListenerContainerConsumerTerminatedEvent) {
 				latch.countDown();
 			}
 		});
-		container.releaseConsumerFor(channel, true, "foo");
+		container.releaseConsumerFor(channelHolder, true, "foo");
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
 	}
 
@@ -505,9 +506,9 @@ public class DirectMessageListenerContainerTests {
 		container.setIdleEventInterval(500);
 		container.afterPropertiesSet();
 		container.start();
-		Channel channel = container.getChannel();
+		ChannelHolder channelHolder = container.getChannelHolder();
 		assertTrue(activeConsumerCount(container, 1));
-		container.releaseConsumerFor(channel, false, null);
+		container.releaseConsumerFor(channelHolder, false, null);
 		assertTrue(activeConsumerCount(container, 0));
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainerTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.amqp.core.Address;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerContainer.ChannelHolder;
+import org.springframework.amqp.rabbit.test.BrokerRunning;
+import org.springframework.amqp.utils.test.TestUtils;
+
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.GetResponse;
+
+/**
+ * DirectReplyToMessageListenerContainer Tests.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class DirectReplyToMessageListenerContainerTests {
+
+	private static final String TEST_RELEASE_CONSUMER_Q = "test.release.consumer";
+
+	@Rule
+	public BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues(TEST_RELEASE_CONSUMER_Q);
+
+	@Test
+	public void testReleaseConsumerRace() throws Exception {
+		ConnectionFactory connectionFactory = new CachingConnectionFactory("localhost");
+		DirectReplyToMessageListenerContainer container = new DirectReplyToMessageListenerContainer(connectionFactory);
+		final CountDownLatch latch = new CountDownLatch(1);
+		container.setMessageListener(m -> latch.countDown());
+		container.start();
+		ChannelHolder channel1 = container.getChannelHolder();
+		BasicProperties props = new BasicProperties().builder().replyTo(Address.AMQ_RABBITMQ_REPLY_TO).build();
+		channel1.getChannel().basicPublish("", TEST_RELEASE_CONSUMER_Q, props, "foo".getBytes());
+		Channel replyChannel = connectionFactory.createConnection().createChannel(false);
+		GetResponse request = replyChannel.basicGet(TEST_RELEASE_CONSUMER_Q, true);
+		int n = 0;
+		while (n++ < 100 && request == null) {
+			Thread.sleep(100);
+			request = replyChannel.basicGet(TEST_RELEASE_CONSUMER_Q, true);
+		}
+		assertNotNull(request);
+		replyChannel.basicPublish("", request.getProps().getReplyTo(), new BasicProperties(), "bar".getBytes());
+		replyChannel.close();
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+		ChannelHolder channel2 = container.getChannelHolder();
+		assertSame(channel1.getChannel(), channel2.getChannel());
+		container.releaseConsumerFor(channel1, false, null); // simulate race for future timeout/cancel and onMessage()
+		Map<?, ?> inUse = TestUtils.getPropertyValue(container, "inUseConsumerChannels", Map.class);
+		assertThat(inUse.size(), equalTo(1));
+		container.releaseConsumerFor(channel2, false, null);
+		assertThat(inUse.size(), equalTo(0));
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-616

Consider the case where a reply is received at the same time as the future times
out or is canceled. At the same time, another request gets the same channel.

It is possible that the "late" future timeout/cancel will remove the consumer from
the in-use map even though the "next" user is waiting for the reply.

Add an epoch to the consumer which is incremented on each use. When releasing
the consumer, only do so if the epoch matches.