### PR TITLE
AMQP-655: RabbitTemplate and DirectReply Container

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/service/AmqpInvokerServiceExporter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/service/AmqpInvokerServiceExporter.java
@@ -79,11 +79,12 @@ public class AmqpInvokerServiceExporter extends RemoteInvocationBasedExporter im
 			RemoteInvocation invocation = (RemoteInvocation) invocationRaw;
 			remoteInvocationResult = invokeAndCreateResult(invocation, getService());
 		}
-		send(remoteInvocationResult, replyToAddress);
+		send(remoteInvocationResult, replyToAddress, message);
 	}
 
-	private void send(Object object, Address replyToAddress) {
+	private void send(Object object, Address replyToAddress, Message requestMessage) {
 		Message message = this.messageConverter.toMessage(object, new MessageProperties());
+		message.getMessageProperties().setCorrelationId(requestMessage.getMessageProperties().getCorrelationId());
 
 		getAmqpTemplate().send(replyToAddress.getExchangeName(), replyToAddress.getRoutingKey(), message);
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
@@ -75,6 +75,8 @@ class TemplateParser extends AbstractSingleBeanDefinitionParser {
 
 	private static final String RECOVERY_CALLBACK = "recovery-callback";
 
+	private static final String DIRECT_REPLY_TO_CONTAINER = "direct-reply-to-container";
+
 	@Override
 	protected Class<?> getBeanClass(Element element) {
 		return RabbitTemplate.class;
@@ -124,6 +126,8 @@ class TemplateParser extends AbstractSingleBeanDefinitionParser {
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, CORRELATION_KEY);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, RETRY_TEMPLATE);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, RECOVERY_CALLBACK);
+		NamespaceUtils.setValueIfAttributeDefined(builder, element, DIRECT_REPLY_TO_CONTAINER,
+				"useDirectReplyToContainer");
 
 		BeanDefinition expressionDef =
 				NamespaceUtils.createExpressionDefinitionFromValueOrExpression(MANDATORY_ATTRIBUTE,

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
@@ -1083,6 +1083,8 @@
 						<xsd:documentation><![CDATA[
 	A <listener-container/> used to receive asynchronous replies on the reply-channel the
 	<listener/> child element is disallowed because the template itself is the listener.
+	A 'reply-listener' must not be provided when using Direct reply-to. See 'reply-queue'
+	for more information.
 						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
@@ -1173,7 +1175,7 @@
 					<xsd:documentation><![CDATA[
 	A reference to a <queue/> for replies; optional; if not supplied, methods expecting replies
 	will use a temporary, exclusive, auto-delete queue or, if the RabbitMQ version is 3.4 or higher,
-	using the 'direct reply-to' mechanism. See also 'reply-address'.
+	using the 'direct reply-to' mechanism. See also 'reply-address' and 'direct-reply-to-container'.
 					]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -1181,6 +1183,25 @@
 						</tool:annotation>
 					</xsd:appinfo>
 				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="direct-reply-to-container">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When true (default) direct reply-to will use a 'DirectReplyToMessageListenerContainer' for replies
+	for sendAndReceive() operations, allowing consumers to be reused. Set to 'false' to create (and cancel)
+	a new consumer for each request. Direct reply-to is enbled by leaving the reply-queue as unspecified,
+	or with a value 'amq.rabbitmq.reply-to'; it can only be used with RabbitMQ version 3.4 or higher.
+	A 'reply-listener' child element must not be provided when this is true.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.core.Queue" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
 			</xsd:attribute>
 			<xsd:attribute name="reply-address" type="xsd:string" use="optional">
 				<xsd:annotation>

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
@@ -1193,11 +1193,6 @@
 	or with a value 'amq.rabbitmq.reply-to'; it can only be used with RabbitMQ version 3.4 or higher.
 	A 'reply-listener' child element must not be provided when this is true.
 					]]></xsd:documentation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.amqp.core.Queue" />
-						</tool:annotation>
-					</xsd:appinfo>
 				</xsd:annotation>
 				<xsd:simpleType>
 					<xsd:union memberTypes="xsd:boolean xsd:string" />

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
@@ -65,6 +65,7 @@ public final class TemplateParserTests {
 		assertEquals(Boolean.FALSE, TestUtils.getPropertyValue(template, "mandatoryExpression.value"));
 		assertNull(TestUtils.getPropertyValue(template, "returnCallback"));
 		assertNull(TestUtils.getPropertyValue(template, "confirmCallback"));
+		assertTrue(TestUtils.getPropertyValue(template, "useDirectReplyToContainer", Boolean.class));
 	}
 
 	@Test
@@ -74,6 +75,7 @@ public final class TemplateParserTests {
 		assertEquals("true", TestUtils.getPropertyValue(template, "mandatoryExpression.literalValue"));
 		assertNotNull(TestUtils.getPropertyValue(template, "returnCallback"));
 		assertNotNull(TestUtils.getPropertyValue(template, "confirmCallback"));
+		assertFalse(TestUtils.getPropertyValue(template, "useDirectReplyToContainer", Boolean.class));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateDirectReplyToContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateDirectReplyToContainerIntegrationTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.core;
+
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+
+/**
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class RabbitTemplateDirectReplyToContainerIntegrationTests extends RabbitTemplateIntegrationTests {
+
+	@Override
+	protected RabbitTemplate createSendAndReceiveRabbitTemplate(ConnectionFactory connectionFactory) {
+		RabbitTemplate template = super.createSendAndReceiveRabbitTemplate(connectionFactory);
+		template.setUseDirectReplyToContainer(true);
+		return template;
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -58,7 +58,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.logging.log4j.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -87,7 +86,6 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactoryUtils;
 import org.springframework.amqp.rabbit.connection.ConnectionListener;
 import org.springframework.amqp.rabbit.connection.RabbitResourceHolder;
 import org.springframework.amqp.rabbit.connection.SingleConnectionFactory;
-import org.springframework.amqp.rabbit.listener.BlockingQueueConsumer;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.support.ConsumerCancelledException;
@@ -96,7 +94,6 @@ import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
 import org.springframework.amqp.rabbit.support.PublisherCallbackChannelImpl;
 import org.springframework.amqp.rabbit.test.BrokerRunning;
 import org.springframework.amqp.rabbit.test.BrokerTestUtils;
-import org.springframework.amqp.rabbit.test.Log4jLevelAdjuster;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.amqp.support.postprocessor.GUnzipPostProcessor;
 import org.springframework.amqp.support.postprocessor.GZipPostProcessor;
@@ -156,11 +153,6 @@ public class RabbitTemplateIntegrationTests {
 
 	@Rule
 	public BrokerRunning brokerIsRunning = BrokerRunning.isRunningWithEmptyQueues(ROUTE, REPLY_QUEUE.getName());
-
-	@Rule
-	public Log4jLevelAdjuster adjuster = new Log4jLevelAdjuster(Level.DEBUG,
-			CachingConnectionFactory.class, SimpleMessageListenerContainer.class, BlockingQueueConsumer.class,
-			RabbitTemplate.class, BrokerRunning.class);
 
 	private CachingConnectionFactory connectionFactory;
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -36,10 +36,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import org.springframework.amqp.AmqpAuthenticationException;
+import org.springframework.amqp.core.Address;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.core.ReceiveAndReplyCallback;
@@ -76,6 +79,9 @@ import com.rabbitmq.client.impl.AMQImpl;
  *
  */
 public class RabbitTemplateTests {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
 
 	@Test
 	public void returnConnectionAfterCommit() throws Exception {
@@ -244,6 +250,21 @@ public class RabbitTemplateTests {
 		RabbitTemplate template = new RabbitTemplate(cf);
 		template.convertAndSend("foo");
 		verify(channel).addListener(template);
+	}
+
+	@Test
+	public void testNoListenerAllowed1() {
+		RabbitTemplate template = new RabbitTemplate();
+		this.exception.expect(IllegalStateException.class);
+		template.expectedQueueNames();
+	}
+
+	@Test
+	public void testNoListenerAllowed2() {
+		RabbitTemplate template = new RabbitTemplate();
+		template.setReplyAddress(Address.AMQ_RABBITMQ_REPLY_TO);
+		this.exception.expect(IllegalStateException.class);
+		template.expectedQueueNames();
 	}
 
 	public final static AtomicInteger LOOKUP_KEY_COUNT = new AtomicInteger();

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
@@ -33,6 +33,7 @@
 	</rabbit:queue-arguments>
 
 	<rabbit:template id="withCallbacks" connection-factory="connectionFactory"
+					 direct-reply-to-container="false"
 					 mandatory="true" return-callback="rcb" confirm-callback="ccb"/>
 
 	<rabbit:template id="withMandatoryExpression" connection-factory="connectionFactory"

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2687,6 +2687,12 @@ The decision whether or not to use direct reply-to can be changed to use differe
 `RabbitTemplate` and overriding `useDirectReplyTo()`.
 The method is called once only; when the first request is sent.
 
+With versions earlier than _verion 2.0_, the `RabbitTemplate` created a new consumer for each request and canceled the consumer when the reply was received (or timed out).
+Now, the template uses a `DirectReplyToMessageListenerContainer` instead, allowing the consumers to be reused; the template still takes care of correlating the replies so there is no danger of a late reply going to a different sender.
+If you want to revert to the previous behavior, set property `useDirectReplyToContainer` (`direct-reply-to-container` when using XML configuration) to false.
+
+The `AsynRabbitTemplate` has no such option - it always used a `DirectReplyToContainer` for replies when direct replyTo is being used.
+
 ===== Message Correlation With A Reply Queue
 
 When using a fixed reply queue (other than `amq.rabbitmq.reply-to`), it is necessary to provide correlation data so that replies can be correlated to requests.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -15,6 +15,9 @@ IMPORTANT: Previously, a non-transactional `RabbitTemplate` participated in an e
 This was a serious bug; however, users might have relied on this behavior.
 Starting with _version 1.6.2_, you must set the `channelTransacted` boolean on the template for it to participate in the container transaction.
 
+The `RabbitTemplate` now uses a `DirecyReplyToMessageListenerContainer` (by default) instead of creating a new consumer for each request.
+See <<direct-reply-to>> for more information.
+
 The `AsyncRabbitTemplate` now supports Direct reply-to; see <<async-template>> for more information.
 
 ===== Listener Adapter


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-655

Use a `DirectReplyToMessageListenerContainer` for Direct reply-to by default.

Add an option to revert to previous behavior of creating a new consumer for each
request.

Fix a problem in the `AmqpInvokerServiceExporter` where the correlation id was not
returned.

Fix a test `testSendToMissingExchange` - sometimes we can get a connectio already closed
exception.