### PR TITLE
AMQP-687: Fix Conditional Rollback

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/ImmediateAcknowledgeAmqpException.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/ImmediateAcknowledgeAmqpException.java
@@ -17,10 +17,12 @@
 package org.springframework.amqp;
 
 /**
- * Special exception for listener implementations that want to signal that the current batch of messages should be
- * acknowledged immediately (i.e. as soon as possible) without rollback, and without consuming any more messages.
+ * Special exception for listener implementations that want to signal that the current
+ * batch of messages should be acknowledged immediately (i.e. as soon as possible) without
+ * rollback, and without consuming any more messages within the current transaction.
  *
  * @author Dave Syer
+ * @author Gary Russell
  *
  */
 @SuppressWarnings("serial")

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -181,8 +181,7 @@ public final class ConnectionFactoryUtils {
 		}
 	}
 
-	public static void registerDeliveryTag(ConnectionFactory connectionFactory, Channel channel, Long tag)
-			throws IOException {
+	public static void registerDeliveryTag(ConnectionFactory connectionFactory, Channel channel, Long tag) {
 
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null");
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -706,6 +706,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @param transactionAttribute the transaction attribute to set
 	 */
 	public void setTransactionAttribute(TransactionAttribute transactionAttribute) {
+		Assert.notNull(transactionAttribute, "'transactionAttribute' cannot be null");
 		this.transactionAttribute = transactionAttribute;
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -139,6 +139,8 @@ public class BlockingQueueConsumer {
 
 	private long shutdownTimeout;
 
+	private boolean locallyTransacted;
+
 	private volatile long abortStarted;
 
 	/**
@@ -305,6 +307,24 @@ public class BlockingQueueConsumer {
 	}
 
 	/**
+	 * True if the channel is locally transacted.
+	 * @param locallyTransacted the locally transacted to set.
+	 * @since 1.6.6
+	 */
+	public void setLocallyTransacted(boolean locallyTransacted) {
+		this.locallyTransacted = locallyTransacted;
+	}
+
+	/**
+	 * Clear the delivery tags when rolling back with an external transaction
+	 * manager.
+	 * @since 1.6.6
+	 */
+	public void clearDeliveryTags() {
+		this.deliveryTags.clear();
+	}
+
+	/**
 	 * Return the size the queues array.
 	 * @return the count.
 	 */
@@ -374,6 +394,10 @@ public class BlockingQueueConsumer {
 			logger.debug("Received message: " + message);
 		}
 		this.deliveryTags.add(messageProperties.getDeliveryTag());
+		if (this.transactional && !locallyTransacted) {
+			ConnectionFactoryUtils.registerDeliveryTag(this.connectionFactory, this.channel,
+					delivery.getEnvelope().getDeliveryTag());
+		}
 		return message;
 	}
 
@@ -469,7 +493,8 @@ public class BlockingQueueConsumer {
 			logger.debug("Starting consumer " + this);
 		}
 		try {
-			this.resourceHolder = ConnectionFactoryUtils.getTransactionalResourceHolder(this.connectionFactory, this.transactional);
+			this.resourceHolder = ConnectionFactoryUtils.getTransactionalResourceHolder(this.connectionFactory,
+					this.transactional);
 			this.channel = this.resourceHolder.getChannel();
 		}
 		catch (AmqpAuthenticationException e) {
@@ -686,17 +711,7 @@ public class BlockingQueueConsumer {
 			boolean ackRequired = !this.acknowledgeMode.isAutoAck() && !this.acknowledgeMode.isManual();
 
 			if (ackRequired) {
-
-				if (this.transactional && !locallyTransacted) {
-
-					// Not locally transacted but it is transacted so it
-					// could be synchronized with an external transaction
-					for (Long deliveryTag : this.deliveryTags) {
-						ConnectionFactoryUtils.registerDeliveryTag(this.connectionFactory, this.channel, deliveryTag);
-					}
-
-				}
-				else {
+				if (!this.transactional || locallyTransacted) {
 					long deliveryTag = new ArrayList<Long>(this.deliveryTags).get(this.deliveryTags.size() - 1);
 					this.channel.basicAck(deliveryTag, true);
 				}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -394,7 +394,7 @@ public class BlockingQueueConsumer {
 			logger.debug("Received message: " + message);
 		}
 		this.deliveryTags.add(messageProperties.getDeliveryTag());
-		if (this.transactional && !locallyTransacted) {
+		if (this.transactional && !this.locallyTransacted) {
 			ConnectionFactoryUtils.registerDeliveryTag(this.connectionFactory, this.channel,
 					delivery.getEnvelope().getDeliveryTag());
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -579,12 +579,12 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 	 */
 	private void actualShutDown() {
 		Assert.state(getTaskExecutor() != null, "Cannot shut down if not initialized");
-		logger.debug("Shutting down");
+		this.logger.debug("Shutting down");
 		// Copy in the same order to avoid ConcurrentModificationException during remove in the cancelConsumer().
 		new LinkedList<>(this.consumers).forEach(this::cancelConsumer);
 		this.consumers.clear();
 		this.consumersByQueue.clear();
-		logger.debug("All consumers canceled");
+		this.logger.debug("All consumers canceled");
 		if (this.consumerMonitorTask != null) {
 			this.consumerMonitorTask.cancel(true);
 			this.consumerMonitorTask = null;
@@ -741,14 +741,14 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			}
 			catch (ImmediateAcknowledgeAmqpException e) {
 				if (this.logger.isDebugEnabled()) {
-					logger.debug("User requested ack for failed delivery");
+					this.logger.debug("User requested ack for failed delivery");
 				}
 				handleAck(deliveryTag, channelLocallyTransacted);
 			}
 			catch (Exception e) {
 				if (causeChainHasImmediateAcknowledgeAmqpException(e)) {
 					if (this.logger.isDebugEnabled()) {
-						logger.debug("User requested ack for failed delivery");
+						this.logger.debug("User requested ack for failed delivery");
 					}
 				}
 				else {
@@ -790,7 +790,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 				}
 			}
 			catch (Exception e) {
-				logger.error("Error acking", e);
+				this.logger.error("Error acking", e);
 			}
 		}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -791,8 +791,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				}
 				if (getTransactionManager() != null) {
 					if (getTransactionAttribute().rollbackOn(ex)) {
-						consumer.rollbackOnExceptionIfNecessary(ex);
-						throw ex;
+						consumer.clearDeliveryTags();
+						throw ex; // encompassing transaction will handle the rollback.
 					}
 					else {
 						if (this.logger.isDebugEnabled()) {
@@ -889,6 +889,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			int consecutiveIdles = 0;
 
 			int consecutiveMessages = 0;
+
+			this.consumer.setLocallyTransacted(isChannelLocallyTransacted());
 
 			if (this.consumer.getQueueCount() < 1) {
 				if (logger.isDebugEnabled()) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -778,14 +778,16 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			}
 			catch (ImmediateAcknowledgeAmqpException e) {
 				if (this.logger.isDebugEnabled()) {
-					this.logger.debug("User requested ack for failed delivery");
+					this.logger.debug("User requested ack for failed delivery: "
+							+ message.getMessageProperties().getDeliveryTag());
 				}
 				break;
 			}
 			catch (Throwable ex) { //NOSONAR
 				if (causeChainHasImmediateAcknowledgeAmqpException(ex)) {
 					if (this.logger.isDebugEnabled()) {
-						this.logger.debug("User requested ack for failed delivery");
+						this.logger.debug("User requested ack for failed delivery: "
+								+ message.getMessageProperties().getDeliveryTag());
 					}
 					break;
 				}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -778,14 +778,14 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			}
 			catch (ImmediateAcknowledgeAmqpException e) {
 				if (this.logger.isDebugEnabled()) {
-					logger.debug("User requested ack for failed delivery");
+					this.logger.debug("User requested ack for failed delivery");
 				}
 				break;
 			}
 			catch (Throwable ex) { //NOSONAR
 				if (causeChainHasImmediateAcknowledgeAmqpException(ex)) {
 					if (this.logger.isDebugEnabled()) {
-						logger.debug("User requested ack for failed delivery");
+						this.logger.debug("User requested ack for failed delivery");
 					}
 					break;
 				}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -762,7 +762,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	}
 
-	private boolean doReceiveAndExecute(BlockingQueueConsumer consumer) throws Throwable {
+	private boolean doReceiveAndExecute(BlockingQueueConsumer consumer) throws Throwable { //NOSONAR
 
 		Channel channel = consumer.getChannel();
 
@@ -783,6 +783,12 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				break;
 			}
 			catch (Throwable ex) { //NOSONAR
+				if (causeChainHasImmediateAcknowledgeAmqpException(ex)) {
+					if (this.logger.isDebugEnabled()) {
+						logger.debug("User requested ack for failed delivery");
+					}
+					break;
+				}
 				if (getTransactionManager() != null) {
 					if (getTransactionAttribute().rollbackOn(ex)) {
 						consumer.rollbackOnExceptionIfNecessary(ex);
@@ -790,7 +796,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					}
 					else {
 						if (this.logger.isDebugEnabled()) {
-							logger.debug("No rollback for " + ex);
+							this.logger.debug("No rollback for " + ex);
 						}
 						break;
 					}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/transaction/ListenerFailedRuleBasedTransactionAttribute.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/transaction/ListenerFailedRuleBasedTransactionAttribute.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.transaction;
+
+import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute;
+
+/**
+ * Subclass of {@link RuleBasedTransactionAttribute} that is aware that
+ * listener exceptions are wrapped in {@link ListenerExecutionFailedException}s.
+ * Allows users to control rollback based on the actual cause.
+ *
+ * @author Gary Russell
+ * @since 1.6.6
+ *
+ */
+@SuppressWarnings("serial")
+public class ListenerFailedRuleBasedTransactionAttribute extends RuleBasedTransactionAttribute {
+
+	@Override
+	public boolean rollbackOn(Throwable ex) {
+		if (ex instanceof ListenerExecutionFailedException) {
+			return super.rollbackOn(ex.getCause());
+		}
+		else {
+			return super.rollbackOn(ex);
+		}
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerSMLCTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerSMLCTests.java
@@ -27,7 +27,9 @@ public class ExternalTxManagerSMLCTests extends ExternalTxManagerTests {
 
 	@Override
 	protected AbstractMessageListenerContainer createContainer(AbstractConnectionFactory connectionFactory) {
-		return new SimpleMessageListenerContainer(connectionFactory);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setReceiveTimeout(60000);
+		return container;
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -19,15 +19,16 @@ package org.springframework.amqp.rabbit.listener;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
@@ -84,16 +85,16 @@ public abstract class ExternalTxManagerTests {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel onlyChannel = mock(Channel.class);
-		when(onlyChannel.isOpen()).thenReturn(true);
+		given(onlyChannel.isOpen()).willReturn(true);
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
 
-		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
-		when(mockConnection.isOpen()).thenReturn(true);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -103,27 +104,35 @@ public abstract class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(mockConnection).createChannel();
+		}).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 		final CountDownLatch consumerLatch = new CountDownLatch(1);
 
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			consumer.set(invocation.getArgumentAt(6, Consumer.class));
 			consumerLatch.countDown();
 			return "consumerTag";
-		}).when(onlyChannel)
+		}).given(onlyChannel)
 				.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(),
 						any(Consumer.class));
 
-		final CountDownLatch commitLatch = new CountDownLatch(1);
-		doAnswer(invocation -> {
-			commitLatch.countDown();
+		final AtomicReference<CountDownLatch> commitLatch = new AtomicReference<>(new CountDownLatch(1));
+		willAnswer(invocation -> {
+			commitLatch.get().countDown();
 			return null;
-		}).when(onlyChannel).txCommit();
+		}).given(onlyChannel).txCommit();
+		final AtomicReference<CountDownLatch> rollbackLatch = new AtomicReference<>(new CountDownLatch(1));
+		willAnswer(invocation -> {
+			rollbackLatch.get().countDown();
+			return null;
+		}).given(onlyChannel).txRollback();
+		willAnswer(invocation -> {
+			return null;
+		}).given(onlyChannel).basicAck(anyLong(), anyBoolean());
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		AbstractMessageListenerContainer container = createContainer(cachingConnectionFactory);
@@ -158,11 +167,12 @@ public abstract class ExternalTxManagerTests {
 			throw e;
 		}
 
-		verify(mockConnection, Mockito.times(1)).createChannel();
-		assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
+		verify(mockConnection, times(1)).createChannel();
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
+		verify(onlyChannel).basicAck(anyLong(), anyBoolean());
 		verify(onlyChannel).txCommit();
-		verify(onlyChannel).basicPublish(Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean(),
-				Mockito.any(BasicProperties.class), Mockito.any(byte[].class));
+		verify(onlyChannel).basicPublish(anyString(), anyString(), anyBoolean(),
+				any(BasicProperties.class), any(byte[].class));
 
 		// verify close() was never called on the channel
 		DirectFieldAccessor dfa = new DirectFieldAccessor(cachingConnectionFactory);
@@ -175,40 +185,59 @@ public abstract class ExternalTxManagerTests {
 		container.setMessageListener(m -> {
 			throw new RuntimeException();
 		});
+		commitLatch.set(new CountDownLatch(1));
 		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
 				new byte[] { 0 });
 		assertTrue(transactionManager.latch.await(10, TimeUnit.SECONDS));
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
 		assertTrue(transactionManager.rolledBack);
+		assertTrue(rollbackLatch.get().await(10, TimeUnit.SECONDS));
+		verify(onlyChannel).basicReject(anyLong(), anyBoolean());
+		verify(onlyChannel, times(1)).txRollback();
 
 		transactionManager.rolledBack = false;
 		transactionManager.latch = new CountDownLatch(1);
 		container.setMessageListener(m -> {
 			throw new IllegalStateException();
 		});
+		commitLatch.set(new CountDownLatch(1));
 		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
 				new byte[] { 0 });
 		assertTrue(transactionManager.latch.await(10, TimeUnit.SECONDS));
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
 		assertTrue(transactionManager.committed);
+		verify(onlyChannel, times(2)).basicAck(anyLong(), anyBoolean());
+		verify(onlyChannel, times(3)).txCommit(); // previous + reject commit for above + this one
 
 		transactionManager.committed = false;
 		transactionManager.latch = new CountDownLatch(1);
 		container.setMessageListener(m -> {
 			throw new AmqpRejectAndDontRequeueException("foo", new ImmediateAcknowledgeAmqpException("bar"));
 		});
+		commitLatch.set(new CountDownLatch(1));
+		rollbackLatch.set(new CountDownLatch(1));
 		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
 				new byte[] { 0 });
 		assertTrue(transactionManager.latch.await(10, TimeUnit.SECONDS));
 		assertTrue(transactionManager.rolledBack);
+		assertTrue(rollbackLatch.get().await(10, TimeUnit.SECONDS));
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
+		verify(onlyChannel, times(2)).basicReject(anyLong(), anyBoolean());
+		verify(onlyChannel, times(2)).txRollback();
 
 		transactionManager.rolledBack = false;
 		transactionManager.latch = new CountDownLatch(1);
 		container.setMessageListener(m -> {
 			throw new ImmediateAcknowledgeAmqpException("foo");
 		});
+		commitLatch.set(new CountDownLatch(1));
 		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
 				new byte[] { 0 });
 		assertTrue(transactionManager.latch.await(10, TimeUnit.SECONDS));
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
 		assertTrue(transactionManager.committed);
+		verify(onlyChannel, times(3)).basicAck(anyLong(), anyBoolean());
+		verify(onlyChannel, times(5)).txCommit();
 
 		container.stop();
 	}
@@ -222,33 +251,33 @@ public abstract class ExternalTxManagerTests {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel channel = mock(Channel.class);
-		when(channel.isOpen()).thenReturn(true);
+		given(channel.isOpen()).willReturn(true);
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
 
-		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
-		when(mockConnection.isOpen()).thenReturn(true);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(invocation -> channel).when(mockConnection).createChannel();
+		willAnswer(invocation -> channel).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 		final CountDownLatch consumerLatch = new CountDownLatch(1);
 
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			consumer.set(invocation.getArgumentAt(6, Consumer.class));
 			consumerLatch.countDown();
 			return "consumerTag";
-		}).when(channel)
+		}).given(channel)
 				.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(),
 						any(Consumer.class));
 
 		final CountDownLatch rollbackLatch = new CountDownLatch(1);
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			rollbackLatch.countDown();
 			return null;
-		}).when(channel).txRollback();
+		}).given(channel).txRollback();
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		AbstractMessageListenerContainer container = createContainer(cachingConnectionFactory);
@@ -292,23 +321,25 @@ public abstract class ExternalTxManagerTests {
 		Connection templateConnection = mock(Connection.class);
 		final Channel listenerChannel = mock(Channel.class);
 		Channel templateChannel = mock(Channel.class);
-		when(listenerChannel.isOpen()).thenReturn(true);
-		when(templateChannel.isOpen()).thenReturn(true);
+		given(listenerChannel.isOpen()).willReturn(true);
+		given(templateChannel.isOpen()).willReturn(true);
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(
 				listenerConnectionFactory);
 		final CachingConnectionFactory cachingTemplateConnectionFactory = new CachingConnectionFactory(
 				templateConnectionFactory);
 
-		when(listenerConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(listenerConnection);
-		when(listenerConnection.isOpen()).thenReturn(true);
-		when(templateConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(templateConnection);
-		when(templateConnection.isOpen()).thenReturn(true);
-		when(templateConnection.createChannel()).thenReturn(templateChannel);
+		given(listenerConnectionFactory.newConnection(any(ExecutorService.class), anyString()))
+				.willReturn(listenerConnection);
+		given(listenerConnection.isOpen()).willReturn(true);
+		given(templateConnectionFactory.newConnection(any(ExecutorService.class), anyString()))
+				.willReturn(templateConnection);
+		given(templateConnection.isOpen()).willReturn(true);
+		given(templateConnection.createChannel()).willReturn(templateChannel);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -318,30 +349,30 @@ public abstract class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(listenerConnection).createChannel();
+		}).given(listenerConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 		final CountDownLatch consumerLatch = new CountDownLatch(1);
 
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			consumer.set(invocation.getArgumentAt(6, Consumer.class));
 			consumerLatch.countDown();
 			return "consumerTag";
-		}).when(listenerChannel)
+		}).given(listenerChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(2);
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			commitLatch.countDown();
 			return null;
-		}).when(listenerChannel).txCommit();
-		doAnswer(invocation -> {
+		}).given(listenerChannel).txCommit();
+		willAnswer(invocation -> {
 			commitLatch.countDown();
 			return null;
-		}).when(templateChannel).txCommit();
+		}).given(templateChannel).txCommit();
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		AbstractMessageListenerContainer container = createContainer(cachingConnectionFactory);
@@ -396,16 +427,16 @@ public abstract class ExternalTxManagerTests {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel onlyChannel = mock(Channel.class);
-		when(onlyChannel.isOpen()).thenReturn(true);
+		given(onlyChannel.isOpen()).willReturn(true);
 
 		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory(mockConnectionFactory);
 
-		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
-		when(mockConnection.isOpen()).thenReturn(true);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -415,26 +446,26 @@ public abstract class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(mockConnection).createChannel();
+		}).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 		final CountDownLatch consumerLatch = new CountDownLatch(1);
 
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			consumer.set(invocation.getArgumentAt(6, Consumer.class));
 			consumerLatch.countDown();
 			return "consumerTag";
