### PR TITLE
Avoid Synthetic ctors

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/BindingBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/BindingBuilder.java
@@ -180,7 +180,7 @@ public final class BindingBuilder {
 
 		protected final String exchange;
 
-		private AbstractRoutingKeyConfigurer(DestinationConfigurer destination, String exchange) {
+		AbstractRoutingKeyConfigurer(DestinationConfigurer destination, String exchange) {
 			this.destination = destination;
 			this.exchange = exchange;
 		}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/GZipPostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/GZipPostProcessor.java
@@ -52,7 +52,7 @@ public class GZipPostProcessor extends AbstractDeflaterPostProcessor {
 
 	private static final class SettableLevelGZIPOutputStream extends GZIPOutputStream {
 
-		private SettableLevelGZIPOutputStream(OutputStream out, int level) throws IOException {
+		SettableLevelGZIPOutputStream(OutputStream out, int level) throws IOException {
 			super(out);
 			this.def.setLevel(level);
 		}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/ZipPostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/ZipPostProcessor.java
@@ -55,7 +55,7 @@ public class ZipPostProcessor extends AbstractDeflaterPostProcessor {
 
 	private static final class SettableLevelZipOutputStream extends ZipOutputStream {
 
-		private SettableLevelZipOutputStream(OutputStream zipped, int level) {
+		SettableLevelZipOutputStream(OutputStream zipped, int level) {
 			super(zipped);
 			this.setLevel(level);
 		}

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/MarshallingMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/MarshallingMessageConverterTests.java
@@ -85,15 +85,22 @@ public class MarshallingMessageConverterTests {
 
 	private static class TestMarshaller implements Marshaller, Unmarshaller {
 
+		TestMarshaller() {
+			super();
+		}
+
+		@Override
 		public boolean supports(Class<?> clazz) {
 			return true;
 		}
 
+		@Override
 		public void marshal(Object graph, Result result) throws IOException, XmlMappingException {
 			String response = ((String) graph).toUpperCase();
 			((StreamResult) result).getOutputStream().write(response.getBytes());
 		}
 
+		@Override
 		public Object unmarshal(Source source) throws IOException, XmlMappingException {
 			byte[] buffer = new byte["UNMARSHAL TEST".length()];
 			((StreamSource) source).getInputStream().read(buffer);

--- a/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
+++ b/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
@@ -114,6 +114,10 @@ public class RabbitListenerTestHarness extends RabbitListenerAnnotationBeanPostP
 
 		private final BlockingQueue<InvocationData> invocationData = new LinkedBlockingQueue<InvocationData>();
 
+		CaptureAdvice() {
+			super();
+		}
+
 		@Override
 		public Object invoke(MethodInvocation invocation) throws Throwable {
 			Object result = null;

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/mockito/AnswerTests.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/mockito/AnswerTests.java
@@ -44,6 +44,10 @@ public class AnswerTests {
 
 	private static class Foo {
 
+		Foo() {
+			super();
+		}
+
 		public String foo(String foo) {
 			return foo.toUpperCase();
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -714,7 +714,7 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 
 		private volatile RabbitConverterFuture<C> future;
 
-		private CorrelationMessagePostProcessor(MessagePostProcessor userPostProcessor,
+		CorrelationMessagePostProcessor(MessagePostProcessor userPostProcessor,
 				CorrelationData correlationData) {
 			this.userPostProcessor = userPostProcessor;
 			this.correlationData = correlationData;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -726,6 +726,10 @@ public class RabbitListenerAnnotationBeanPostProcessor
 
 		private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
+		RabbitHandlerMethodFactoryAdapter() {
+			super();
+		}
+
 		public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory rabbitHandlerMethodFactory1) {
 			this.messageHandlerMethodFactory = rabbitHandlerMethodFactory1;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilder.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilder.java
@@ -200,9 +200,6 @@ public abstract class RetryInterceptorBuilder<T extends MethodInterceptor> {
 	public abstract T build();
 
 
-	private RetryInterceptorBuilder() {
-	}
-
 	public static final class StatefulRetryInterceptorBuilder extends RetryInterceptorBuilder<StatefulRetryOperationsInterceptor> {
 
 		private final StatefulRetryOperationsInterceptorFactoryBean factoryBean =
@@ -211,6 +208,9 @@ public abstract class RetryInterceptorBuilder<T extends MethodInterceptor> {
 		private MessageKeyGenerator messageKeyGenerator;
 
 		private NewMessageIdentifier newMessageIdentifier;
+
+		StatefulRetryInterceptorBuilder() {
+		}
 
 		/**
 		 * Stateful retry requires messages to be identifiable. Default is to use the message id header; use a custom
@@ -283,9 +283,6 @@ public abstract class RetryInterceptorBuilder<T extends MethodInterceptor> {
 			return this.factoryBean.getObject();
 		}
 
-		private StatefulRetryInterceptorBuilder() {
-		}
-
 	}
 
 
@@ -294,13 +291,13 @@ public abstract class RetryInterceptorBuilder<T extends MethodInterceptor> {
 		private final StatelessRetryOperationsInterceptorFactoryBean factoryBean =
 				new StatelessRetryOperationsInterceptorFactoryBean();
 
+		StatelessRetryInterceptorBuilder() {
+		}
+
 		@Override
 		public RetryOperationsInterceptor build() {
 			this.applyCommonSettings(this.factoryBean);
 			return this.factoryBean.getObject();
-		}
-
-		private StatelessRetryInterceptorBuilder() {
 		}
 
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilder.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilder.java
@@ -292,6 +292,7 @@ public abstract class RetryInterceptorBuilder<T extends MethodInterceptor> {
 				new StatelessRetryOperationsInterceptorFactoryBean();
 
 		StatelessRetryInterceptorBuilder() {
+			super();
 		}
 
 		@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatefulRetryOperationsInterceptorFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatefulRetryOperationsInterceptorFactoryBean.java
@@ -25,9 +25,6 @@ import org.springframework.amqp.rabbit.retry.MessageKeyGenerator;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.rabbit.retry.NewMessageIdentifier;
 import org.springframework.retry.RetryOperations;
-import org.springframework.retry.interceptor.MethodArgumentsKeyGenerator;
-import org.springframework.retry.interceptor.MethodInvocationRecoverer;
-import org.springframework.retry.interceptor.NewMethodArgumentsIdentifier;
 import org.springframework.retry.interceptor.StatefulRetryOperationsInterceptor;
 import org.springframework.retry.support.RetryTemplate;
 
@@ -65,6 +62,7 @@ public class StatefulRetryOperationsInterceptorFactoryBean extends AbstractRetry
 		this.newMessageIdentifier = newMessageIdentifier;
 	}
 
+	@Override
 	public StatefulRetryOperationsInterceptor getObject() {
 
 		StatefulRetryOperationsInterceptor retryInterceptor = new StatefulRetryOperationsInterceptor();
@@ -74,48 +72,42 @@ public class StatefulRetryOperationsInterceptorFactoryBean extends AbstractRetry
 		}
 		retryInterceptor.setRetryOperations(retryTemplate);
 
-		retryInterceptor.setNewItemIdentifier(new NewMethodArgumentsIdentifier() {
-			public boolean isNew(Object[] args) {
-				Message message = (Message) args[1];
-				if (StatefulRetryOperationsInterceptorFactoryBean.this.newMessageIdentifier == null) {
-					return !message.getMessageProperties().isRedelivered();
-				}
-				else {
-					return StatefulRetryOperationsInterceptorFactoryBean.this.newMessageIdentifier.isNew(message);
-				}
+		retryInterceptor.setNewItemIdentifier(args -> {
+			Message message = (Message) args[1];
+			if (StatefulRetryOperationsInterceptorFactoryBean.this.newMessageIdentifier == null) {
+				return !message.getMessageProperties().isRedelivered();
+			}
+			else {
+				return StatefulRetryOperationsInterceptorFactoryBean.this.newMessageIdentifier.isNew(message);
 			}
 		});
 
 		final MessageRecoverer messageRecoverer = getMessageRecoverer();
-		retryInterceptor.setRecoverer(new MethodInvocationRecoverer<Void>() {
-			public Void recover(Object[] args, Throwable cause) {
-				Message message = (Message) args[1];
-				if (messageRecoverer == null) {
-					logger.warn("Message dropped on recovery: " + message, cause);
-				}
-				else {
-					messageRecoverer.recover(message, cause);
-				}
-				// This is actually a normal outcome. It means the recovery was successful, but we don't want to consume
-				// any more messages until the acks and commits are sent for this (problematic) message...
-				throw new ImmediateAcknowledgeAmqpException("Recovered message forces ack (if ack mode requires it): "
-						+ message, cause);
+		retryInterceptor.setRecoverer((args, cause) -> {
+			Message message = (Message) args[1];
+			if (messageRecoverer == null) {
+				logger.warn("Message dropped on recovery: " + message, cause);
 			}
+			else {
+				messageRecoverer.recover(message, cause);
+			}
+			// This is actually a normal outcome. It means the recovery was successful, but we don't want to consume
+			// any more messages until the acks and commits are sent for this (problematic) message...
+			throw new ImmediateAcknowledgeAmqpException("Recovered message forces ack (if ack mode requires it): "
+					+ message, cause);
 		});
 
-		retryInterceptor.setKeyGenerator(new MethodArgumentsKeyGenerator() {
-			public Object getKey(Object[] args) {
-				Message message = (Message) args[1];
-				if (StatefulRetryOperationsInterceptorFactoryBean.this.messageKeyGenerator == null) {
-					String messageId = message.getMessageProperties().getMessageId();
-					if (messageId == null && message.getMessageProperties().isRedelivered()) {
-						message.getMessageProperties().setFinalRetryForMessageWithNoId(true);
-					}
-					return messageId;
+		retryInterceptor.setKeyGenerator(args -> {
+			Message message = (Message) args[1];
+			if (StatefulRetryOperationsInterceptorFactoryBean.this.messageKeyGenerator == null) {
+				String messageId = message.getMessageProperties().getMessageId();
+				if (messageId == null && message.getMessageProperties().isRedelivered()) {
+					message.getMessageProperties().setFinalRetryForMessageWithNoId(true);
 				}
-				else {
-					return StatefulRetryOperationsInterceptorFactoryBean.this.messageKeyGenerator.getKey(message);
-				}
+				return messageId;
+			}
+			else {
+				return StatefulRetryOperationsInterceptorFactoryBean.this.messageKeyGenerator.getKey(message);
 			}
 		});
 
@@ -123,6 +115,7 @@ public class StatefulRetryOperationsInterceptorFactoryBean extends AbstractRetry
 
 	}
 
+	@Override
 	public Class<?> getObjectType() {
 		return StatefulRetryOperationsInterceptor.class;
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptorFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptorFactoryBean.java
@@ -22,7 +22,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.retry.RetryOperations;
-import org.springframework.retry.interceptor.MethodInvocationRecoverer;
 import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 import org.springframework.retry.support.RetryTemplate;
 
@@ -46,6 +45,7 @@ public class StatelessRetryOperationsInterceptorFactoryBean extends AbstractRetr
 
 	private static Log logger = LogFactory.getLog(StatelessRetryOperationsInterceptorFactoryBean.class);
 
+	@Override
 	public RetryOperationsInterceptor getObject() {
 
 		RetryOperationsInterceptor retryInterceptor = new RetryOperationsInterceptor();
@@ -56,23 +56,22 @@ public class StatelessRetryOperationsInterceptorFactoryBean extends AbstractRetr
 		retryInterceptor.setRetryOperations(retryTemplate);
 
 		final MessageRecoverer messageRecoverer = getMessageRecoverer();
-		retryInterceptor.setRecoverer(new MethodInvocationRecoverer<Void>() {
-			public Void recover(Object[] args, Throwable cause) {
-				Message message = (Message) args[1];
-				if (messageRecoverer == null) {
-					logger.warn("Message dropped on recovery: " + message, cause);
-				}
-				else {
-					messageRecoverer.recover(message, cause);
-				}
-				return null;
+		retryInterceptor.setRecoverer((args, cause) -> {
+			Message message = (Message) args[1];
+			if (messageRecoverer == null) {
+				logger.warn("Message dropped on recovery: " + message, cause);
 			}
+			else {
+				messageRecoverer.recover(message, cause);
+			}
+			return null;
 		});
 
 		return retryInterceptor;
 
 	}
 
+	@Override
 	public Class<?> getObjectType() {
 		return RetryOperationsInterceptor.class;
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -847,7 +847,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 		private final boolean transactional;
 
-		private CachedChannelInvocationHandler(ChannelCachingConnectionProxy connection,
+		CachedChannelInvocationHandler(ChannelCachingConnectionProxy connection,
 				Channel target,
 				LinkedList<ChannelProxy> channelList,
 				boolean transactional) {
@@ -1022,34 +1022,29 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 							? getExecutorService()
 							: CachingConnectionFactory.this.deferredCloseExecutor);
 					final Channel channel = CachedChannelInvocationHandler.this.target;
-					executorService.execute(new Runnable() {
-
-						@Override
-						public void run() {
-							try {
-								if (CachingConnectionFactory.this.publisherConfirms) {
-									channel.waitForConfirmsOrDie(5000);
-								}
-								else {
-									Thread.sleep(5000);
-								}
+					executorService.execute(() -> {
+						try {
+							if (CachingConnectionFactory.this.publisherConfirms) {
+								channel.waitForConfirmsOrDie(5000);
 							}
-							catch (InterruptedException e) {
-								Thread.currentThread().interrupt();
-							}
-							catch (Exception e) { }
-							finally {
-								try {
-									if (channel.isOpen()) {
-										channel.close();
-									}
-								}
-								catch (IOException e) { }
-								catch (AlreadyClosedException e) { }
-								catch (TimeoutException e) { }
+							else {
+								Thread.sleep(5000);
 							}
 						}
-
+						catch (InterruptedException e1) {
+							Thread.currentThread().interrupt();
+						}
+						catch (Exception e2) { }
+						finally {
+							try {
+								if (channel.isOpen()) {
+									channel.close();
+								}
+							}
+							catch (IOException e3) { }
+							catch (AlreadyClosedException e4) { }
+							catch (TimeoutException e5) { }
+						}
 					});
 				}
 				else {
@@ -1074,7 +1069,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 		private final AtomicBoolean closeNotified = new AtomicBoolean(false);
 
-		private ChannelCachingConnectionProxy(Connection target) {
+		ChannelCachingConnectionProxy(Connection target) {
 			this.target = target;
 		}
 
@@ -1183,6 +1178,10 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	 * @since 1.5
 	 */
 	private static class DefaultChannelCloseLogger implements ConditionalExceptionLogger {
+
+		DefaultChannelCloseLogger() {
+			super();
+		}
 
 		@Override
 		public void log(Log logger, String message, Throwable t) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -248,7 +248,7 @@ public final class ConnectionFactoryUtils {
 
 		private final RabbitResourceHolder resourceHolder;
 
-		private RabbitResourceSynchronization(RabbitResourceHolder resourceHolder, Object resourceKey) {
+		RabbitResourceSynchronization(RabbitResourceHolder resourceHolder, Object resourceKey) {
 			super(resourceHolder, resourceKey);
 			this.resourceHolder = resourceHolder;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConsumerChannelRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConsumerChannelRegistry.java
@@ -109,7 +109,7 @@ public final class ConsumerChannelRegistry {
 
 		private final ConnectionFactory connectionFactory;
 
-		private ChannelHolder(Channel channel, ConnectionFactory connectionFactory) {
+		ChannelHolder(Channel channel, ConnectionFactory connectionFactory) {
 			this.channel = channel;
 			this.connectionFactory = connectionFactory;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplate.java
@@ -76,13 +76,7 @@ public class BatchingRabbitTemplate extends RabbitTemplate implements Lifecycle 
 			}
 			Date next = this.batchingStrategy.nextRelease();
 			if (next != null) {
-				this.scheduledTask = this.scheduler.schedule(new Runnable() {
-
-					@Override
-					public void run() {
-						releaseBatches();
-					}
-				}, next);
+				this.scheduledTask = this.scheduler.schedule((Runnable) () -> releaseBatches(), next);
 			}
 		}
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1539,6 +1539,10 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 */
 	private static class DefaultExclusiveConsumerLogger implements ConditionalExceptionLogger {
 
+		DefaultExclusiveConsumerLogger() {
+			super();
+		}
+
 		@Override
 		public void log(Log logger, String message, Throwable t) {
 			if (t instanceof ShutdownSignalException) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -715,7 +715,7 @@ public class BlockingQueueConsumer {
 
 	private final class InternalConsumer extends DefaultConsumer {
 
-		private InternalConsumer(Channel channel) {
+		InternalConsumer(Channel channel) {
 			super(channel);
 		}
 
@@ -828,7 +828,7 @@ public class BlockingQueueConsumer {
 	@SuppressWarnings("serial")
 	private static final class DeclarationException extends AmqpException {
 
-		private DeclarationException() {
+		DeclarationException() {
 			super("Failed to declare queue(s):");
 		}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistrar.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistrar.java
@@ -200,7 +200,8 @@ public class RabbitListenerEndpointRegistrar implements BeanFactoryAware, Initia
 
 		private final RabbitListenerContainerFactory<?> containerFactory;
 
-		private AmqpListenerEndpointDescriptor(RabbitListenerEndpoint endpoint, RabbitListenerContainerFactory<?> containerFactory) {
+		AmqpListenerEndpointDescriptor(RabbitListenerEndpoint endpoint,
+				RabbitListenerContainerFactory<?> containerFactory) {
 			this.endpoint = endpoint;
 			this.containerFactory = containerFactory;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
@@ -288,7 +288,7 @@ public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLife
 
 		private final Runnable finishCallback;
 
-		private AggregatingCallback(int count, Runnable finishCallback) {
+		AggregatingCallback(int count, Runnable finishCallback) {
 			this.count = new AtomicInteger(count);
 			this.finishCallback = finishCallback;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -190,7 +190,7 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 
 		private final Type inferredArgumentType;
 
-		private MessagingMessageConverterAdapter(Object bean, Method method) {
+		MessagingMessageConverterAdapter(Object bean, Method method) {
 			this.bean = bean;
 			this.method = method;
 			this.inferredArgumentType = determineInferredType();

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.java
@@ -112,12 +112,14 @@ public class RabbitTransactionManager extends AbstractPlatformTransactionManager
 	/**
 	 * Make sure the ConnectionFactory has been set.
 	 */
+	@Override
 	public void afterPropertiesSet() {
 		if (getConnectionFactory() == null) {
 			throw new IllegalArgumentException("Property 'connectionFactory' is required");
 		}
 	}
 
+	@Override
 	public Object getResourceFactory() {
 		return getConnectionFactory();
 	}
@@ -215,6 +217,10 @@ public class RabbitTransactionManager extends AbstractPlatformTransactionManager
 
 		private RabbitResourceHolder resourceHolder;
 
+		RabbitTransactionObject() {
+			super();
+		}
+
 		public void setResourceHolder(RabbitResourceHolder resourceHolder) {
 			this.resourceHolder = resourceHolder;
 		}
@@ -223,10 +229,12 @@ public class RabbitTransactionManager extends AbstractPlatformTransactionManager
 			return this.resourceHolder;
 		}
 
+		@Override
 		public boolean isRollbackOnly() {
 			return this.resourceHolder.isRollbackOnly();
 		}
 
+		@Override
 		public void flush() {
 			// no-op
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryIntegrationTests.java
@@ -131,6 +131,10 @@ public class RabbitListenerContainerFactoryIntegrationTests {
 
 	private static class UpperCaseMessageConverter implements MessageConverter {
 
+		UpperCaseMessageConverter() {
+			super();
+		}
+
 		@Override
 		public Message toMessage(Object object, MessageProperties messageProperties) throws MessageConversionException {
 			return new Message(object.toString().toUpperCase().getBytes(), new MessageProperties());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilderSupportTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilderSupportTests.java
@@ -247,14 +247,9 @@ public class RetryInterceptorBuilderSupportTests {
 	}
 
 	private Foo createDelegate(MethodInterceptor interceptor, final AtomicInteger count) {
-		Foo delegate = new Foo() {
-
-			@Override
-			public void onMessage(String s, Message message) {
-				count.incrementAndGet();
-				throw new RuntimeException("foo", new RuntimeException("bar"));
-			}
-
+		Foo delegate = (s, message) -> {
+			count.incrementAndGet();
+			throw new RuntimeException("foo", new RuntimeException("bar"));
 		};
 		ProxyFactory factory = new ProxyFactory();
 		factory.addAdvisor(new DefaultPointcutAdvisor(Pointcut.TRUE, interceptor));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -362,21 +362,13 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.setChannelCheckoutTimeout(10);
 		ccf.setCacheMode(mode);
 
-		ccf.addConnectionListener(new ConnectionListener() { // simulate admin
-
-			@Override
-			public void onCreate(Connection connection) {
-				try {
-					connection.createChannel(false).close();
-				}
-				catch (Exception e) {
-					fail(e.getMessage());
-				}
+		ccf.addConnectionListener(connection -> {
+			try {
+				 // simulate admin
+				connection.createChannel(false).close();
 			}
-
-			@Override
-			public void onClose(Connection connection) {
-				// empty
+			catch (Exception e) {
+				fail(e.getMessage());
 			}
 		});
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePerformanceIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePerformanceIntegrationTests.java
@@ -131,6 +131,10 @@ public class RabbitTemplatePerformanceIntegrationTests {
 	@SuppressWarnings("serial")
 	private class TestTransactionManager extends AbstractPlatformTransactionManager {
 
+		TestTransactionManager() {
+			super();
+		}
+
 		@Override
 		protected void doBegin(Object transaction, TransactionDefinition definition) throws TransactionException {
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryRepeatIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryRepeatIntegrationTests.java
@@ -175,6 +175,10 @@ public class MessageListenerRecoveryRepeatIntegrationTests {
 
 		private CountDownLatch latch;
 
+		CloseConnectionListener() {
+			super();
+		}
+
 		public void setLatch(CountDownLatch latch) {
 			this.latch = latch;
 			failed.set(false);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -580,10 +580,18 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 	@SuppressWarnings("serial")
 	private static final class Foo implements Serializable {
 
+		Foo() {
+			super();
+		}
+
 	}
 
 	@SuppressWarnings("serial")
 	private static final class Bar implements Serializable {
+
+		Bar() {
+			super();
+		}
 
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
@@ -409,6 +409,10 @@ public class SimpleMessageListenerContainerIntegrationTests {
 	@SuppressWarnings("serial")
 	private class TestTransactionManager extends AbstractPlatformTransactionManager {
 
+		TestTransactionManager() {
+			super();
+		}
+
 		@Override
 		protected void doBegin(Object transaction, TransactionDefinition definition) throws TransactionException {
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerWithRabbitMQ.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerWithRabbitMQ.java
@@ -112,6 +112,10 @@ public final class SimpleMessageListenerWithRabbitMQ {
 
 	private static class SimpleAdapter {
 
+		SimpleAdapter() {
+			super();
+		}
+
 		@SuppressWarnings("unused")
 		public void handleMessage(String input) {
 			logger.debug("Got it: " + input);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -175,6 +175,10 @@ public class MessagingMessageListenerAdapterTests {
 
 		private Object payload;
 
+		SampleBean() {
+			super();
+		}
+
 		@SuppressWarnings("unused")
 		public Message<String> echo(Message<String> input) {
 			return MessageBuilder.withPayload(input.getPayload())

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/RabbitMatchers.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/RabbitMatchers.java
@@ -39,7 +39,7 @@ public final class RabbitMatchers {
 
 		private final String pattern;
 
-		private RegexMatcher(String pattern) {
+		RegexMatcher(String pattern) {
 			this.pattern = pattern;
 		}
 


### PR DESCRIPTION
Private inner classes with a private ctor (real or implied) cause the compiler
to generate synthetic package-visibility ctors, with a synthetic class parameter if needed.

Also a few more lambdas.