### PR TITLE
AMQP-676: @RabbitListener Improvements

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/AmqpRemoteException.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/AmqpRemoteException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp;
+
+/**
+ * An exception that wraps an exception thrown by the server in a
+ * request/reply scenario.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+@SuppressWarnings("serial")
+public class AmqpRemoteException extends AmqpException {
+
+	public AmqpRemoteException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/RemoteInvocationAwareMessageConverterAdapter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/RemoteInvocationAwareMessageConverterAdapter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support.converter;
+
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.remoting.support.RemoteInvocationResult;
+import org.springframework.util.Assert;
+
+/**
+ * A delegating adapter that unwraps {@link RemoteInvocationResult} after invoking
+ * the delegate to convert from a message.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class RemoteInvocationAwareMessageConverterAdapter implements MessageConverter, BeanClassLoaderAware {
+
+	private final SimpleMessageConverter defaultMessageConverter = new SimpleMessageConverter();
+
+	private final MessageConverter delegate;
+
+	public RemoteInvocationAwareMessageConverterAdapter() {
+		this.delegate = this.defaultMessageConverter;
+	}
+
+	public RemoteInvocationAwareMessageConverterAdapter(MessageConverter delegate) {
+		Assert.notNull(delegate, "'delegate' converter cannot be null");
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		this.defaultMessageConverter.setBeanClassLoader(classLoader);
+	}
+
+	@Override
+	public Message toMessage(Object object, MessageProperties messageProperties) throws MessageConversionException {
+		return this.delegate.toMessage(object, messageProperties);
+	}
+
+	@Override
+	public Object fromMessage(Message message) throws MessageConversionException {
+		Object result = this.delegate.fromMessage(message);
+		if (result instanceof RemoteInvocationResult) {
+			try {
+				result = ((RemoteInvocationResult) result).recreate();
+			}
+			catch (Throwable e) {
+				throw new AmqpException(e);
+			}
+		}
+		return result;
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/RemoteInvocationAwareMessageConverterAdapter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/RemoteInvocationAwareMessageConverterAdapter.java
@@ -26,6 +26,7 @@ import org.springframework.util.Assert;
 /**
  * A delegating adapter that unwraps {@link RemoteInvocationResult} after invoking
  * the delegate to convert from a message.
+ * Delegates to a {@link SimpleMessageConverter} by default.
  *
  * @author Gary Russell
  * @since 2.0

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -187,4 +187,21 @@ public @interface RabbitListener {
 	 */
 	String group() default "";
 
