### PR TITLE
AMQP-687: Fix Conditional Rollback [1.7.x]

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/ImmediateAcknowledgeAmqpException.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/ImmediateAcknowledgeAmqpException.java
@@ -17,10 +17,12 @@
 package org.springframework.amqp;
 
 /**
- * Special exception for listener implementations that want to signal that the current batch of messages should be
- * acknowledged immediately (i.e. as soon as possible) without rollback, and without consuming any more messages.
+ * Special exception for listener implementations that want to signal that the current
+ * batch of messages should be acknowledged immediately (i.e. as soon as possible) without
+ * rollback, and without consuming any more messages within the current transaction.
  *
  * @author Dave Syer
+ * @author Gary Russell
  *
  */
 @SuppressWarnings("serial")

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -181,8 +181,7 @@ public final class ConnectionFactoryUtils {
 		}
 	}
 
-	public static void registerDeliveryTag(ConnectionFactory connectionFactory, Channel channel, Long tag)
-			throws IOException {
+	public static void registerDeliveryTag(ConnectionFactory connectionFactory, Channel channel, Long tag) {
 
 		Assert.notNull(connectionFactory, "ConnectionFactory must not be null");
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.ImmediateAcknowledgeAmqpException;
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
@@ -834,7 +836,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @see #isChannelTransacted()
 	 */
 	protected boolean isChannelLocallyTransacted(Channel channel) {
-		return this.isChannelTransacted();
+		return isChannelTransacted();
 	}
 
 	/**
@@ -870,6 +872,31 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 			return new ListenerExecutionFailedException("Listener threw exception", e, message);
 		}
 		return e;
+	}
+
+	/**
+	 * Traverse the cause chain and, if an {@link ImmediateAcknowledgeAmqpException}
+	 * is found before an {@link AmqpRejectAndDontRequeueException}, return true.
+	 * An {@link Error} will take precedence.
+	 * @param ex the exception
+	 * @return true if we should ack immediately.
+	 * @since 1.6.6
+	 */
+	protected boolean causeChainHasImmediateAcknowledgeAmqpException(Throwable ex) {
+		if (ex instanceof Error) {
+			return false;
+		}
+		Throwable cause = ex.getCause();
+		while (cause != null) {
+			if (cause instanceof ImmediateAcknowledgeAmqpException) {
+				return true;
+			}
+			else if (cause instanceof AmqpRejectAndDontRequeueException || cause instanceof Error) {
+				return false;
+			}
+			cause = cause.getCause();
+		}
+		return false;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -138,6 +138,8 @@ public class BlockingQueueConsumer {
 
 	private long shutdownTimeout;
 
+	private boolean locallyTransacted;
+
 	private volatile long abortStarted;
 
 	/**
@@ -313,6 +315,24 @@ public class BlockingQueueConsumer {
 	}
 
 	/**
+	 * True if the channel is locally transacted.
+	 * @param locallyTransacted the locally transacted to set.
+	 * @since 1.6.6
+	 */
+	public void setLocallyTransacted(boolean locallyTransacted) {
+		this.locallyTransacted = locallyTransacted;
+	}
+
+	/**
+	 * Clear the delivery tags when rolling back with an external transaction
+	 * manager.
+	 * @since 1.6.6
+	 */
+	public void clearDeliveryTags() {
+		this.deliveryTags.clear();
+	}
+
+	/**
 	 * Return the size the queues array.
 	 * @return the count.
 	 */
@@ -383,6 +403,10 @@ public class BlockingQueueConsumer {
 			logger.debug("Received message: " + message);
 		}
 		this.deliveryTags.add(messageProperties.getDeliveryTag());
+		if (this.transactional && !this.locallyTransacted) {
+			ConnectionFactoryUtils.registerDeliveryTag(this.connectionFactory, this.channel,
+					delivery.getEnvelope().getDeliveryTag());
+		}
 		return message;
 	}
 
@@ -478,7 +502,8 @@ public class BlockingQueueConsumer {
 			logger.debug("Starting consumer " + this);
 		}
 		try {
-			this.resourceHolder = ConnectionFactoryUtils.getTransactionalResourceHolder(this.connectionFactory, this.transactional);
+			this.resourceHolder = ConnectionFactoryUtils.getTransactionalResourceHolder(this.connectionFactory,
+					this.transactional);
 			this.channel = this.resourceHolder.getChannel();
 		}
 		catch (AmqpAuthenticationException e) {
@@ -707,17 +732,7 @@ public class BlockingQueueConsumer {
 			boolean ackRequired = !this.acknowledgeMode.isAutoAck() && !this.acknowledgeMode.isManual();
 
 			if (ackRequired) {
-
-				if (this.transactional && !locallyTransacted) {
-
-					// Not locally transacted but it is transacted so it
-					// could be synchronized with an external transaction
-					for (Long deliveryTag : this.deliveryTags) {
-						ConnectionFactoryUtils.registerDeliveryTag(this.connectionFactory, this.channel, deliveryTag);
-					}
-
-				}
-				else {
+				if (!this.transactional || locallyTransacted) {
 					long deliveryTag = new ArrayList<Long>(this.deliveryTags).get(this.deliveryTags.size() - 1);
 					this.channel.basicAck(deliveryTag, true);
 				}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -203,6 +203,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	private volatile long lastReceive = System.currentTimeMillis();
 
+	private TransactionTemplate transactionTemplate;
+
 	/**
 	 * Default constructor for convenient dependency injection via setters.
 	 */
@@ -452,6 +454,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 * @param transactionAttribute the transaction attribute to set
 	 */
 	public void setTransactionAttribute(TransactionAttribute transactionAttribute) {
+		Assert.notNull(transactionAttribute, "'transactionAttribute' cannot be null");
 		this.transactionAttribute = transactionAttribute;
 	}
 
@@ -1138,7 +1141,11 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 		if (this.transactionManager != null) {
 			try {
-				return new TransactionTemplate(this.transactionManager, this.transactionAttribute)
+				if (this.transactionTemplate == null) {
+					this.transactionTemplate =
+							new TransactionTemplate(this.transactionManager, this.transactionAttribute);
+				}
+				return this.transactionTemplate
 						.execute(new TransactionCallback<Boolean>() {
 							@Override
 							public Boolean doInTransaction(TransactionStatus status) {
@@ -1167,7 +1174,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	}
 
-	private boolean doReceiveAndExecute(BlockingQueueConsumer consumer) throws Throwable {
+	private boolean doReceiveAndExecute(BlockingQueueConsumer consumer) throws Throwable { //NOSONAR
 
 		Channel channel = consumer.getChannel();
 
@@ -1182,13 +1189,37 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				executeListener(channel, message);
 			}
 			catch (ImmediateAcknowledgeAmqpException e) {
+				if (this.logger.isDebugEnabled()) {
+					this.logger.debug("User requested ack for failed delivery: "
+							+ message.getMessageProperties().getDeliveryTag());
+				}
 				break;
 			}
 			catch (Throwable ex) { //NOSONAR
-				consumer.rollbackOnExceptionIfNecessary(ex);
-				throw ex;
+				if (causeChainHasImmediateAcknowledgeAmqpException(ex)) {
+					if (this.logger.isDebugEnabled()) {
+						this.logger.debug("User requested ack for failed delivery: "
+								+ message.getMessageProperties().getDeliveryTag());
+					}
+					break;
+				}
+				if (this.transactionManager != null) {
+					if (this.transactionAttribute.rollbackOn(ex)) {
+						consumer.clearDeliveryTags();
+						throw ex; // encompassing transaction will handle the rollback.
+					}
+					else {
+						if (this.logger.isDebugEnabled()) {
+							this.logger.debug("No rollback for " + ex);
+						}
+						break;
+					}
+				}
+				else {
+					consumer.rollbackOnExceptionIfNecessary(ex);
+					throw ex;
+				}
 			}
-
 		}
 
 		return consumer.commitIfNecessary(isChannelLocallyTransacted(channel));
@@ -1287,6 +1318,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			int consecutiveIdles = 0;
 
 			int consecutiveMessages = 0;
+
+			this.consumer.setLocallyTransacted(isChannelLocallyTransacted(null));
 
 			if (this.consumer.getQueueCount() < 1) {
 				if (logger.isDebugEnabled()) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/transaction/ListenerFailedRuleBasedTransactionAttribute.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/transaction/ListenerFailedRuleBasedTransactionAttribute.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.transaction;
+
+import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute;
+
+/**
+ * Subclass of {@link RuleBasedTransactionAttribute} that is aware that
+ * listener exceptions are wrapped in {@link ListenerExecutionFailedException}s.
+ * Allows users to control rollback based on the actual cause.
+ *
+ * @author Gary Russell
+ * @since 1.6.6
+ *
+ */
+@SuppressWarnings("serial")
+public class ListenerFailedRuleBasedTransactionAttribute extends RuleBasedTransactionAttribute {
+
+	@Override
+	public boolean rollbackOn(Throwable ex) {
+		if (ex instanceof ListenerExecutionFailedException) {
+			return super.rollbackOn(ex.getCause());
+		}
+		else {
+			return super.rollbackOn(ex);
+		}
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -19,15 +19,18 @@ package org.springframework.amqp.rabbit.listener;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -39,16 +42,22 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.ImmediateAcknowledgeAmqpException;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.SingleConnectionFactory;
 import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.transaction.ListenerFailedRuleBasedTransactionAttribute;
 import org.springframework.amqp.rabbit.transaction.RabbitTransactionManager;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.interceptor.NoRollbackRuleAttribute;
+import org.springframework.transaction.interceptor.RollbackRuleAttribute;
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 
@@ -76,16 +85,16 @@ public class ExternalTxManagerTests {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel onlyChannel = mock(Channel.class);
-		when(onlyChannel.isOpen()).thenReturn(true);
+		given(onlyChannel.isOpen()).willReturn(true);
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
-		when(mockConnection.isOpen()).thenReturn(true);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class))).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -95,53 +104,61 @@ public class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(mockConnection).createChannel();
+		}).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
+		final CountDownLatch consumerLatch = new CountDownLatch(1);
 
-		doAnswer(new Answer<String>() {
+		willAnswer(invocation -> {
+			consumer.set(invocation.getArgumentAt(6, Consumer.class));
+			consumerLatch.countDown();
+			return "consumerTag";
+		}).given(onlyChannel)
+				.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(),
+						any(Consumer.class));
 
-			@Override
-			public String answer(InvocationOnMock invocation) throws Throwable {
-				consumer.set((Consumer) invocation.getArguments()[6]);
-				return "consumerTag";
-			}
-		}).when(onlyChannel)
-			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
-
-		final CountDownLatch commitLatch = new CountDownLatch(1);
-		doAnswer(new Answer<String>() {
-
-			@Override
-			public String answer(InvocationOnMock invocation) throws Throwable {
-				commitLatch.countDown();
-				return null;
-			}
-		}).when(onlyChannel).txCommit();
+		final AtomicReference<CountDownLatch> commitLatch = new AtomicReference<>(new CountDownLatch(1));
+		willAnswer(invocation -> {
+			commitLatch.get().countDown();
+			return null;
+		}).given(onlyChannel).txCommit();
+		final AtomicReference<CountDownLatch> rollbackLatch = new AtomicReference<>(new CountDownLatch(1));
+		willAnswer(invocation -> {
+			rollbackLatch.get().countDown();
+			return null;
+		}).given(onlyChannel).txRollback();
+		willAnswer(invocation -> {
+			return null;
+		}).given(onlyChannel).basicAck(anyLong(), anyBoolean());
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(cachingConnectionFactory);
-		container.setMessageListener(new MessageListener() {
-			@Override
-			public void onMessage(Message message) {
-				RabbitTemplate rabbitTemplate = new RabbitTemplate(cachingConnectionFactory);
-				rabbitTemplate.setChannelTransacted(true);
-				// should use same channel as container
-				rabbitTemplate.convertAndSend("foo", "bar", "baz");
-				latch.countDown();
-			}
+		container.setMessageListener((MessageListener) message -> {
+			RabbitTemplate rabbitTemplate = new RabbitTemplate(cachingConnectionFactory);
+			rabbitTemplate.setChannelTransacted(true);
+			// should use same channel as container
+			rabbitTemplate.convertAndSend("foo", "bar", "baz");
+			latch.countDown();
 		});
 		container.setQueueNames("queue");
 		container.setChannelTransacted(true);
 		container.setShutdownTimeout(100);
-		container.setTransactionManager(new DummyTxManager());
+		DummyTxManager transactionManager = new DummyTxManager();
+		container.setTransactionManager(transactionManager);
+		RuleBasedTransactionAttribute transactionAttribute = new ListenerFailedRuleBasedTransactionAttribute();
+		List<RollbackRuleAttribute> rollbackRules =
+				Collections.singletonList(new NoRollbackRuleAttribute(IllegalStateException.class));
+		transactionAttribute.setRollbackRules(rollbackRules);
+		container.setTransactionAttribute(transactionAttribute);
 		container.afterPropertiesSet();
 		container.start();
+		assertTrue(consumerLatch.await(10, TimeUnit.SECONDS));
 
-		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(), new byte[] {0});
+		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
+				new byte[] { 0 });
 
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
 
@@ -150,19 +167,79 @@ public class ExternalTxManagerTests {
 			throw e;
 		}
 
-		verify(mockConnection, Mockito.times(1)).createChannel();
-		assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
+		verify(mockConnection, times(1)).createChannel();
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
+		verify(onlyChannel).basicAck(anyLong(), anyBoolean());
 		verify(onlyChannel).txCommit();
-		verify(onlyChannel).basicPublish(Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean(),
-				Mockito.any(BasicProperties.class), Mockito.any(byte[].class));
+		verify(onlyChannel).basicPublish(anyString(), anyString(), anyBoolean(),
+				any(BasicProperties.class), any(byte[].class));
 
 		// verify close() was never called on the channel
 		DirectFieldAccessor dfa = new DirectFieldAccessor(cachingConnectionFactory);
 		List<?> channels = (List<?>) dfa.getPropertyValue("cachedChannelsTransactional");
 		assertEquals(0, channels.size());
 
-		container.stop();
+		assertTrue(transactionManager.committed);
+		transactionManager.committed = false;
+		transactionManager.latch = new CountDownLatch(1);
+		container.setMessageListener((MessageListener) m -> {
+			throw new RuntimeException();
+		});
+		commitLatch.set(new CountDownLatch(1));
+		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
+				new byte[] { 0 });
+		assertTrue(transactionManager.latch.await(10, TimeUnit.SECONDS));
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
+		assertTrue(transactionManager.rolledBack);
+		assertTrue(rollbackLatch.get().await(10, TimeUnit.SECONDS));
+		verify(onlyChannel).basicReject(anyLong(), anyBoolean());
+		verify(onlyChannel, times(1)).txRollback();
 
+		transactionManager.rolledBack = false;
+		transactionManager.latch = new CountDownLatch(1);
+		container.setMessageListener((MessageListener) m -> {
+			throw new IllegalStateException();
+		});
+		commitLatch.set(new CountDownLatch(1));
+		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
+				new byte[] { 0 });
+		assertTrue(transactionManager.latch.await(10, TimeUnit.SECONDS));
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
+		assertTrue(transactionManager.committed);
+		verify(onlyChannel, times(2)).basicAck(anyLong(), anyBoolean());
+		verify(onlyChannel, times(3)).txCommit(); // previous + reject commit for above + this one
+
+		transactionManager.committed = false;
+		transactionManager.latch = new CountDownLatch(1);
+		container.setMessageListener((MessageListener) m -> {
+			throw new AmqpRejectAndDontRequeueException("foo", new ImmediateAcknowledgeAmqpException("bar"));
+		});
+		commitLatch.set(new CountDownLatch(1));
+		rollbackLatch.set(new CountDownLatch(1));
+		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
+				new byte[] { 0 });
+		assertTrue(transactionManager.latch.await(10, TimeUnit.SECONDS));
+		assertTrue(transactionManager.rolledBack);
+		assertTrue(rollbackLatch.get().await(10, TimeUnit.SECONDS));
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
+		verify(onlyChannel, times(2)).basicReject(anyLong(), anyBoolean());
+		verify(onlyChannel, times(2)).txRollback();
+
+		transactionManager.rolledBack = false;
+		transactionManager.latch = new CountDownLatch(1);
+		container.setMessageListener((MessageListener) m -> {
+			throw new ImmediateAcknowledgeAmqpException("foo");
+		});
+		commitLatch.set(new CountDownLatch(1));
+		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
+				new byte[] { 0 });
+		assertTrue(transactionManager.latch.await(10, TimeUnit.SECONDS));
+		assertTrue(commitLatch.get().await(10, TimeUnit.SECONDS));
+		assertTrue(transactionManager.committed);
+		verify(onlyChannel, times(3)).basicAck(anyLong(), anyBoolean());
+		verify(onlyChannel, times(5)).txCommit();
+
+		container.stop();
 	}
 
 	/**
@@ -178,21 +255,21 @@ public class ExternalTxManagerTests {
 		Connection templateConnection = mock(Connection.class);
 		final Channel listenerChannel = mock(Channel.class);
 		Channel templateChannel = mock(Channel.class);
-		when(listenerChannel.isOpen()).thenReturn(true);
-		when(templateChannel.isOpen()).thenReturn(true);
+		given(listenerChannel.isOpen()).willReturn(true);
+		given(templateChannel.isOpen()).willReturn(true);
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(listenerConnectionFactory);
 		final CachingConnectionFactory cachingTemplateConnectionFactory = new CachingConnectionFactory(templateConnectionFactory);
 
-		when(listenerConnectionFactory.newConnection((ExecutorService) null)).thenReturn(listenerConnection);
-		when(listenerConnection.isOpen()).thenReturn(true);
-		when(templateConnectionFactory.newConnection((ExecutorService) null)).thenReturn(templateConnection);
-		when(templateConnection.isOpen()).thenReturn(true);
-		when(templateConnection.createChannel()).thenReturn(templateChannel);
+		given(listenerConnectionFactory.newConnection((ExecutorService) null)).willReturn(listenerConnection);
+		given(listenerConnection.isOpen()).willReturn(true);
+		given(templateConnectionFactory.newConnection((ExecutorService) null)).willReturn(templateConnection);
+		given(templateConnection.isOpen()).willReturn(true);
+		given(templateConnection.createChannel()).willReturn(templateChannel);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -202,40 +279,40 @@ public class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(listenerConnection).createChannel();
+		}).given(listenerConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 
-		doAnswer(new Answer<String>() {
+		willAnswer(new Answer<String>() {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
 				return "consumerTag";
 			}
-		}).when(listenerChannel)
+		}).given(listenerChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(2);
-		doAnswer(new Answer<String>() {
+		willAnswer(new Answer<String>() {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				commitLatch.countDown();
 				return null;
 			}
-		}).when(listenerChannel).txCommit();
-		doAnswer(new Answer<String>() {
+		}).given(listenerChannel).txCommit();
+		willAnswer(new Answer<String>() {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				commitLatch.countDown();
 				return null;
 			}
-		}).when(templateChannel).txCommit();
+		}).given(templateChannel).txCommit();
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(cachingConnectionFactory);
@@ -292,16 +369,16 @@ public class ExternalTxManagerTests {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel onlyChannel = mock(Channel.class);
-		when(onlyChannel.isOpen()).thenReturn(true);
+		given(onlyChannel.isOpen()).willReturn(true);
 
 		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory(mockConnectionFactory);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
-		when(mockConnection.isOpen()).thenReturn(true);
+		given(mockConnectionFactory.newConnection((ExecutorService) null)).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -311,32 +388,32 @@ public class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(mockConnection).createChannel();
+		}).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 
-		doAnswer(new Answer<String>() {
+		willAnswer(new Answer<String>() {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
 				return "consumerTag";
 			}
-		}).when(onlyChannel)
+		}).given(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
-		doAnswer(new Answer<String>() {
+		willAnswer(new Answer<String>() {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				commitLatch.countDown();
 				return null;
 			}
-		}).when(onlyChannel).txCommit();
+		}).given(onlyChannel).txCommit();
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<Channel> exposed = new AtomicReference<Channel>();
@@ -394,16 +471,16 @@ public class ExternalTxManagerTests {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel onlyChannel = mock(Channel.class);
-		when(onlyChannel.isOpen()).thenReturn(true);
+		given(onlyChannel.isOpen()).willReturn(true);
 
 		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory(mockConnectionFactory);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
-		when(mockConnection.isOpen()).thenReturn(true);
+		given(mockConnectionFactory.newConnection((ExecutorService) null)).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -413,32 +490,32 @@ public class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(mockConnection).createChannel();
+		}).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 
-		doAnswer(new Answer<String>() {
+		willAnswer(new Answer<String>() {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
 				return "consumerTag";
 			}
-		}).when(onlyChannel)
+		}).given(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
-		doAnswer(new Answer<String>() {
+		willAnswer(new Answer<String>() {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				commitLatch.countDown();
 				return null;
 			}
-		}).when(onlyChannel).txCommit();
+		}).given(onlyChannel).txCommit();
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicReference<Channel> exposed = new AtomicReference<Channel>();
@@ -497,16 +574,16 @@ public class ExternalTxManagerTests {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel onlyChannel = mock(Channel.class);
-		when(onlyChannel.isOpen()).thenReturn(true);
+		given(onlyChannel.isOpen()).willReturn(true);
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
-		when(mockConnection.isOpen()).thenReturn(true);
+		given(mockConnectionFactory.newConnection((ExecutorService) null)).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		doAnswer(new Answer<Channel>() {
+		willAnswer(new Answer<Channel>() {
 			boolean done;
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
@@ -516,32 +593,32 @@ public class ExternalTxManagerTests {
 				}
 				tooManyChannels.set(new Exception("More than one channel requested"));
 				Channel channel = mock(Channel.class);
-				when(channel.isOpen()).thenReturn(true);
+				given(channel.isOpen()).willReturn(true);
 				return channel;
 			}
-		}).when(mockConnection).createChannel();
+		}).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 
-		doAnswer(new Answer<String>() {
+		willAnswer(new Answer<String>() {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				consumer.set((Consumer) invocation.getArguments()[6]);
 				return "consumerTag";
 			}
-		}).when(onlyChannel)
+		}).given(onlyChannel)
 			.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(), any(Consumer.class));
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
-		doAnswer(new Answer<String>() {
+		willAnswer(new Answer<String>() {
 
 			@Override
 			public String answer(InvocationOnMock invocation) throws Throwable {
 				commitLatch.countDown();
 				return null;
 			}
-		}).when(onlyChannel).txCommit();
+		}).given(onlyChannel).txCommit();
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(cachingConnectionFactory);
@@ -588,6 +665,12 @@ public class ExternalTxManagerTests {
 	@SuppressWarnings("serial")
 	private static class DummyTxManager extends AbstractPlatformTransactionManager {
 
+		private volatile boolean committed;
+
+		private volatile boolean rolledBack;
+
+		private volatile CountDownLatch latch = new CountDownLatch(1);
+
 		@Override
 		protected Object doGetTransaction() throws TransactionException {
 			return new Object();
@@ -599,10 +682,14 @@ public class ExternalTxManagerTests {
 
 		@Override
 		protected void doCommit(DefaultTransactionStatus status) throws TransactionException {
+			this.committed = true;
+			this.latch.countDown();
 		}
 
 		@Override
 		protected void doRollback(DefaultTransactionStatus status) throws TransactionException {
+			this.rolledBack = true;
+			this.latch.countDown();
 		}
 	}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3603,6 +3603,34 @@ a database constraint error, or connectivity problem), then the AMQP transaction
 This is sometimes known as a Best Efforts 1 Phase Commit, and is a very powerful pattern for reliable messaging.
 If the `channelTransacted` flag was set to false in the example above, which is the default, then the external transaction would still be provided for the listener, but all messaging operations would be auto-acked, so the effect is to commit the messaging operations even on a rollback of the business operation.
 
+[[conditional-rollback]]
+===== Conditional Rollback
+
+Prior to _version 1.6.6_, adding a rollback rule to a container's `transactionAttribute`, when using an external transaction manager (e.g. JDBC) had no effect; exceptions always rolled back the transaction.
+
+Also, when using a http://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/transaction.html#transaction-declarative[transaction advice] in the container's advice chain, conditional rollback was not very useful because all listener exceptions are wrapped in a `ListenerExecutionFailedException`.
+
+The first problem has been corrected and the rules are now applied properly.
+Further, the `ListenerFailedRuleBasedTransactionAttribute` is now provided; it is a subclass of `RuleBasedTransactionAttribute`, with the only difference being that it is aware of the `ListenerExecutionFailedException` and uses the cause of such exceptions for the rule.
+This transaction attribute can be used directly in the container, or via a transaction advice.
+
+An example of using this rule follows:
+
+[source, java]
+----
+@Bean
+public AbstractMessageListenerContainer container() {
+    ...
+    container.setTransactionManager(transactionManager);
+    RuleBasedTransactionAttribute transactionAttribute =
+        new ListenerFailedRuleBasedTransactionAttribute();
+    transactionAttribute.setRollbackRules(Collections.singletonList(
+        new NoRollbackRuleAttribute(DontRollBackException.class)));
+    container.setTransactionAttribute(transactionAttribute);
+    ...
+}
+----
+
 ===== A note on Rollback of Received Messages
 
 AMQP transactions only apply to messages and acks sent to the broker, so when there is a rollback of a Spring transaction and a message has been received, what Spring AMQP has to do is not just rollback the transaction, but also manually reject the message (sort of a nack, but that's not what the specification calls it).

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -29,6 +29,12 @@ The framework is no longer compatible with previous versions.
 Rules that have up until now been used internally by the framework have now been made available in a separate jar `spring-rabbit-junit`.
 See <<junit-rules>> for more information.
 
+===== Container Conditional Rollback
+
+When using an external transaction manager (e.g. JDBC), rule-based rollback is now supported when providing the container with a transaction attribute.
+It is also now more flexible when using a transaction advice.
+See <<conditional-rollback>> for more information.
+
 ==== Earlier Releases
 
 See <<previous-whats-new>> for changes in previous versions.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-687

When using a rule-based transaction attribute with a rollback/no-rollback rule,
the rule is ignored when providing the transaction attribute directly to the container
rather than via a transaction advice,

Also, user exceptions are always wrapped in a `ListenerExecutionFailedException` which
limits the ability to configure rules, even when using an advice.

- Honor the attribute `rollBackOn()` mechanism within the container
- Add `ListenerFailedRuleBasedTransactionAttribute` to allow the user to configure rules based on the actual exception.

Add docs.

AMQP-686: Handle ImmediateAcknowledgeAmqpException

JIRA: https://jira.spring.io/browse/AMQP-686

Previously, `ImmediateAcknowledgeAmqpException` only worked if thrown by
an error handler, not a listener.

Examine the cause chain to see if this exception appears, and handle accordingly.

An `AmqpRejectAndDontRequeueException` found first stops the chain traversal.

Also clarify the javadocs to make it clear the current transaction is ended
immediately, not all message delivery.

checkstyle

Polishing and Fixes

While polishing for PR comments, I found some more problems (existing code).

When using an external transaction manager, txRollback() was called twice, once
within the transaction and once by the after completion in the transaction synchronization.

This was benign because the delivery tags were not registered, but incorrect.

Now, the delivery tag is always registered and the rollback done by the synchronization.

Added more tests and added tests for the local transaction scenario.

Add missing .this

Polishing

Conflicts:
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerSMLCTests.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
	src/reference/asciidoc/whats-new.adoc

Resolved.