### PR TITLE
AMQP-667: Support 'delayed' on `@Exchange`

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeTypes.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeTypes.java
@@ -34,6 +34,4 @@ public abstract class ExchangeTypes {
 
 	public static final String SYSTEM = "system";
 
-	public static final String DELAYED = "x-delayed-message";
-
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Exchange.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Exchange.java
@@ -65,6 +65,7 @@ public @interface Exchange {
 
 	/**
 	 * @return true if the exchange is to be declared as internal.
+	 * @since 1.6
 	 */
 	String internal() default "false";
 
@@ -73,6 +74,14 @@ public @interface Exchange {
 	 * @since 1.6
 	 */
 	String ignoreDeclarationExceptions() default "false";
+
+	/**
+	 * @return true if the exchange is to be declared as an
+	 * 'x-delayed-message' exchange. Requires the delayed message exchange
+	 * plugin on the broker.
+	 * @since 1.6.4
+	 */
+	String delayed() default "false";
 
 	/**
 	 * @return the arguments to apply when declaring this exchange.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -559,6 +559,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 		}
 		AbstractExchange abstractExchange = (AbstractExchange) exchange;
 		abstractExchange.setInternal(resolveExpressionAsBoolean(bindingExchange.internal()));
+		abstractExchange.setDelayed(resolveExpressionAsBoolean(bindingExchange.delayed()));
 		abstractExchange.setIgnoreDeclarationExceptions(resolveExpressionAsBoolean(bindingExchange.ignoreDeclarationExceptions()));
 		((AbstractDeclarable) actualBinding)
 				.setIgnoreDeclarationExceptions(resolveExpressionAsBoolean(binding.ignoreDeclarationExceptions()));

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -36,7 +36,6 @@ import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Declarable;
 import org.springframework.amqp.core.Exchange;
-import org.springframework.amqp.core.ExchangeTypes;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
@@ -88,6 +87,8 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 	 * {@link #getQueueProperties(String)}.
 	 */
 	public static final Object QUEUE_CONSUMER_COUNT = "QUEUE_CONSUMER_COUNT";
+
+	private static final String DELAYED_MESSAGE_EXCHANGE = "x-delayed-message";
 
 	/** Logger available to subclasses */
 	protected final Log logger = LogFactory.getLog(getClass());
@@ -500,7 +501,7 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 							arguments = new HashMap<String, Object>(arguments);
 						}
 						arguments.put("x-delayed-type", exchange.getType());
-						channel.exchangeDeclare(exchange.getName(), ExchangeTypes.DELAYED, exchange.isDurable(),
+						channel.exchangeDeclare(exchange.getName(), DELAYED_MESSAGE_EXCHANGE, exchange.isDurable(),
 								exchange.isAutoDelete(), exchange.isInternal(), arguments);
 					}
 					else {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -444,6 +444,7 @@ public class EnableRabbitIntegrationTests {
 
 		// No type info in message
 		template.setMessageConverter(new SimpleMessageConverter());
+		@SuppressWarnings("resource")
 		MessagePostProcessor messagePostProcessor = message -> {
 			message.getMessageProperties().setContentType("application/json");
 			message.getMessageProperties().setUserId("guest");
@@ -729,7 +730,7 @@ public class EnableRabbitIntegrationTests {
 		@RabbitListener(id = "notStarted", containerFactory = "rabbitAutoStartFalseListenerContainerFactory",
 			bindings = @QueueBinding(
 				value = @Queue(autoDelete = "true", exclusive = "true", durable = "true"),
-				exchange = @Exchange(value = "auto.start", autoDelete = "true"),
+				exchange = @Exchange(value = "auto.start", autoDelete = "true", delayed = "${no.prop:false}"),
 				key = "auto.start")
 		)
 		public void handleWithAutoStartFalse(String foo) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-667

Add `delayed` property to `@Exchange` to support delayed message exchanges with
`@QueueBinding`.

Note: Ran the test locally with `"${no.prop:true}"` - Bamboo and travis don't have
the plugin.

__cherry-pick to 1.6.x__