### PR TITLE
AMQP-680: Avoid allocations from Method.getParameterTypes() in MessagingMessageListenerAdapter

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -256,7 +256,7 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 
 			Type genericParameterType = null;
 
-			for (int i = 0; i < this.method.getParameterTypes().length; i++) {
+			for (int i = 0; i < this.method.getParameterCount(); i++) {
 				MethodParameter methodParameter = new MethodParameter(this.method, i);
 				/*
 				 * We're looking for a single non-annotated parameter, or one annotated with @Payload.


### PR DESCRIPTION
Fixes https://jira.spring.io/browse/AMQP-680