### PR TITLE
Fix AmqpAppCtxClosedE race condition in the DMLC

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -514,6 +514,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 							? getConsumerTagStrategy().createConsumerTag(queue) : ""),
 					false, isExclusive(), getConsumerArguments(), consumer);
 		}
+		catch (AmqpApplicationContextClosedException e) {
+			throw new AmqpConnectException(e);
+		}
 		catch (IOException e) {
 			RabbitUtils.closeChannel(channel);
 			RabbitUtils.closeConnection(connection);


### PR DESCRIPTION
https://build.spring.io/browse/AMQP-MEIGHT-919

The `AmqpApplicationContextClosedException` is considered as fatal for the `DirectMessageListenerContainer` but only in case of direct `getConnectionFactory().createConnection()`.
All subsequent interactions with `connection` and its `channels` may lead to the same problem because `ConnectionFactory` may be closed in between

* Catch `AmqpApplicationContextClosedException` in the general `doConsumeFromQueue()` block and rethrow it as a `AmqpConnectException` to fail container fast.
* Rework `DirectMessageListenerContainerTests.testNonManagedContainerDoesntStartWhenConnectionFactoryDestroyed()` to let pass the first `getConnectionFactory().createConnection()`, but fail on the other subsequent interactions with `connection` and its `channels` as that was a fact of the CI plan failure.