### PR TITLE
Rabbit SSL connection error RabbitConnectionFactoryBean

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -128,17 +128,20 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	/**
 	 *
-	 * @return whether or not Server Side certificate has to be validated or not
+	 * @return true if Server Side certificate has to be skipped
+	 * @since 1.6.6
      */
 	public boolean isSkipServerCertificateValidation() {
 		return this.skipServerCertificateValidation;
 	}
 
 	/**
-	 * whether or not Server Side certificate has to be validated or not
-	 * this would be used if useSSL is set to true and should only be used on dev or Qa regions
-	 * skipServerCertificateValidation should never be set to true in production
-	 *
+	 * whether or not Server Side certificate has to be validated or not.
+	 * This would be used if useSSL is set to true and should only be used on dev or Qa regions
+	 * skipServerCertificateValidation should <b> never be set to true in production</b>
+	 * @param skipServerCertificateValidation Flag to override Server side certificate checks; if set to true com.rabbitmq.client.NullTrustManager would be used
+	 * @since 1.6.6
+	 * @see com.rabbitmq.client.NullTrustManager
 	 */
 	public void setSkipServerCertificateValidation(boolean skipServerCertificateValidation) {
 		this.skipServerCertificateValidation = skipServerCertificateValidation;
@@ -661,11 +664,11 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	 * @throws KeyStoreException
      */
 	private void useDefaultTrustStoreMechanism() throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException {
-		SSLContext c = SSLContext.getInstance(this.sslAlgorithm);
-		TrustManagerFactory factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-		factory.init((KeyStore) null);
-		c.init(null, factory.getTrustManagers(), null);
-		this.connectionFactory.useSslProtocol(c);
+		SSLContext sslContext = SSLContext.getInstance(this.sslAlgorithm);
+		TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+		trustManagerFactory.init((KeyStore) null);
+		sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+		this.connectionFactory.useSslProtocol(sslContext);
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -68,6 +68,7 @@ import com.rabbitmq.client.impl.nio.NioParams;
  * @author Gary Russell
  * @author Heath Abelson
  * @author Arnaud Cogoluègnes
+ * @author Hareendran
  *
  * @since 1.4
  */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -35,7 +35,6 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -635,28 +634,12 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	 * @throws KeyManagementException
 	 * @throws KeyStoreException
      */
-	private void useDefaultTrustStoreMechanism() throws NoSuchAlgorithmException, KeyManagementException,
-			KeyStoreException {
+	private void useDefaultTrustStoreMechanism() throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException {
 		SSLContext c = SSLContext.getInstance(this.sslAlgorithm);
-		c.init(null, new TrustManager[] {  getDefaultTrustManager(TrustManagerFactory.getDefaultAlgorithm(), null) }, null);
+		TrustManagerFactory factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+		factory.init((KeyStore) null);
+		c.init(null, factory.getTrustManagers(), null);
 		this.connectionFactory.useSslProtocol(c);
-	}
-
-
-	private static X509TrustManager getDefaultTrustManager(String algorithm, KeyStore keystore) throws NoSuchAlgorithmException, KeyStoreException {
-
-		TrustManagerFactory factory = TrustManagerFactory.getInstance(algorithm);
-		X509TrustManager x509TrustManager = null;
-        factory.init(keystore);
-			for (TrustManager trustManager : factory.getTrustManagers()) {
-				if (trustManager instanceof X509TrustManager) {
-					x509TrustManager = (X509TrustManager) trustManager;
-					break;
-				}
-			}
-
-		return x509TrustManager;
-
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -644,27 +644,15 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	public static X509TrustManager getDefaultTrustManager(String algorithm, KeyStore keystore) throws NoSuchAlgorithmException, KeyStoreException {
 
-		TrustManagerFactory factory;
+		TrustManagerFactory factory = TrustManagerFactory.getInstance(algorithm);
 		X509TrustManager x509TrustManager = null;
-
-		try {
-			factory = TrustManagerFactory.getInstance(algorithm);
-			factory.init(keystore);
+        factory.init(keystore);
 			for (TrustManager trustManager : factory.getTrustManagers()) {
-
 				if (trustManager instanceof X509TrustManager) {
 					x509TrustManager = (X509TrustManager) trustManager;
 					break;
 				}
 			}
-
-		}
-		catch (NoSuchAlgorithmException e) {
-			throw  e;
-		}
-		catch (KeyStoreException e) {
-			throw  e;
-		}
 
 		return x509TrustManager;
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -123,6 +123,27 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	private volatile SecureRandom secureRandom;
 
+	private boolean skipServerCertificateValidation;
+
+
+	/**
+	 *
+	 * @return whether or not Server Side certificate has to be validated or not
+     */
+	public boolean isSkipServerCertificateValidation() {
+		return this.skipServerCertificateValidation;
+	}
+
+	/**
+	 * whether or not Server Side certificate has to be validated or not
+	 * this would be used if useSSL is set to true and should only be used on dev or Qa regions
+	 * skipServerCertificateValidation should never be set to true in production
+	 *
+	 */
+	public void setSkipServerCertificateValidation(boolean skipServerCertificateValidation) {
+		this.skipServerCertificateValidation = skipServerCertificateValidation;
+	}
+
 	/**
 	 * Whether or not the factory should be configured to use SSL.
 	 * @param useSSL true to use SSL.
@@ -561,7 +582,12 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	protected void setUpSSL() throws Exception {
 		if (this.sslPropertiesLocation == null && this.keyStore == null && this.trustStore == null
 				&& this.keyStoreResource == null && this.trustStoreResource == null) {
-			useDefaultTrustStoreMechanism();
+			if (this.skipServerCertificateValidation) {
+				this.connectionFactory.useSslProtocol(this.getSslAlgorithm());
+			}
+			else {
+				useDefaultTrustStoreMechanism();
+			}
 		}
 		else {
 			if (this.sslPropertiesLocation != null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -635,7 +635,7 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	 * @throws KeyManagementException
 	 * @throws KeyStoreException
      */
-	public void useDefaultTrustStoreMechanism() throws NoSuchAlgorithmException, KeyManagementException,
+	private void useDefaultTrustStoreMechanism() throws NoSuchAlgorithmException, KeyManagementException,
 			KeyStoreException {
 		SSLContext c = SSLContext.getInstance(this.sslAlgorithm);
 		c.init(null, new TrustManager[] {  getDefaultTrustManager(TrustManagerFactory.getDefaultAlgorithm(), null) }, null);
@@ -643,7 +643,7 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	}
 
 
-	public static X509TrustManager getDefaultTrustManager(String algorithm, KeyStore keystore) throws NoSuchAlgorithmException, KeyStoreException {
+	private static X509TrustManager getDefaultTrustManager(String algorithm, KeyStore keystore) throws NoSuchAlgorithmException, KeyStoreException {
 
 		TrustManagerFactory factory = TrustManagerFactory.getInstance(algorithm);
 		X509TrustManager x509TrustManager = null;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -47,6 +47,7 @@ import javax.net.ssl.SSLContext;
 /**
  * @author Gary Russell
  * @author Heath Abelson
+ * @author Hareendran 
  * @since 1.4.4
  *
  */

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -28,12 +28,15 @@ import static org.mockito.Mockito.verify;
 import java.security.SecureRandom;
 import java.util.Collections;
 
+import javax.net.ssl.SSLContext;
+
 import org.apache.commons.logging.Log;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.mockito.Mockito;
+
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.core.io.ClassPathResource;
@@ -42,12 +45,12 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 
-import javax.net.ssl.SSLContext;
+
 
 /**
  * @author Gary Russell
  * @author Heath Abelson
- * @author Hareendran 
+ * @author Hareendran
  * @since 1.4.4
  *
  */

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -33,6 +33,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.mockito.Mockito;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.core.io.ClassPathResource;
@@ -40,6 +41,8 @@ import org.springframework.core.io.ClassPathResource;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+
+import javax.net.ssl.SSLContext;
 
 /**
  * @author Gary Russell
@@ -74,9 +77,7 @@ public class SSLConnectionTests {
 		fb.setSslAlgorithm("TLSv1.2");
 		fb.afterPropertiesSet();
 		fb.getObject();
-		//since useSslProtocol is not called directly; commenting off the verification ; and not sure on what to verify
-		// as well may be perhaps checking whether  useSslProtocol (SSLContext) method is invoked at least 1 time
-		//verify(rabbitCf).useSslProtocol("TLSv1.2");
+		verify(rabbitCf).useSslProtocol(Mockito.any(SSLContext.class));
 	}
 
 	@Test
@@ -87,9 +88,7 @@ public class SSLConnectionTests {
 		fb.setUseSSL(true);
 		fb.afterPropertiesSet();
 		fb.getObject();
-		//since useSslProtocol is not called directly; commenting off the verification ; and not sure on what to verify
-		// as well may be perhaps checking whether  useSslProtocol (SSLContext) method is invoked at least 1 time
-		//verify(rabbitCf).useSslProtocol();
+		verify(rabbitCf).useSslProtocol(Mockito.any(SSLContext.class));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -94,6 +95,31 @@ public class SSLConnectionTests {
 		fb.getObject();
 		verify(rabbitCf).useSslProtocol(Mockito.any(SSLContext.class));
 	}
+
+	@Test
+	public void testuseSslProtocolShouldNotbecalled() throws Exception {
+		RabbitConnectionFactoryBean fb = new RabbitConnectionFactoryBean();
+		ConnectionFactory rabbitCf = spy(TestUtils.getPropertyValue(fb, "connectionFactory", ConnectionFactory.class));
+		new DirectFieldAccessor(fb).setPropertyValue("connectionFactory", rabbitCf);
+		fb.setUseSSL(true);
+		fb.afterPropertiesSet();
+		fb.getObject();
+		verify(rabbitCf, never()).useSslProtocol();
+	}
+
+
+	@Test
+	public void testuseSslProtocolwithProtocolShouldNotbecalled() throws Exception {
+		RabbitConnectionFactoryBean fb = new RabbitConnectionFactoryBean();
+		ConnectionFactory rabbitCf = spy(TestUtils.getPropertyValue(fb, "connectionFactory", ConnectionFactory.class));
+		new DirectFieldAccessor(fb).setPropertyValue("connectionFactory", rabbitCf);
+		fb.setUseSSL(true);
+		fb.setSslAlgorithm("TLSv1.2");
+		fb.afterPropertiesSet();
+		fb.getObject();
+		verify(rabbitCf, never()).useSslProtocol("TLSv1.2");
+	}
+
 
 	@Test
 	public void testKSTS() throws Exception {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -74,7 +74,9 @@ public class SSLConnectionTests {
 		fb.setSslAlgorithm("TLSv1.2");
 		fb.afterPropertiesSet();
 		fb.getObject();
-		verify(rabbitCf).useSslProtocol("TLSv1.2");
+		//since useSslProtocol is not called directly; commenting off the verification ; and not sure on what to verify
+		// as well may be perhaps checking whether  useSslProtocol (SSLContext) method is invoked at least 1 time
+		//verify(rabbitCf).useSslProtocol("TLSv1.2");
 	}
 
 	@Test
@@ -85,7 +87,9 @@ public class SSLConnectionTests {
 		fb.setUseSSL(true);
 		fb.afterPropertiesSet();
 		fb.getObject();
-		verify(rabbitCf).useSslProtocol();
+		//since useSslProtocol is not called directly; commenting off the verification ; and not sure on what to verify
+		// as well may be perhaps checking whether  useSslProtocol (SSLContext) method is invoked at least 1 time
+		//verify(rabbitCf).useSslProtocol();
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -107,6 +107,32 @@ public class SSLConnectionTests {
 		verify(rabbitCf, never()).useSslProtocol();
 	}
 
+	@Test
+	public void testSkipServerCertificate() throws Exception {
+		RabbitConnectionFactoryBean fb = new RabbitConnectionFactoryBean();
+		ConnectionFactory rabbitCf = spy(TestUtils.getPropertyValue(fb, "connectionFactory", ConnectionFactory.class));
+		new DirectFieldAccessor(fb).setPropertyValue("connectionFactory", rabbitCf);
+		fb.setUseSSL(true);
+		fb.setSkipServerCertificateValidation(true);
+		fb.afterPropertiesSet();
+		fb.getObject();
+		verify(rabbitCf).useSslProtocol("TLSv1.1");
+	}
+
+	@Test
+	public void testSkipServerCertificateWithAlgo() throws Exception {
+		RabbitConnectionFactoryBean fb = new RabbitConnectionFactoryBean();
+		ConnectionFactory rabbitCf = spy(TestUtils.getPropertyValue(fb, "connectionFactory", ConnectionFactory.class));
+		new DirectFieldAccessor(fb).setPropertyValue("connectionFactory", rabbitCf);
+		fb.setUseSSL(true);
+		fb.setSslAlgorithm("TLSv1.2");
+		fb.setSkipServerCertificateValidation(true);
+		fb.afterPropertiesSet();
+		fb.getObject();
+		verify(rabbitCf).useSslProtocol("TLSv1.2");
+	}
+
+
 
 	@Test
 	public void testUseSslProtocolWithProtocolShouldNotbeCalled() throws Exception {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -97,7 +97,7 @@ public class SSLConnectionTests {
 	}
 
 	@Test
-	public void testuseSslProtocolShouldNotbecalled() throws Exception {
+	public void testUseSslProtocolShouldNotbeCalled() throws Exception {
 		RabbitConnectionFactoryBean fb = new RabbitConnectionFactoryBean();
 		ConnectionFactory rabbitCf = spy(TestUtils.getPropertyValue(fb, "connectionFactory", ConnectionFactory.class));
 		new DirectFieldAccessor(fb).setPropertyValue("connectionFactory", rabbitCf);
@@ -109,7 +109,7 @@ public class SSLConnectionTests {
 
 
 	@Test
-	public void testuseSslProtocolwithProtocolShouldNotbecalled() throws Exception {
+	public void testUseSslProtocolWithProtocolShouldNotbeCalled() throws Exception {
 		RabbitConnectionFactoryBean fb = new RabbitConnectionFactoryBean();
 		ConnectionFactory rabbitCf = spy(TestUtils.getPropertyValue(fb, "connectionFactory", ConnectionFactory.class));
 		new DirectFieldAccessor(fb).setPropertyValue("connectionFactory", rabbitCf);


### PR DESCRIPTION
#522

In case if we use RabbitConnectionFactoryBean with
useSSL=true
&&sslPropertiesLocation == null && keyStore == null &&trustStore == null
&& keyStorePassphrase == null && this.trustStorePassphrase == null

it makes a call to amqp-rabbit-connectionfactory which does nothing which is a security flaw as such. It opens a possibility of man-in-middle attack.
this fix would would delegate to Java's trust mechanism if truststore or ssllocationpath is null.
