### PR TITLE
Fix Sonar Detected Bad instanceof Check

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -345,8 +345,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 			if (this.logger.isInfoEnabled()) {
 				this.logger.info("Created new connection: " + connection);
 			}
-			if (this.recoveryListener != null && connection instanceof AutorecoveringConnection) {
-				((AutorecoveringConnection) connection).addRecoveryListener(this.recoveryListener);
+			if (this.recoveryListener != null && rabbitConnection instanceof AutorecoveringConnection) {
+				((AutorecoveringConnection) rabbitConnection).addRecoveryListener(this.recoveryListener);
 			}
 			return connection;
 		}


### PR DESCRIPTION
https://sonar.spring.io/component_issues?id=org.springframework.amqp%3Aspring-amqp-dist%3Amaster#resolved=false|types=BUG

Checking wrong connection object to attach recovery listener.

After merge, needs backport of this default listener.