### PR TITLE
AMQP-672: SMLC: Support Start with No Queues

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -269,7 +269,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	protected String[] getRequiredQueueNames() {
 		Assert.state(this.queueNames.size() > 0, "Queue names must not be empty.");
-		return this.getQueueNames();
+		return getQueueNames();
 	}
 
 	protected Set<String> getQueueNamesAsSet() {
@@ -308,19 +308,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	public boolean removeQueueNames(String... queueNames) {
 		Assert.notNull(queueNames, "'queueNames' cannot be null");
 		Assert.noNullElements(queueNames, "'queueNames' cannot contain null elements");
-		Assert.isTrue(canRemoveLastQueue() || this.queueNames.size() - queueNames.length > 0,
-				"Cannot remove the last queue");
 		return this.queueNames.removeAll(Arrays.asList(queueNames));
-	}
-
-	/**
-	 * Subclasses can override this method if they allow running with zero configured
-	 * queues.
-	 * @return true to allow removal of the last queue.
-	 * @since 2.0
-	 */
-	protected boolean canRemoveLastQueue() {
-		return false;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AsyncConsumerRestartedEvent.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AsyncConsumerRestartedEvent.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import org.springframework.amqp.event.AmqpEvent;
+
+/**
+ * An event that is published whenever a consumer is restarted.
+ *
+ * @author Gary Russell
+ * @since 1.7
+ *
+ */
+@SuppressWarnings("serial")
+public class AsyncConsumerRestartedEvent extends AmqpEvent {
+
+	private final Object oldConsumer;
+
+	private final Object newConsumer;
+
+	/**
+	 * @param source the listener container.
+	 * @param oldConsumer the old consumer.
+	 * @param newConsumer the new consumer.
+	 */
+	public AsyncConsumerRestartedEvent(Object source, Object oldConsumer, Object newConsumer) {
+		super(source);
+		this.oldConsumer = oldConsumer;
+		this.newConsumer = newConsumer;
+	}
+
+	public Object getOldConsumer() {
+		return this.oldConsumer;
+	}
+
+	public Object getNewConsumer() {
+		return this.newConsumer;
+	}
+
+	@Override
+	public String toString() {
+		return "AsyncConsumerRestartedEvent [oldConsumer=" + this.oldConsumer + ", newConsumer=" + this.newConsumer
+				+ ", container=" + this.getSource() + "]";
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AsyncConsumerStartedEvent.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AsyncConsumerStartedEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import org.springframework.amqp.event.AmqpEvent;
+
+/**
+ * An event that is published whenever a new consumer is started.
+ *
+ * @author Gary Russell
+ * @since 1.7
+ *
+ */
+@SuppressWarnings("serial")
+public class AsyncConsumerStartedEvent extends AmqpEvent {
+
+	private final Object consumer;
+
+	/**
+	 * @param source the listener container.
+	 * @param consumer the old consumer.
+	 */
+	public AsyncConsumerStartedEvent(Object source, Object consumer) {
+		super(source);
+		this.consumer = consumer;
+	}
+
+	public Object getConsumer() {
+		return this.consumer;
+	}
+
+	@Override
+	public String toString() {
+		return "AsyncConsumerStartedEvent [consumer=" + this.consumer
+				+ ", container=" + this.getSource() + "]";
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AsyncConsumerStoppedEvent.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AsyncConsumerStoppedEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import org.springframework.amqp.event.AmqpEvent;
+
+/**
+ * An event that is published whenever a consumer is stopped (and not restarted).
+ *
+ * @author Gary Russell
+ * @since 1.7
+ *
+ */
+@SuppressWarnings("serial")
+public class AsyncConsumerStoppedEvent extends AmqpEvent {
+
+	private final Object consumer;
+
+	/**
+	 * @param source the listener container.
+	 * @param consumer the old consumer.
+	 */
+	public AsyncConsumerStoppedEvent(Object source, Object consumer) {
+		super(source);
+		this.consumer = consumer;
+	}
+
+	public Object getConsumer() {
+		return this.consumer;
+	}
+
+	@Override
+	public String toString() {
+		return "AsyncConsumerStoppedEvent [consumer=" + this.consumer
+				+ ", container=" + this.getSource() + "]";
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -54,6 +54,7 @@ import org.springframework.amqp.rabbit.support.ConsumerCancelledException;
 import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
 import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
 import org.springframework.amqp.support.ConsumerTagStrategy;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.backoff.BackOffExecution;
 
 import com.rabbitmq.client.AMQP;
@@ -235,7 +236,7 @@ public class BlockingQueueConsumer {
 			this.consumerArgs.putAll(consumerArgs);
 		}
 		this.exclusive = exclusive;
-		this.queues = queues;
+		this.queues = Arrays.copyOf(queues, queues.length);
 		this.queue = new LinkedBlockingQueue<Delivery>(prefetchCount);
 	}
 
@@ -301,6 +302,14 @@ public class BlockingQueueConsumer {
 
 	public BackOffExecution getBackOffExecution() {
 		return this.backOffExecution;
+	}
+
+	/**
+	 * Return the size the queues array.
+	 * @return the count.
+	 */
+	int getQueueCount() {
+		return this.queues.length;
 	}
 
 	protected void basicCancel() {
@@ -709,7 +718,8 @@ public class BlockingQueueConsumer {
 
 	@Override
 	public String toString() {
-		return "Consumer: tags=[" + (this.consumerTags.toString()) + "], channel=" + this.channel
+		return "Consumer@" + ObjectUtils.getIdentityHexString(this) + ": "
+				+ "tags=[" + (this.consumerTags.toString()) + "], channel=" + this.channel
 				+ ", acknowledgeMode=" + this.acknowledgeMode + " local queue size=" + this.queue.size();
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -261,11 +261,6 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		}
 	}
 
-	@Override
-	protected boolean canRemoveLastQueue() {
-		return true;
-	}
-
 	private void adjustConsumers(int newCount) {
 		synchronized (this.consumersMonitor) {
 			checkStartState();

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -487,6 +487,9 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				AsyncMessageProcessingConsumer processor = new AsyncMessageProcessingConsumer(consumer);
 				processors.add(processor);
 				getTaskExecutor().execute(processor);
+				if (getApplicationEventPublisher() != null) {
+					getApplicationEventPublisher().publishEvent(new AsyncConsumerStartedEvent(this, consumer));
+				}
 			}
 			for (AsyncMessageProcessingConsumer processor : processors) {
 				FatalListenerStartupException startupException = processor.getStartupException();
@@ -593,6 +596,9 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 						logger.debug("Starting a new consumer: " + consumer);
 					}
 					getTaskExecutor().execute(processor);
+					if (this.getApplicationEventPublisher() != null) {
+						this.getApplicationEventPublisher().publishEvent(new AsyncConsumerStartedEvent(this, consumer));
+					}
 					try {
 						FatalListenerStartupException startupException = processor.getStartupException();
 						if (startupException != null) {
@@ -664,7 +670,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	protected BlockingQueueConsumer createBlockingQueueConsumer() {
 		BlockingQueueConsumer consumer;
-		String[] queues = getRequiredQueueNames();
+		String[] queues = getQueueNames();
 		// There's no point prefetching less than the tx size, otherwise the consumer will stall because the broker
 		// didn't get an ack for delivered messages
 		int actualPrefetchCount = getPrefetchCount() > this.txSize ? getPrefetchCount() : this.txSize;
@@ -688,7 +694,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		return consumer;
 	}
 
-	private void restart(BlockingQueueConsumer consumer) {
+	private void restart(BlockingQueueConsumer oldConsumer) {
+		BlockingQueueConsumer consumer = oldConsumer;
 		synchronized (this.consumersMonitor) {
 			if (this.consumers != null) {
 				try {
@@ -703,6 +710,10 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					newConsumer.setBackOffExecution(consumer.getBackOffExecution());
 					consumer = newConsumer;
 					this.consumers.put(consumer, true);
+					if (getApplicationEventPublisher() != null) {
+						getApplicationEventPublisher()
+								.publishEvent(new AsyncConsumerRestartedEvent(this, oldConsumer, newConsumer));
+					}
 				}
 				catch (RuntimeException e) {
 					logger.warn("Consumer failed irretrievably on restart. " + e.getClass() + ": " + e.getMessage());
@@ -849,6 +860,19 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			int consecutiveIdles = 0;
 
 			int consecutiveMessages = 0;
+
+			if (this.consumer.getQueueCount() < 1) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Consumer stopping; no queues for " + this.consumer);
+				}
+				SimpleMessageListenerContainer.this.cancellationLock.release(this.consumer);
+				if (getApplicationEventPublisher() != null) {
+					getApplicationEventPublisher().publishEvent(
+							new AsyncConsumerStoppedEvent(SimpleMessageListenerContainer.this, this.consumer));
+				}
+				this.start.countDown();
+				return;
+			}
 
 			try {
 
@@ -1017,6 +1041,10 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 						if (SimpleMessageListenerContainer.this.consumers != null) {
 							SimpleMessageListenerContainer.this.consumers.remove(this.consumer);
 						}
+					}
+					if (getApplicationEventPublisher() != null) {
+						getApplicationEventPublisher().publishEvent(
+								new AsyncConsumerStoppedEvent(SimpleMessageListenerContainer.this, this.consumer));
 					}
 				}
 				catch (AmqpException e) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-672

Also add events for consumer start/stop/restart.

Stop consumer immediately if no queues.

Conflicts:
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplateTests.java
Resolved.

Removed redundant `canRemoveLastQueue()` method from AMLC.