### PR TITLE
AMQP-682: DMLC: Fatal Connection Error

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/AmqpApplicationContextClosedException.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/AmqpApplicationContextClosedException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp;
+
+/**
+ * Thrown when the connection factory has been destroyed during
+ * context close; the factory can no longer open connections.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+@SuppressWarnings("serial")
+public class AmqpApplicationContextClosedException extends AmqpException {
+
+	public AmqpApplicationContextClosedException(String message) {
+		super(message);
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
 
+import org.springframework.amqp.AmqpApplicationContextClosedException;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpTimeoutException;
 import org.springframework.amqp.rabbit.support.PublisherCallbackChannel;
@@ -543,7 +544,10 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	@Override
 	public final Connection createConnection() throws AmqpException {
-		Assert.state(!this.stopped, "The ApplicationContext is closed and the ConnectionFactory can no longer create connections.");
+		if (this.stopped) {
+			throw new AmqpApplicationContextClosedException(
+					"The ApplicationContext is closed and the ConnectionFactory can no longer create connections.");
+		}
 		synchronized (this.connectionMonitor) {
 			if (this.cacheMode == CacheMode.CHANNEL) {
 				if (this.connection.target == null) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryLifecycleTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryLifecycleTests.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.springframework.amqp.AmqpApplicationContextClosedException;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -58,7 +59,7 @@ public class ConnectionFactoryLifecycleTests {
 			cf.createConnection();
 			fail("Expected exception");
 		}
-		catch (IllegalStateException e) {
+		catch (AmqpApplicationContextClosedException e) {
 			assertThat(e.getMessage(), containsString("The ApplicationContext is closed"));
 		}
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-682

Stop the container if the connection factory has been destroyed by Spring.

This can happen if a non-Spring-managed container uses a Spring-managed connection factory.