### PR TITLE
Fix Test Race Condition

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/ConsumeOkNotReceivedException.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/ConsumeOkNotReceivedException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.core;
+
+import org.springframework.amqp.AmqpException;
+
+/**
+ * Thrown when a blocking receive operation is performed but the consumeOk
+ * was not received before the receive timeout. Consider increasing the
+ * receive timeout.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+@SuppressWarnings("serial")
+public class ConsumeOkNotReceivedException extends AmqpException {
+
+	public ConsumeOkNotReceivedException(String message) {
+		super(message);
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1858,8 +1858,8 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			if (channel instanceof ChannelProxy) {
 				((ChannelProxy) channel).getTargetChannel().close();
 			}
-			future.completeExceptionally(new AmqpException("Blocking receive, consumer failed to consume: "
-					+ consumer));
+			future.completeExceptionally(
+					new ConsumeOkNotReceivedException("Blocking receive, consumer failed to consume: " + consumer));
 		}
 		return consumer;
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -966,7 +966,12 @@ public class RabbitTemplateIntegrationTests {
 		if (timeout > 0) {
 			this.template.setReceiveTimeout(1);
 		}
-		received = this.template.receiveAndReply(message -> message);
+		try {
+			received = this.template.receiveAndReply(message -> message);
+		}
+		catch (ConsumeOkNotReceivedException e) {
+			// we're expecting no result, this could happen, depending on timing.
+		}
 		assertFalse(received);
 
 		this.template.convertAndSend(ROUTE, "test");


### PR DESCRIPTION
https://build.spring.io/browse/AMQP-SONAR-1671/

With a receive timeout of only 1ms, we might not get a consumeOk.