### PR TITLE
AMQP-659: @RabbitListener Annotation Improvements

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Exchange.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Exchange.java
@@ -21,6 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.amqp.core.ExchangeTypes;
+import org.springframework.core.annotation.AliasFor;
 
 /**
  * An exchange to which to bind a {@code RabbitListener} queue.
@@ -36,7 +37,15 @@ public @interface Exchange {
 	/**
 	 * @return the exchange name.
 	 */
-	String value();
+	@AliasFor("name")
+	String value() default "";
+
+	/**
+	 * @return the exchange name.
+	 * @since 2.0
+	 */
+	@AliasFor("value")
+	String name() default "";
 
 	/**
 	 * The exchange type - only DIRECT, FANOUT TOPIC, and HEADERS exchanges are supported.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Queue.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Queue.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.core.annotation.AliasFor;
+
 /**
  * A queue definition used within the bindings attribute of a {@code QueueBinding}.
  *
@@ -34,7 +36,15 @@ public @interface Queue {
 	/**
 	 * @return the queue name or "" for a generated queue name (default).
 	 */
+	@AliasFor("name")
 	String value() default "";
+
+	/**
+	 * @return the queue name or "" for a generated queue name (default).
+	 * @since 2.0
+	 */
+	@AliasFor("value")
+	String name() default "";
 
 	/**
 	 * @return true if the queue is to be declared as durable.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -120,11 +120,26 @@ public @interface RabbitListener {
 	 * The queues for this listener.
 	 * The entries can be 'queue name', 'property-placeholder keys' or 'expressions'.
 	 * Expression must be resolved to the queue name or {@code Queue} object.
-	 * Mutually exclusive with {@link #bindings()}
+	 * The queue(s) must exist, or be otherwise defined elsewhere as a bean(s) with
+	 * a {@link org.springframework.amqp.rabbit.core.RabbitAdmin} in the application
+	 * context.
+	 * Mutually exclusive with {@link #bindings()} and {@link #queuesToDeclare()}.
 	 * @return the queue names or expressions (SpEL) to listen to from target
-	 * {@link org.springframework.amqp.rabbit.listener.MessageListenerContainer}.
+	 * @see org.springframework.amqp.rabbit.listener.MessageListenerContainer
 	 */
 	String[] queues() default {};
+
+	/**
+	 * The queues for this listener.
+	 * If there is a {@link org.springframework.amqp.rabbit.core.RabbitAdmin} in the
+	 * application context, the queue will be declared on the broker with default
+	 * binding (default exchange with the queue name as the routing key).
+	 * Mutually exclusive with {@link #bindings()} and {@link #queues()}.
+	 * @return the queue(s) to declare.
+	 * @see org.springframework.amqp.rabbit.listener.MessageListenerContainer
+	 * @since 2.0
+	 */
+	Queue[] queuesToDeclare() default {};
 
 	/**
 	 * When {@code true}, a single consumer in the container will have exclusive use of the
@@ -148,14 +163,16 @@ public @interface RabbitListener {
 	 * queues and those queues are configured for conditional declaration. This
 	 * is the admin that will (re)declare those queues when the container is
 	 * (re)started. See the reference documentation for more information.
-	  @return the {@link org.springframework.amqp.rabbit.core.RabbitAdmin} bean name.
+	 * @return the {@link org.springframework.amqp.rabbit.core.RabbitAdmin} bean name.
 	 */
 	String admin() default "";
 
 	/**
 	 * Array of {@link QueueBinding}s providing the listener's queue names, together
 	 * with the exchange and optional binding information.
+	 * Mutually exclusive with {@link #queues()} and {@link #queuesToDeclare()}.
 	 * @return the bindings.
+	 * @see org.springframework.amqp.rabbit.listener.MessageListenerContainer
 	 * @since 1.5
 	 */
 	QueueBinding[] bindings() default {};

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -149,7 +149,7 @@ public class EnableRabbitIntegrationTests {
 			"test.converted.args2", "test.converted.message", "test.notconverted.message",
 			"test.notconverted.channel", "test.notconverted.messagechannel", "test.notconverted.messagingmessage",
 			"test.converted.foomessage", "test.notconverted.messagingmessagenotgeneric", "test.simple.direct",
-			"amqp656dlq");
+			"amqp656dlq", "test.simple.declare");
 
 	@Autowired
 	private RabbitTemplate rabbitTemplate;