+	/**
+	 * Set to true to cause exceptions thrown by the listener to be sent to the sender
+	 * using normal {@code replyTo/@SendTo} semantics. When false, the exception is thrown
+	 * to the listener container and normal retry/DLQ processing is performed.
+	 * @return true to propagate exceptions.
+	 * @since 2.0
+	 */
+	String propagateExceptions() default "";
+
+	/**
+	 * Set an {@link RabbitListenerErrorHandler} to invoke if the listener method throws
+	 * an exception.
+	 * @return the error handler.
+	 * @since 2.0
+	 */
+	String errorHandler() default "";
+
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -188,13 +188,16 @@ public @interface RabbitListener {
 	String group() default "";
 
 	/**
-	 * Set to true to cause exceptions thrown by the listener to be sent to the sender
+	 * Set to "true" to cause exceptions thrown by the listener to be sent to the sender
 	 * using normal {@code replyTo/@SendTo} semantics. When false, the exception is thrown
 	 * to the listener container and normal retry/DLQ processing is performed.
-	 * @return true to propagate exceptions.
+	 * @return true to return exceptions. If the client side uses a
+	 * {@code RemoteInvocationAwareMessageConverterAdapter} the exception will be re-thrown.
+	 * Otherwise, the sender will receive a {@code RemoteInvocationResult} wrapping the
+	 * exception.
 	 * @since 2.0
 	 */
-	String propagateExceptions() default "";
+	String returnExceptions() default "";
 
 	/**
 	 * Set an {@link RabbitListenerErrorHandler} to invoke if the listener method throws

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -330,7 +330,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
 		endpoint.setMethod(methodToUse);
 		endpoint.setBeanFactory(this.beanFactory);
-		endpoint.setPropagateExceptions(resolveExpressionAsBoolean(rabbitListener.propagateExceptions()));
+		endpoint.setReturnExceptions(resolveExpressionAsBoolean(rabbitListener.returnExceptions()));
 		String errorHandlerBeanName = resolveExpressionAsString(rabbitListener.errorHandler(), "errorHandler");
 		if (StringUtils.hasText(errorHandlerBeanName)) {
 			endpoint.setErrorHandler(this.beanFactory.getBean(errorHandlerBeanName, RabbitListenerErrorHandler.class));

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -330,6 +330,11 @@ public class RabbitListenerAnnotationBeanPostProcessor
 		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
 		endpoint.setMethod(methodToUse);
 		endpoint.setBeanFactory(this.beanFactory);
+		endpoint.setPropagateExceptions(resolveExpressionAsBoolean(rabbitListener.propagateExceptions()));
+		String errorHandlerBeanName = resolveExpressionAsString(rabbitListener.errorHandler(), "errorHandler");
+		if (StringUtils.hasText(errorHandlerBeanName)) {
+			endpoint.setErrorHandler(this.beanFactory.getBean(errorHandlerBeanName, RabbitListenerErrorHandler.class));
+		}
 		processListener(endpoint, rabbitListener, bean, methodToUse, beanName);
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerErrorHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerErrorHandler.java
@@ -39,7 +39,7 @@ public interface RabbitListenerErrorHandler {
 	 * @param exception the exception the listener threw, wrapped in a
 	 * {@link ListenerExecutionFailedException}.
 	 * @return the return value to be sent to the sender.
-	 * @throws an exception which may be the original or different.
+	 * @throws Exception an exception which may be the original or different.
 	 */
 	Object handleError(Message amqpMessage, org.springframework.messaging.Message<?> message,
 			ListenerExecutionFailedException exception) throws Exception;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerErrorHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerErrorHandler.java
@@ -38,7 +38,8 @@ public interface RabbitListenerErrorHandler {
 	 * @param message the converted spring-messaging message.
 	 * @param exception the exception the listener threw, wrapped in a
 	 * {@link ListenerExecutionFailedException}.
-	 * @return the return value.
+	 * @return the return value to be sent to the sender.
+	 * @throws an exception which may be the original or different.
 	 */
 	Object handleError(Message amqpMessage, org.springframework.messaging.Message<?> message,
 			ListenerExecutionFailedException exception) throws Exception;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerErrorHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerErrorHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
+
+/**
+ * An error handler which is called when a {code @RabbitListener} method
+ * throws an exception. This is invoked higher up the stack than the
+ * listener container's error handler.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+@FunctionalInterface
+public interface RabbitListenerErrorHandler {
+
+	/**
+	 * Handle the error. If an exception is not thrown, the return value is returned to
+	 * the sender using normal {@code replyTo/@SendTo} semantics.
+	 * @param amqpMessage the raw message received.
+	 * @param message the converted spring-messaging message.
+	 * @param exception the exception the listener threw, wrapped in a
+	 * {@link ListenerExecutionFailedException}.
+	 * @return the return value.
+	 */
+	Object handleError(Message amqpMessage, org.springframework.messaging.Message<?> message,
+			ListenerExecutionFailedException exception) throws Exception;
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
@@ -45,7 +45,7 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 
 	private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
-	private boolean propagateExceptions;
+	private boolean returnExceptions;
 
 	private RabbitListenerErrorHandler errorHandler;
 
@@ -84,13 +84,13 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 	}
 
 	/**
-	 * Set whether exceptions thrown by the listener should be propagated to the sender
+	 * Set whether exceptions thrown by the listener should be returned to the sender
 	 * using the normal {@code replyTo/@SendTo} semantics.
-	 * @param propagateExceptions true to propagate exceptions.
+	 * @param returnExceptions true to return exceptions.
 	 * @since 2.0
 	 */
-	public void setPropagateExceptions(boolean propagateExceptions) {
-		this.propagateExceptions = propagateExceptions;
+	public void setReturnExceptions(boolean returnExceptions) {
+		this.returnExceptions = returnExceptions;
 	}
 
 	/**
@@ -145,7 +145,7 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 	 * @return the {@link MessagingMessageListenerAdapter} instance.
 	 */
 	protected MessagingMessageListenerAdapter createMessageListenerInstance() {
-		return new MessagingMessageListenerAdapter(this.bean, this.method, this.propagateExceptions, this.errorHandler);
+		return new MessagingMessageListenerAdapter(this.bean, this.method, this.returnExceptions, this.errorHandler);
 	}
 
 	private String getDefaultReplyToAddress() {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
@@ -19,6 +19,7 @@ package org.springframework.amqp.rabbit.listener;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+import org.springframework.amqp.rabbit.annotation.RabbitListenerErrorHandler;
 import org.springframework.amqp.rabbit.listener.adapter.HandlerAdapter;
 import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.amqp.support.converter.MessageConverter;
@@ -44,6 +45,9 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 
 	private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
+	private boolean propagateExceptions;
+
+	private RabbitListenerErrorHandler errorHandler;
 
 	/**
 	 * Set the object instance that should manage this endpoint.
@@ -77,6 +81,25 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 	 */
 	public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory messageHandlerMethodFactory) {
 		this.messageHandlerMethodFactory = messageHandlerMethodFactory;
+	}
+
+	/**
+	 * Set whether exceptions thrown by the listener should be propagated to the sender
+	 * using the normal {@code replyTo/@SendTo} semantics.
+	 * @param propagateExceptions true to propagate exceptions.
+	 * @since 2.0
+	 */
+	public void setPropagateExceptions(boolean propagateExceptions) {
+		this.propagateExceptions = propagateExceptions;
+	}
+
+	/**
+	 * Set the {@link RabbitListenerErrorHandler} to invoke if the listener method
+	 * throws an exception.
+	 * @param errorHandler the error handler.
+	 */
+	public void setErrorHandler(RabbitListenerErrorHandler errorHandler) {
+		this.errorHandler = errorHandler;
 	}
 
 	/**
@@ -122,7 +145,7 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 	 * @return the {@link MessagingMessageListenerAdapter} instance.
 	 */
 	protected MessagingMessageListenerAdapter createMessageListenerInstance() {
-		return new MessagingMessageListenerAdapter(this.bean, this.method);
+		return new MessagingMessageListenerAdapter(this.bean, this.method, this.propagateExceptions, this.errorHandler);
 	}
 
 	private String getDefaultReplyToAddress() {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -61,7 +61,7 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 
 	private final MessagingMessageConverterAdapter messagingMessageConverter;
 
-	private final boolean propagateExceptions;
+	private final boolean returnExceptions;
 
 	private final RabbitListenerErrorHandler errorHandler;
 
@@ -73,10 +73,10 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 		this(bean, method, false, null);
 	}
 
-	public MessagingMessageListenerAdapter(Object bean, Method method, boolean propagateExceptions,
+	public MessagingMessageListenerAdapter(Object bean, Method method, boolean returnExceptions,
 			RabbitListenerErrorHandler errorHandler) {
 		this.messagingMessageConverter = new MessagingMessageConverterAdapter(bean, method);
-		this.propagateExceptions = propagateExceptions;
+		this.returnExceptions = returnExceptions;
 		this.errorHandler = errorHandler;
 	}
 
@@ -136,14 +136,14 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 					}
 				}
 				catch (Exception ex) {
-					if (!this.propagateExceptions) {
+					if (!this.returnExceptions) {
 						throw ex;
 					}
 					handleResult(new RemoteInvocationResult(ex), amqpMessage, channel, message);
 				}
 			}
 			else {
-				if (!this.propagateExceptions) {
+				if (!this.returnExceptions) {
 					throw e;
 				}
 				handleResult(new RemoteInvocationResult(e.getCause()), amqpMessage, channel, message);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 
 import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.annotation.RabbitListenerErrorHandler;
 import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
 import org.springframework.amqp.support.AmqpHeaderMapper;
 import org.springframework.amqp.support.converter.MessageConversionException;
@@ -31,6 +32,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.remoting.support.RemoteInvocationResult;
 import org.springframework.util.Assert;
 
 import com.rabbitmq.client.Channel;
@@ -59,12 +61,23 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 
 	private final MessagingMessageConverterAdapter messagingMessageConverter;
 
+	private final boolean propagateExceptions;
+
+	private final RabbitListenerErrorHandler errorHandler;
+
 	public MessagingMessageListenerAdapter() {
 		this(null, null);
 	}
 
 	public MessagingMessageListenerAdapter(Object bean, Method method) {
+		this(bean, method, false, null);
+	}
+
+	public MessagingMessageListenerAdapter(Object bean, Method method, boolean propagateExceptions,
+			RabbitListenerErrorHandler errorHandler) {
 		this.messagingMessageConverter = new MessagingMessageConverterAdapter(bean, method);
+		this.propagateExceptions = propagateExceptions;
+		this.errorHandler = errorHandler;
 	}
 
 	/**
@@ -102,12 +115,39 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 		if (logger.isDebugEnabled()) {
 			logger.debug("Processing [" + message + "]");
 		}
-		Object result = invokeHandler(amqpMessage, channel, message);
-		if (result != null) {
-			handleResult(result, amqpMessage, channel, message);
+		try {
+			Object result = invokeHandler(amqpMessage, channel, message);
+			if (result != null) {
+				handleResult(result, amqpMessage, channel, message);
+			}
+			else {
+				logger.trace("No result object given - no result to handle");
+			}
 		}
-		else {
-			logger.trace("No result object given - no result to handle");
+		catch (ListenerExecutionFailedException e) {
+			if (this.errorHandler != null) {
+				try {
+					Object result = this.errorHandler.handleError(amqpMessage, message, e);
+					if (result != null) {
+						handleResult(result, amqpMessage, channel, message);
+					}
+					else {
+						logger.trace("Error handler returned no result");
+					}
+				}
+				catch (Exception ex) {
+					if (!this.propagateExceptions) {
+						throw ex;
+					}
+					handleResult(new RemoteInvocationResult(ex), amqpMessage, channel, message);
+				}
+			}
+			else {
+				if (!this.propagateExceptions) {
+					throw e;
+				}
+				handleResult(new RemoteInvocationResult(e.getCause()), amqpMessage, channel, message);
+			}
 		}
 	}
 
@@ -123,11 +163,6 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 			Message<?> message) {
 		try {
 			return this.handlerMethod.invoke(message, amqpMessage, channel);
-		}
-		catch (org.springframework.messaging.converter.MessageConversionException ex) {
-			throw new ListenerExecutionFailedException(createMessagingErrorMessage("Listener method could not " +
-					"be invoked with the incoming message", message.getPayload()),
-					new MessageConversionException("Cannot handle message", ex));
 		}
 		catch (MessagingException ex) {
 			throw new ListenerExecutionFailedException(createMessagingErrorMessage("Listener method could not " +

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -152,7 +152,7 @@ public class EnableRabbitIntegrationTests {
 			"test.converted.args2", "test.converted.message", "test.notconverted.message",
 			"test.notconverted.channel", "test.notconverted.messagechannel", "test.notconverted.messagingmessage",
 			"test.converted.foomessage", "test.notconverted.messagingmessagenotgeneric", "test.simple.direct",
-			"amqp656dlq", "test.simple.declare", "test.propagate.exceptions", "test.pojo.errors", "test.pojo.errors2");
+			"amqp656dlq", "test.simple.declare", "test.return.exceptions", "test.pojo.errors", "test.pojo.errors2");
 
 	@Autowired
 	private RabbitTemplate rabbitTemplate;
@@ -559,14 +559,14 @@ public class EnableRabbitIntegrationTests {
 
 	@Test
 	@DirtiesContext
-	public void propagate() {
+	public void returnExceptionWithRethrowAdapter() {
 		this.rabbitTemplate.setMessageConverter(new RemoteInvocationAwareMessageConverterAdapter());
 		try {
-			this.rabbitTemplate.convertSendAndReceive("test.propagate.exceptions", "foo");
+			this.rabbitTemplate.convertSendAndReceive("test.return.exceptions", "foo");
 			fail("ExpectedException");
 		}
 		catch (Exception e) {
-			assertThat(e.getCause().getMessage(), equalTo("propagate this"));
+			assertThat(e.getCause().getMessage(), equalTo("return this"));
 		}
 	}
 
@@ -585,7 +585,7 @@ public class EnableRabbitIntegrationTests {
 		}
 		catch (Exception e) {
 			assertThat(e.getCause().getMessage(), equalTo("from error handler"));
-			assertThat(e.getCause().getCause().getMessage(), equalTo("propagate this"));
+			assertThat(e.getCause().getCause().getMessage(), equalTo("return this"));
 		}
 	}
 
@@ -834,19 +834,19 @@ public class EnableRabbitIntegrationTests {
 			throw new AmqpRejectAndDontRequeueException("dlq");
 		}
 
-		@RabbitListener(queues = "test.propagate.exceptions", propagateExceptions = "${some.prop:true}")
+		@RabbitListener(queues = "test.return.exceptions", returnExceptions = "${some.prop:true}")
 		public String alwaysFails(String data) throws Exception {
-			throw new Exception("propagate this");
+			throw new Exception("return this");
 		}
 
 		@RabbitListener(queues = "test.pojo.errors", errorHandler = "alwaysBARHandler")
 		public String alwaysFailsWithErrorHandler(String data) throws Exception {
-			throw new Exception("propagate this");
+			throw new Exception("return this");
 		}
 
-		@RabbitListener(queues = "test.pojo.errors2", errorHandler = "throwANewException", propagateExceptions = "true")
+		@RabbitListener(queues = "test.pojo.errors2", errorHandler = "throwANewException", returnExceptions = "true")
 		public String alwaysFailsWithErrorHandlerThrowAnother(String data) throws Exception {
-			throw new Exception("propagate this");
+			throw new Exception("return this");
 		}
 
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpointTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpointTests.java
@@ -378,7 +378,7 @@ public class MethodRabbitListenerEndpointTests {
 		Channel channel = mock(Channel.class);
 
 		thrown.expect(ListenerExecutionFailedException.class);
-		thrown.expectCause(Matchers.isA(MessageConversionException.class));
+		thrown.expectCause(Matchers.isA(org.springframework.messaging.converter.MessageConversionException.class));
 		thrown.expectMessage(getDefaultListenerMethod(Integer.class).toGenericString()); // ref to method
 		listener.onMessage(MessageTestUtils.createTextMessage("test"), channel); // test is not a valid integer
 	}
@@ -390,7 +390,7 @@ public class MethodRabbitListenerEndpointTests {
 
 		thrown.expect(ListenerExecutionFailedException.class);
 		thrown.expectCause(Matchers.<Throwable>either(Matchers.instanceOf(MethodArgumentTypeMismatchException.class))
-				.or(Matchers.instanceOf(MessageConversionException.class)));
+				.or(Matchers.instanceOf(org.springframework.messaging.converter.MessageConversionException.class)));
 		listener.onMessage(MessageTestUtils.createTextMessage("test"), channel);  // Message<String> as Message<Integer>
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -105,10 +105,8 @@ public class MessagingMessageListenerAdapterTests {
 			fail("Should have thrown an exception");
 		}
 		catch (ListenerExecutionFailedException ex) {
-			assertEquals(org.springframework.amqp.support.converter.MessageConversionException.class,
-					ex.getCause().getClass());
 			assertEquals(org.springframework.messaging.converter.MessageConversionException.class,
-					ex.getCause().getCause().getClass());
+					ex.getCause().getClass());
 		}
 		catch (Exception ex) {
 			fail("Should not have thrown another exception");

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1520,7 +1520,7 @@ public class MyService {
 }
 ----
 
-The idea of the example above is that, whenever a message is available on the `org.springframework.amqp.core.Queue` "myQueue", the `processOrder` method is invoked accordingly (in this case, with the payload of the message).
+The idea of the example above is that, whenever a message is available on the queue named `myQueue`, the `processOrder` method is invoked accordingly (in this case, with the payload of the message).
 
 The annotated endpoint infrastructure creates a message listener container behind the scenes for each annotated method, using a `RabbitListenerContainerFactory`.
 
@@ -2125,6 +2125,42 @@ static class TxServiceImpl implements TxService<Foo> {
 
 }
 ----
+
+[[annotation-error-handling]]
+====== Handling Exceptions
+
+By default, if an annotated listener method throws an exception, the exeption is thrown to the container and the message will be requeued and redelivered, discarded, or routed to a Dead Letter Exchange, depending on the container and broker configuration.
+Nothing is returned to the sender.
+
+Starting with _version 2.0_, the `@RabbitListener` annotation has two new attributes: `errorHandler` and `returnExceptions`.
+
+These are not configured by default.
+
+Use the `errorHandler` to provide the bean name of a `RabbitListenerErrorHandler` implementation.
+This functional interface has one method:
+
+[source, java]
+----
+@FunctionalInterface
+public interface RabbitListenerErrorHandler {
+
+	Object handleError(Message amqpMessage, org.springframework.messaging.Message<?> message,
+			ListenerExecutionFailedException exception) throws Exception;
+
+}
+----
+
+As you can see, you have access to the raw message received from the container, the spring-messaging `Message<?>` object produced by the message converter and the exception that was thrown by the listener, wrapped in a `ListenerExecutionFailedException`.
+The error handler can either return some result which will be sent as the reply, or throw the original or a new exception which will be thrown to the container, or returned to the sender, depending on the `returnExceptions` setting.
+
+The `returnExceptions` attribute, when "true" will cause exceptions to be returned to the sender.
+The exception is wrapped in a `RemoteInvocationResult` object.
+On the sender side, there is an available `RemoteInvocationAwareMessageConverterAdapter` which, if configured into the `RabbitTemplate`, will re-throw the server-side exception, wrapped in an `AmqpRemoteException`.
+The stack trace of the server exception will be synthesized by merging the server and client stack traces.
+
+IMPORTANT: This mechanism will generally only work with the default `SimpleMessageConverter`, which uses Java serialization; exceptions are generally not "Jackson-friendly" so can't be serialized to JSON.
+If you are using JSON, consider using an `errorHandler` to return some other Jackson-friendly `Error` object when an exception is thrown.
+
 
 
 ====== Container Management

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -57,6 +57,11 @@ See <<anonymous-queue>> for more information.
 You can now provide simple queue declarations (only bound to the default exchange) in `@RabbitListener` annotations.
 See <<async-annotation-driven>> for more information.
 
+You can now configure `@RabbitListener` annotations so that any exceptions thrown will be returned to the sender.
+You can also configure a `RabbitListenerErrorHandler` to handle exceptions.
+See <<annotation-error-handling>> for more information.
+
+
 ==== Earlier Releases
 
 See <<previous-whats-new>> for changes in previous versions.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-676

1. Add the ability to propagate exceptions from POJO `@RabbitListener` methods to senders
(when using `replyTo/@SendTo`. Exceptions are propagated in a `RemoteInvocationResult`.
2. Add `RemoteInvocationAwareMessageConverterAdapter` to support unwrapping these exceptions
on the client side.
3. Note: this feature generally requires the use of the `SimpleMessageConverter` since exceptions
are `Serializable` and generally, are not JSON friendly.
4. Add `errorHandler` to `@RabbitListener`, allowing users to catch exceptions, send a modified result,
or throw some other exception.
5. Remove the (now) unnecessary wrapping of spring-messaging `MessageConversionException`s.

__review only - needs docs__