-		}).when(onlyChannel)
+		}).given(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			commitLatch.countDown();
 			return null;
-		}).when(onlyChannel).txCommit();
+		}).given(onlyChannel).txCommit();
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<Channel> exposed = new AtomicReference<Channel>();
@@ -489,16 +520,16 @@ public abstract class ExternalTxManagerTests {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel onlyChannel = mock(Channel.class);
-		when(onlyChannel.isOpen()).thenReturn(true);
+		given(onlyChannel.isOpen()).willReturn(true);
 
 		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory(mockConnectionFactory);
 
-		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
-		when(mockConnection.isOpen()).thenReturn(true);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -508,26 +539,26 @@ public abstract class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(mockConnection).createChannel();
+		}).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 		final CountDownLatch consumerLatch = new CountDownLatch(1);
 
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			consumer.set(invocation.getArgumentAt(6, Consumer.class));
 			consumerLatch.countDown();
 			return "consumerTag";
-		}).when(onlyChannel)
+		}).given(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			commitLatch.countDown();
 			return null;
-		}).when(onlyChannel).txCommit();
+		}).given(onlyChannel).txCommit();
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<Channel> exposed = new AtomicReference<Channel>();
@@ -583,16 +614,16 @@ public abstract class ExternalTxManagerTests {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel onlyChannel = mock(Channel.class);
-		when(onlyChannel.isOpen()).thenReturn(true);
+		given(onlyChannel.isOpen()).willReturn(true);
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
 
-		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
-		when(mockConnection.isOpen()).thenReturn(true);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -602,27 +633,27 @@ public abstract class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(mockConnection).createChannel();
+		}).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 		final CountDownLatch consumerLatch = new CountDownLatch(1);
 
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			consumer.set(invocation.getArgumentAt(6, Consumer.class));
 			consumerLatch.countDown();
 			return "consumerTag";