@@ -204,6 +204,11 @@ public class EnableRabbitIntegrationTests {
 	@Test
 	public void autoDeclare() {
 		assertEquals("FOO", rabbitTemplate.convertSendAndReceive("auto.exch", "auto.rk", "foo"));
+	}
+
+	@Test
+	public void autoSimpleDeclare() {
+		assertEquals("FOOX", rabbitTemplate.convertSendAndReceive("test.simple.declare", "foo"));
 	}
 
 	@Test
@@ -615,6 +620,11 @@ public class EnableRabbitIntegrationTests {
 			return foo.toUpperCase();
 		}
 
+		@RabbitListener(queuesToDeclare = @Queue(name = "${jjjj:test.simple.declare}", durable = "true"))
+		public String handleWithSimpleDeclare(String foo) {
+			return foo.toUpperCase() + "X";
+		}
+
 		@RabbitListener(bindings = @QueueBinding(
 				value = @Queue(value = "auto.declare.fanout", autoDelete = "true"),
 				exchange = @Exchange(value = "auto.exch.fanout", autoDelete = "true", type = "fanout"))
@@ -725,12 +735,12 @@ public class EnableRabbitIntegrationTests {
 		public void handleWithAutoStartFalse(String foo) {
 		}
 
-		@RabbitListener(bindings = {
+		@RabbitListener(id = "headersId", bindings = {
 				@QueueBinding(
-					value = @Queue(value = "auto.headers1", autoDelete = "true",
+					value = @Queue(name = "auto.headers1", autoDelete = "true",
 									arguments = @Argument(name = "x-message-ttl", value = "10000",
 															type = "java.lang.Integer")),
-					exchange = @Exchange(value = "auto.headers", type = ExchangeTypes.HEADERS, autoDelete = "true"),
+					exchange = @Exchange(name = "auto.headers", type = ExchangeTypes.HEADERS, autoDelete = "true"),
 					arguments = {
 							@Argument(name = "x-match", value = "all"),
 							@Argument(name = "foo", value = "bar"),

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1492,7 +1492,7 @@ See <<containerAttributes>>.
 
 ====== Introduction
 
-Starting with _version 1.4_, the easiest way to receive a message asynchronously is to use the annotated listener endpoint infrastructure.
+The easiest way to receive a message asynchronously is to use the annotated listener endpoint infrastructure.
 In a nutshell, it allows you to expose a method of a managed bean as a Rabbit listener endpoint.
 
 [source,java]
@@ -1514,8 +1514,7 @@ The idea of the example above is that, whenever a message is available on the `o
 The annotated endpoint infrastructure creates a message listener container behind the scenes for each annotated method, using a `RabbitListenerContainerFactory`.
 
 In the example above, `myQueue` must already exist and be bound to some exchange.
-Starting with _version 1.5.0_, the queue can be declared and bound automatically, as long as a `RabbitAdmin` exists
-in the application context.
+The queue can be declared and bound automatically, as long as a `RabbitAdmin` exists in the application context.
 
 [source,java]
 ----
@@ -1528,7 +1527,7 @@ public class MyService {
         exchange = @Exchange(value = "auto.exch", ignoreDeclarationExceptions = "true"),
         key = "orderRoutingKey")
   )
-  public void processOrder(String data) {
+  public void processOrder(Order order) {
     ...
   }
 
@@ -1537,8 +1536,13 @@ public class MyService {
         exchange = @Exchange(value = "auto.exch"),
         key = "invoiceRoutingKey")
   )
-  public void processInvoice(String data) {
+  public void processInvoice(Invoice invoice) {
     ...
+  }
+
+  @RabbitListener(queuesToDeclare = @Queue(name = "${my.queue}", durable = "true"))
+  public String handleWithSimpleDeclare(String data) {
+      ...
   }
 
 }
@@ -1548,6 +1552,7 @@ In the first example, a queue `myQueue` will be declared automatically (durable)
 and bound to the exchange with the routing key.
 In the second example, an anonymous (exclusive, auto-delete) queue will be declared and bound.
 Multiple `QueueBinding` entries can be provided, allowing the listener to listen to multiple queues.
+In the third example, a queue with the name retrieved from property `my.queue` will be declared if necessary, with the default binding to the default exchange using the queue name as the routing key.
 
 Only DIRECT, FANOUT, TOPIC and HEADERS, exchange types are supported with this mechanism.
 Use normal `@Bean` definitions when more advanced configuration is required.
@@ -1556,7 +1561,7 @@ Notice `ignoreDeclarationExceptions` on the exchange in the first example.
 This allows, for example, binding to an existing exchange that might have different settings (such as `internal`).
 By default the properties of an existing exchange must match.
 
-Starting with _version 1.6_, you can now specify arguments within `@QueueBinding` annotations for queues, exchanges
+You can also specify arguments within `@QueueBinding` annotations for queues, exchanges
 and bindings. For example:
 
 [source, java]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -44,6 +44,11 @@ The `MissingMessageIdAdvice` is no longer provided; it's functionality is now bu
 By default, `AnonymousQueues` are now named with the default `Base64UrlNamingStrategy` instead of a simple `UUID` string.
 See <<anonymous-queue>> for more information.
 
+===== @RabbitListener Changes
+
+You can now provide simple queue declarations (only bound to the default exchange) in `@RabbitListener` annotations.
+See <<async-annotation-driven>> for more information.
+
 ==== Earlier Releases
 
 See <<previous-whats-new>> for changes in previous versions.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-659

- add `@AliasFor` to `@Queue` and `@Exchange` annotation `value()`
- Support simple queue declaration (no binding)