### PR TITLE
chore: primitive long in ActiveObjectCounter.await()

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ActiveObjectCounter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ActiveObjectCounter.java
@@ -43,7 +43,7 @@ public class ActiveObjectCounter<T> {
 		}
 	}
 
-	public boolean await(Long timeout, TimeUnit timeUnit) throws InterruptedException {
+	public boolean await(long timeout, TimeUnit timeUnit) throws InterruptedException {
 		long t0 = System.currentTimeMillis();
 		long t1 = t0 + TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
 		while (System.currentTimeMillis() <= t1) {


### PR DESCRIPTION
There is no need to pass timeout as object Long here, looks like a typo.