-		}).when(onlyChannel)
+		}).given(onlyChannel)
 				.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(),
 						any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
-		doAnswer(invocation -> {
+		willAnswer(invocation -> {
 			commitLatch.countDown();
 			return null;
-		}).when(onlyChannel).txCommit();
+		}).given(onlyChannel).txCommit();
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		AbstractMessageListenerContainer container = createContainer(cachingConnectionFactory);

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3834,6 +3834,34 @@ a database constraint error, or connectivity problem), then the AMQP transaction
 This is sometimes known as a Best Efforts 1 Phase Commit, and is a very powerful pattern for reliable messaging.
 If the `channelTransacted` flag was set to false in the example above, which is the default, then the external transaction would still be provided for the listener, but all messaging operations would be auto-acked, so the effect is to commit the messaging operations even on a rollback of the business operation.
 
+[[conditional-rollback]]
+===== Conditional Rollback
+
+Prior to _version 1.6.6_, adding a rollback rule to a container's `transactionAttribute`, when using an external transaction manager (e.g. JDBC) had no effect; exceptions always rolled back the transaction.
+
+Also, when using a http://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/transaction.html#transaction-declarative[transaction advice] in the container's advice chain, conditional rollback was not very useful because all listener exceptions are wrapped in a `ListenerExecutionFailedException`.
+
+The first problem has been corrected and the rules are now applied properly.
+Further, the `ListenerFailedRuleBasedTransactionAttribute` is now provided; it is a subclass of `RuleBasedTransactionAttribute`, with the only difference being that it is aware of the `ListenerExecutionFailedException` and uses the cause of such exceptions for the rule.
+This transaction attribute can be used directly in the container, or via a transaction advice.
+
+An example of using this rule follows:
+
+[source, java]
+----
+@Bean
+public AbstractMessageListenerContainer container() {
+    ...
+    container.setTransactionManager(transactionManager);
+    RuleBasedTransactionAttribute transactionAttribute =
+        new ListenerFailedRuleBasedTransactionAttribute();
+    transactionAttribute.setRollbackRules(Collections.singletonList(
+        new NoRollbackRuleAttribute(DontRollBackException.class)));
+    container.setTransactionAttribute(transactionAttribute);
+    ...
+}
+----
+
 ===== A note on Rollback of Received Messages
 
 AMQP transactions only apply to messages and acks sent to the broker, so when there is a rollback of a Spring transaction and a message has been received, what Spring AMQP has to do is not just rollback the transaction, but also manually reject the message (sort of a nack, but that's not what the specification calls it).

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -67,6 +67,11 @@ You can now configure `@RabbitListener` annotations so that any exceptions throw
 You can also configure a `RabbitListenerErrorHandler` to handle exceptions.
 See <<annotation-error-handling>> for more information.
 
+===== Container Conditional Rollback
+
+When using an external transaction manager (e.g. JDBC), rule-based rollback is now supported when providing the container with a transaction attribute.
+It is also now more flexible when using a transaction advice.
+See <<conditional-rollback>> for more information.
 
 ==== Earlier Releases
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-687

When using a rule-based transaction attribute with a rollback/no-rollback rule,
the rule is ignored when providing the transaction attribute directly to the container
rather than via a transaction advice,

Also, user exceptions are always wrapped in a `ListenerExecutionFailedException` which
limits the ability to configure rules, even when using an advice.

- Honor the attribute `rollBackOn()` mechanism within the container
- Add `ListenerFailedRuleBasedTransactionAttribute` to allow the user to configure rules based on the actual exception.