### PR TITLE
AMQP-675: RabbitTemplate - Add Typed Returns

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpTemplate.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpTemplate.java
@@ -18,18 +18,21 @@ package org.springframework.amqp.core;
 
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.core.ParameterizedTypeReference;
 
 /**
  * Specifies a basic set of AMQP operations.
  *
- * Provides synchronous send and receive methods. The {@link #convertAndSend(Object)} and {@link #receiveAndConvert()}
- * methods allow let you send and receive POJO objects. Implementations are expected to delegate to an instance of
- * {@link MessageConverter} to perform conversion to and from AMQP byte[] payload type.
+ * Provides synchronous send and receive methods. The {@link #convertAndSend(Object)} and
+ * {@link #receiveAndConvert()} methods allow let you send and receive POJO objects.
+ * Implementations are expected to delegate to an instance of {@link MessageConverter} to
+ * perform conversion to and from AMQP byte[] payload type.
  *
  * @author Mark Pollack
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Ernest Sadykov
+ * @author Gary Russell
  */
 public interface AmqpTemplate {
 
@@ -65,7 +68,8 @@ public interface AmqpTemplate {
 	// send methods with conversion
 
 	/**
-	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange with a default routing key.
+	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange
+	 * with a default routing key.
 	 *
 	 * @param message a message to send
 	 * @throws AmqpException if there is a problem
@@ -73,7 +77,8 @@ public interface AmqpTemplate {
 	void convertAndSend(Object message) throws AmqpException;
 
 	/**
-	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange with a specific routing key.
+	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange
+	 * with a specific routing key.
 	 *
 	 * @param routingKey the routing key
 	 * @param message a message to send
@@ -82,7 +87,8 @@ public interface AmqpTemplate {
 	void convertAndSend(String routingKey, Object message) throws AmqpException;
 
 	/**
-	 * Convert a Java object to an Amqp {@link Message} and send it to a specific exchange with a specific routing key.
+	 * Convert a Java object to an Amqp {@link Message} and send it to a specific exchange
+	 * with a specific routing key.
 	 *
 	 * @param exchange the name of the exchange
 	 * @param routingKey the routing key
@@ -92,7 +98,8 @@ public interface AmqpTemplate {
 	void convertAndSend(String exchange, String routingKey, Object message) throws AmqpException;
 
 	/**
-	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange with a default routing key.
+	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange
+	 * with a default routing key.
 	 *
 	 * @param message a message to send
 	 * @param messagePostProcessor a processor to apply to the message before it is sent
@@ -101,7 +108,8 @@ public interface AmqpTemplate {
 	void convertAndSend(Object message, MessagePostProcessor messagePostProcessor) throws AmqpException;
 
 	/**
-	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange with a specific routing key.
+	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange
+	 * with a specific routing key.
 	 *
 	 * @param routingKey the routing key
 	 * @param message a message to send
@@ -112,7 +120,8 @@ public interface AmqpTemplate {
 			throws AmqpException;
 
 	/**
-	 * Convert a Java object to an Amqp {@link Message} and send it to a specific exchange with a specific routing key.
+	 * Convert a Java object to an Amqp {@link Message} and send it to a specific exchange
+	 * with a specific routing key.
 	 *
 	 * @param exchange the name of the exchange
 	 * @param routingKey the routing key
@@ -126,7 +135,8 @@ public interface AmqpTemplate {
 	// receive methods for messages
 
 	/**
-	 * Receive a message if there is one from a default queue. Returns immediately, possibly with a null value.
+	 * Receive a message if there is one from a default queue. Returns immediately,
+	 * possibly with a null value.
 	 *
 	 * @return a message or null if there is none waiting
 	 * @throws AmqpException if there is a problem
@@ -134,7 +144,8 @@ public interface AmqpTemplate {
 	Message receive() throws AmqpException;
 
 	/**
-	 * Receive a message if there is one from a specific queue. Returns immediately, possibly with a null value.
+	 * Receive a message if there is one from a specific queue. Returns immediately,
+	 * possibly with a null value.
 	 *
 	 * @param queueName the name of the queue to poll
 	 * @return a message or null if there is none waiting
@@ -143,12 +154,12 @@ public interface AmqpTemplate {
 	Message receive(String queueName) throws AmqpException;
 
 	/**
-	 * Receive a message from a default queue, waiting up to the specified wait time if necessary for a message
-	 * to become available.
+	 * Receive a message from a default queue, waiting up to the specified wait time if
+	 * necessary for a message to become available.
 	 *
-	 * @param timeoutMillis how long to wait before giving up. Zero value means the method will return {@code null}
-	 *                      immediately if there is no message available. Negative value makes method wait for
-	 *                      a message indefinitely.
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method
+	 * will return {@code null} immediately if there is no message available. Negative
+	 * value makes method wait for a message indefinitely.
 	 * @return a message or null if the time expires
 	 * @throws AmqpException if there is a problem
 	 * @since 1.6
@@ -156,13 +167,13 @@ public interface AmqpTemplate {
 	Message receive(long timeoutMillis) throws AmqpException;
 
 	/**
-	 * Receive a message from a specific queue, waiting up to the specified wait time if necessary for a message
-	 * to become available.
+	 * Receive a message from a specific queue, waiting up to the specified wait time if
+	 * necessary for a message to become available.
 	 *
 	 * @param queueName the queue to receive from
-	 * @param timeoutMillis how long to wait before giving up. Zero value means the method will return {@code null}
-	 *                      immediately if there is no message available. Negative value makes method wait for
-	 *                      a message indefinitely.
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method
+	 * will return {@code null} immediately if there is no message available. Negative
+	 * value makes method wait for a message indefinitely.
 	 * @return a message or null if the time expires
 	 * @throws AmqpException if there is a problem
 	 * @since 1.6
@@ -172,8 +183,8 @@ public interface AmqpTemplate {
 	// receive methods with conversion
 
 	/**
-	 * Receive a message if there is one from a default queue and convert it to a Java object. Returns immediately,
-	 * possibly with a null value.
+	 * Receive a message if there is one from a default queue and convert it to a Java
+	 * object. Returns immediately, possibly with a null value.
 	 *
 	 * @return a message or null if there is none waiting
 	 * @throws AmqpException if there is a problem
@@ -181,8 +192,8 @@ public interface AmqpTemplate {
 	Object receiveAndConvert() throws AmqpException;
 
 	/**
-	 * Receive a message if there is one from a specific queue and convert it to a Java object. Returns immediately,
-	 * possibly with a null value.
+	 * Receive a message if there is one from a specific queue and convert it to a Java
+	 * object. Returns immediately, possibly with a null value.
 	 *
 	 * @param queueName the name of the queue to poll
 	 * @return a message or null if there is none waiting
@@ -191,12 +202,13 @@ public interface AmqpTemplate {
 	Object receiveAndConvert(String queueName) throws AmqpException;
 
 	/**
-	 * Receive a message if there is one from a default queue and convert it to a Java object. Wait up to the
-	 * specified wait time if necessary for a message to become available.
+	 * Receive a message if there is one from a default queue and convert it to a Java
+	 * object. Wait up to the specified wait time if necessary for a message to become
+	 * available.
 	 *
-	 * @param timeoutMillis how long to wait before giving up. Zero value means the method will return {@code null}
-	 *                      immediately if there is no message available. Negative value makes method wait for
-	 *                      a message indefinitely.
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method
+	 * will return {@code null} immediately if there is no message available. Negative
+	 * value makes method wait for a message indefinitely.
 	 * @return a message or null if the time expires
 	 * @throws AmqpException if there is a problem
 	 * @since 1.6
@@ -204,30 +216,94 @@ public interface AmqpTemplate {
 	Object receiveAndConvert(long timeoutMillis) throws AmqpException;
 
 	/**
-	 * Receive a message if there is one from a specific queue and convert it to a Java object. Wait up to the
-	 * specified wait time if necessary for a message to become available.
+	 * Receive a message if there is one from a specific queue and convert it to a Java
+	 * object. Wait up to the specified wait time if necessary for a message to become
+	 * available.
 	 *
 	 * @param queueName the name of the queue to poll
-	 * @param timeoutMillis how long to wait before giving up. Zero value means the method will return {@code null}
-	 *                      immediately if there is no message available. Negative value makes method wait for
-	 *                      a message indefinitely.
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method
+	 * will return {@code null} immediately if there is no message available. Negative
+	 * value makes method wait for a message indefinitely.
 	 * @return a message or null if the time expires
 	 * @throws AmqpException if there is a problem
 	 * @since 1.6
 	 */
 	Object receiveAndConvert(String queueName, long timeoutMillis) throws AmqpException;
 
+	/**
+	 * Receive a message if there is one from a default queue and convert it to a Java
+	 * object. Returns immediately, possibly with a null value. Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param type the type to convert to.
+	 * @param <T> the type.
+	 * @return a message or null if there is none waiting.
+	 * @throws AmqpException if there is a problem.
+	 * @since 2.0
+	 */
+	<T> T receiveAndConvert(ParameterizedTypeReference<T> type) throws AmqpException;
+
+	/**
+	 * Receive a message if there is one from a specific queue and convert it to a Java
+	 * object. Returns immediately, possibly with a null value. Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param queueName the name of the queue to poll
+	 * @param type the type to convert to.
+	 * @param <T> the type.
+	 * @return a message or null if there is none waiting
+	 * @throws AmqpException if there is a problem
+	 * @since 2.0
+	 */
+	<T> T receiveAndConvert(String queueName, ParameterizedTypeReference<T> type) throws AmqpException;
+
+	/**
+	 * Receive a message if there is one from a default queue and convert it to a Java
+	 * object. Wait up to the specified wait time if necessary for a message to become
+	 * available. Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method
+	 * will return {@code null} immediately if there is no message available. Negative
+	 * value makes method wait for a message indefinitely.
+	 * @param type the type to convert to.
+	 * @param <T> the type.
+	 * @return a message or null if the time expires
+	 * @throws AmqpException if there is a problem
+	 * @since 2.0
+	 */
+	<T> T receiveAndConvert(long timeoutMillis, ParameterizedTypeReference<T> type) throws AmqpException;
+
+	/**
+	 * Receive a message if there is one from a specific queue and convert it to a Java
+	 * object. Wait up to the specified wait time if necessary for a message to become
+	 * available. Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param queueName the name of the queue to poll
+	 * @param timeoutMillis how long to wait before giving up. Zero value means the method
+	 * will return {@code null} immediately if there is no message available. Negative
+	 * value makes method wait for a message indefinitely.
+	 * @param type the type to convert to.
+	 * @param <T> the type.
+	 * @return a message or null if the time expires
+	 * @throws AmqpException if there is a problem
+	 * @since 2.0
+	 */
+	<T> T receiveAndConvert(String queueName, long timeoutMillis, ParameterizedTypeReference<T> type)
+			throws AmqpException;
+
 	// receive and send methods for provided callback
 
 	/**
-	 * Receive a message if there is one from a default queue, invoke provided {@link ReceiveAndReplyCallback}
-	 * and send reply message, if the {@code callback} returns one,
-	 * to the {@code replyTo} {@link org.springframework.amqp.core.Address}
-	 * from {@link org.springframework.amqp.core.MessageProperties}
-	 * or to default exchange and default routingKey.
+	 * Receive a message if there is one from a default queue, invoke provided
+	 * {@link ReceiveAndReplyCallback} and send reply message, if the {@code callback}
+	 * returns one, to the {@code replyTo} {@link org.springframework.amqp.core.Address}
+	 * from {@link org.springframework.amqp.core.MessageProperties} or to default exchange
+	 * and default routingKey.
 	 *
-	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to process received message
-	 *                 and return a reply message.
+	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to
+	 * process received message and return a reply message.
 	 * @param <R> The type of the request after conversion from the {@link Message}.
 	 * @param <S> The type of the response.
 	 * @return {@code true}, if message was received
@@ -236,15 +312,15 @@ public interface AmqpTemplate {
 	<R, S> boolean receiveAndReply(ReceiveAndReplyCallback<R, S> callback) throws AmqpException;
 
 	/**
-	 * Receive a message if there is one from provided queue, invoke provided {@link ReceiveAndReplyCallback}
-	 * and send reply message, if the {@code callback} returns one,
-	 * to the {@code replyTo} {@link org.springframework.amqp.core.Address}
-	 * from {@link org.springframework.amqp.core.MessageProperties}
-	 * or to default exchange and default routingKey.
+	 * Receive a message if there is one from provided queue, invoke provided
+	 * {@link ReceiveAndReplyCallback} and send reply message, if the {@code callback}
+	 * returns one, to the {@code replyTo} {@link org.springframework.amqp.core.Address}
+	 * from {@link org.springframework.amqp.core.MessageProperties} or to default exchange
+	 * and default routingKey.
 	 *
 	 * @param queueName the queue name to receive a message.
-	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to process received message
-	 *                 and return a reply message.
+	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to
+	 * process received message and return a reply message.
 	 * @param <R> The type of the request after conversion from the {@link Message}.
 	 * @param <S> The type of the response.
 	 * @return {@code true}, if message was received.
@@ -253,12 +329,12 @@ public interface AmqpTemplate {
 	<R, S> boolean receiveAndReply(String queueName, ReceiveAndReplyCallback<R, S> callback) throws AmqpException;
 
 	/**
-	 * Receive a message if there is one from default queue, invoke provided {@link ReceiveAndReplyCallback}
-	 * and send reply message, if the {@code callback} returns one,
-	 * to the provided {@code exchange} and {@code routingKey}.
+	 * Receive a message if there is one from default queue, invoke provided
+	 * {@link ReceiveAndReplyCallback} and send reply message, if the {@code callback}
+	 * returns one, to the provided {@code exchange} and {@code routingKey}.
 	 *
-	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to process received message
-	 *                 and return a reply message.
+	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to
+	 * process received message and return a reply message.
 	 * @param replyExchange the exchange name to send reply message.
 	 * @param replyRoutingKey the routing key to send reply message.
 	 * @param <R> The type of the request after conversion from the {@link Message}.
@@ -270,14 +346,14 @@ public interface AmqpTemplate {
 			throws AmqpException;
 
 	/**
-	 * Receive a message if there is one from provided queue, invoke provided {@link ReceiveAndReplyCallback}
-	 * and send reply message, if the {@code callback} returns one,
-	 * to the provided {@code exchange} and {@code routingKey}.
+	 * Receive a message if there is one from provided queue, invoke provided
+	 * {@link ReceiveAndReplyCallback} and send reply message, if the {@code callback}
+	 * returns one, to the provided {@code exchange} and {@code routingKey}.
 	 *
 	 *
 	 * @param queueName the queue name to receive a message.
-	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to process received message
-	 *                 and return a reply message.
+	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to
+	 * process received message and return a reply message.
 	 * @param replyExchange the exchange name to send reply message.
 	 * @param replyRoutingKey the routing key to send reply message.
 	 * @param <R> The type of the request after conversion from the {@link Message}.
@@ -286,34 +362,34 @@ public interface AmqpTemplate {
 	 * @throws AmqpException if there is a problem
 	 */
 	<R, S> boolean receiveAndReply(String queueName, ReceiveAndReplyCallback<R, S> callback, String replyExchange,
-								   String replyRoutingKey) throws AmqpException;
+			String replyRoutingKey) throws AmqpException;
 
 	/**
-	 * Receive a message if there is one from a default queue, invoke provided {@link ReceiveAndReplyCallback}
-	 * and send reply message, if the {@code callback} returns one,
-	 * to the {@code replyTo} {@link org.springframework.amqp.core.Address}
+	 * Receive a message if there is one from a default queue, invoke provided
+	 * {@link ReceiveAndReplyCallback} and send reply message, if the {@code callback}
+	 * returns one, to the {@code replyTo} {@link org.springframework.amqp.core.Address}
 	 * from result of {@link ReplyToAddressCallback}.
 	 *
-	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to process received message
-	 *                 and return a reply message.
+	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to
+	 * process received message and return a reply message.
 	 * @param replyToAddressCallback the callback to determine replyTo address at runtime.
 	 * @param <R> The type of the request after conversion from the {@link Message}.
 	 * @param <S> The type of the response.
 	 * @return {@code true}, if message was received.
 	 * @throws AmqpException if there is a problem.
 	 */
-	<R, S> boolean receiveAndReply(ReceiveAndReplyCallback<R, S> callback, ReplyToAddressCallback<S> replyToAddressCallback)
-			throws AmqpException;
+	<R, S> boolean receiveAndReply(ReceiveAndReplyCallback<R, S> callback,
+			ReplyToAddressCallback<S> replyToAddressCallback) throws AmqpException;
 
 	/**
-	 * Receive a message if there is one from provided queue, invoke provided {@link ReceiveAndReplyCallback}
-	 * and send reply message, if the {@code callback} returns one,
-	 * to the {@code replyTo} {@link org.springframework.amqp.core.Address}
+	 * Receive a message if there is one from provided queue, invoke provided
+	 * {@link ReceiveAndReplyCallback} and send reply message, if the {@code callback}
+	 * returns one, to the {@code replyTo} {@link org.springframework.amqp.core.Address}
 	 * from result of {@link ReplyToAddressCallback}.
 	 *
 	 * @param queueName the queue name to receive a message.
-	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to process received message
-	 *                 and return a reply message.
+	 * @param callback a user-provided {@link ReceiveAndReplyCallback} implementation to
+	 * process received message and return a reply message.
 	 * @param replyToAddressCallback the callback to determine replyTo address at runtime.
 	 * @param <R> The type of the request after conversion from the {@link Message}.
 	 * @param <S> The type of the response.
@@ -326,9 +402,9 @@ public interface AmqpTemplate {
 	// send and receive methods for messages
 
 	/**
-	 * Basic RPC pattern. Send a message to a default exchange with a default routing key and attempt to receive a
-	 * response. Implementations will normally set the reply-to header to an exclusive queue and wait up for some time
-	 * limited by a timeout.
+	 * Basic RPC pattern. Send a message to a default exchange with a default routing key
+	 * and attempt to receive a response. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
 	 *
 	 * @param message a message to send
 	 * @return the response if there is one
@@ -337,9 +413,9 @@ public interface AmqpTemplate {
 	Message sendAndReceive(Message message) throws AmqpException;
 
 	/**
-	 * Basic RPC pattern. Send a message to a default exchange with a specific routing key and attempt to receive a
-	 * response. Implementations will normally set the reply-to header to an exclusive queue and wait up for some time
-	 * limited by a timeout.
+	 * Basic RPC pattern. Send a message to a default exchange with a specific routing key
+	 * and attempt to receive a response. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
 	 *
 	 * @param routingKey the routing key
 	 * @param message a message to send
@@ -349,9 +425,10 @@ public interface AmqpTemplate {
 	Message sendAndReceive(String routingKey, Message message) throws AmqpException;
 
 	/**
-	 * Basic RPC pattern. Send a message to a specific exchange with a specific routing key and attempt to receive a
-	 * response. Implementations will normally set the reply-to header to an exclusive queue and wait up for some time
-	 * limited by a timeout.
+	 * Basic RPC pattern. Send a message to a specific exchange with a specific routing
+	 * key and attempt to receive a response. Implementations will normally set the
+	 * reply-to header to an exclusive queue and wait up for some time limited by a
+	 * timeout.
 	 *
 	 * @param exchange the name of the exchange
 	 * @param routingKey the routing key
@@ -364,9 +441,10 @@ public interface AmqpTemplate {
 	// send and receive methods with conversion
 
 	/**
-	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a default exchange with a default
-	 * routing key and attempt to receive a response, converting that to a Java object. Implementations will normally
-	 * set the reply-to header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a default routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
 	 *
 	 * @param message a message to send
 	 * @return the response if there is one
@@ -375,9 +453,10 @@ public interface AmqpTemplate {
 	Object convertSendAndReceive(Object message) throws AmqpException;
 
 	/**
-	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a default exchange with a
-	 * specific routing key and attempt to receive a response, converting that to a Java object. Implementations will
-	 * normally set the reply-to header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
 	 *
 	 * @param routingKey the routing key
 	 * @param message a message to send
@@ -387,9 +466,10 @@ public interface AmqpTemplate {
 	Object convertSendAndReceive(String routingKey, Object message) throws AmqpException;
 
 	/**
-	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a specific exchange with a
-	 * specific routing key and attempt to receive a response, converting that to a Java object. Implementations will
-	 * normally set the reply-to header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * specific exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
 	 *
 	 * @param exchange the name of the exchange
 	 * @param routingKey the routing key
@@ -400,9 +480,10 @@ public interface AmqpTemplate {
 	Object convertSendAndReceive(String exchange, String routingKey, Object message) throws AmqpException;
 
 	/**
-	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a default exchange with a default
-	 * routing key and attempt to receive a response, converting that to a Java object. Implementations will normally
-	 * set the reply-to header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a default routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
 	 *
 	 * @param message a message to send
 	 * @param messagePostProcessor a processor to apply to the message before it is sent
@@ -412,9 +493,10 @@ public interface AmqpTemplate {
 	Object convertSendAndReceive(Object message, MessagePostProcessor messagePostProcessor) throws AmqpException;
 
 	/**
-	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a default exchange with a
-	 * specific routing key and attempt to receive a response, converting that to a Java object. Implementations will
-	 * normally set the reply-to header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
 	 *
 	 * @param routingKey the routing key
 	 * @param message a message to send
@@ -422,12 +504,14 @@ public interface AmqpTemplate {
 	 * @return the response if there is one
 	 * @throws AmqpException if there is a problem
 	 */
-	Object convertSendAndReceive(String routingKey, Object message, MessagePostProcessor messagePostProcessor) throws AmqpException;
+	Object convertSendAndReceive(String routingKey, Object message, MessagePostProcessor messagePostProcessor)
+			throws AmqpException;
 
 	/**
-	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a specific exchange with a
-	 * specific routing key and attempt to receive a response, converting that to a Java object. Implementations will
-	 * normally set the reply-to header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * specific exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
 	 *
 	 * @param exchange the name of the exchange
 	 * @param routingKey the routing key
@@ -436,6 +520,120 @@ public interface AmqpTemplate {
 	 * @return the response if there is one
 	 * @throws AmqpException if there is a problem
 	 */
-	Object convertSendAndReceive(String exchange, String routingKey, Object message, MessagePostProcessor messagePostProcessor) throws AmqpException;
+	Object convertSendAndReceive(String exchange, String routingKey, Object message,
+			MessagePostProcessor messagePostProcessor) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a default routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param message a message to send.
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one.
+	 * @throws AmqpException if there is a problem.
+	 */
+	<T> T convertSendAndReceiveAsType(final Object message, ParameterizedTypeReference<T> responseType)
+			throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(final String routingKey, final Object message,
+			ParameterizedTypeReference<T> responseType) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * specific exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(final String exchange, final String routingKey, final Object message,
+			ParameterizedTypeReference<T> responseType) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a default routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(final Object message, final MessagePostProcessor messagePostProcessor,
+			ParameterizedTypeReference<T> responseType) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(final String routingKey, final Object message,
+			final MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<T> responseType)
+			throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * specific exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(final String exchange, final String routingKey, final Object message,
+			final MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<T> responseType)
+			throws AmqpException;
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AsyncAmqpTemplate.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AsyncAmqpTemplate.java
@@ -16,6 +16,7 @@
 
 package org.springframework.amqp.core;
 
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.concurrent.ListenableFuture;
 
 /**
@@ -122,5 +123,82 @@ public interface AsyncAmqpTemplate {
 	 */
 	<C> ListenableFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object,
 			MessagePostProcessor messagePostProcessor);
+
+	/**
+	 * Convert the object to a message and send it to the default exchange with the
+	 * default routing key.
+	 * @param object the object to convert.
+	 * @param responseType the response type.
+	 * @param <C> the expected result type.
+	 * @return the {@link ListenableFuture}.
+	 */
+	<C> ListenableFuture<C> convertSendAndReceiveAsType(Object object, ParameterizedTypeReference<C> responseType);
+
+	/**
+	 * Convert the object to a message and send it to the default exchange with the
+	 * provided routing key.
+	 * @param routingKey the routing key.
+	 * @param object the object to convert.
+	 * @param responseType the response type.
+	 * @param <C> the expected result type.
+	 * @return the {@link ListenableFuture}.
+	 */
+	<C> ListenableFuture<C> convertSendAndReceiveAsType(String routingKey, Object object,
+			ParameterizedTypeReference<C> responseType);
+
+	/**
+	 * Convert the object to a message and send it to the provided exchange and
+	 * routing key.
+	 * @param exchange the exchange.
+	 * @param routingKey the routing key.
+	 * @param object the object to convert.
+	 * @param responseType the response type.
+	 * @param <C> the expected result type.
+	 * @return the {@link ListenableFuture}.
+	 */
+	<C> ListenableFuture<C> convertSendAndReceiveAsType(String exchange, String routingKey, Object object,
+			ParameterizedTypeReference<C> responseType);
+
+	/**
+	 * Convert the object to a message and send it to the default exchange with the
+	 * default routing key after invoking the {@link MessagePostProcessor}.
+	 * If the post processor adds a correlationId property, it must be unique.
+	 * @param object the object to convert.
+	 * @param messagePostProcessor the post processor.
+	 * @param responseType the response type.
+	 * @param <C> the expected result type.
+	 * @return the {@link ListenableFuture}.
+	 */
+	<C> ListenableFuture<C> convertSendAndReceiveAsType(Object object, MessagePostProcessor messagePostProcessor,
+			ParameterizedTypeReference<C> responseType);
+
+	/**
+	 * Convert the object to a message and send it to the default exchange with the
+	 * provided routing key after invoking the {@link MessagePostProcessor}.
+	 * If the post processor adds a correlationId property, it must be unique.
+	 * @param routingKey the routing key.
+	 * @param object the object to convert.
+	 * @param messagePostProcessor the post processor.
+	 * @param responseType the response type.
+	 * @param <C> the expected result type.
+	 * @return the {@link ListenableFuture}.
+	 */
+	<C> ListenableFuture<C> convertSendAndReceiveAsType(String routingKey, Object object,
+			MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<C> responseType);
+
+	/**
+	 * Convert the object to a message and send it to the provided exchange and
+	 * routing key after invoking the {@link MessagePostProcessor}.
+	 * If the post processor adds a correlationId property, it must be unique.
+	 * @param exchange the exchange
+	 * @param routingKey the routing key.
+	 * @param object the object to convert.
+	 * @param messagePostProcessor the post processor.
+	 * @param responseType the response type.
+	 * @param <C> the expected result type.
+	 * @return the {@link ListenableFuture}.
+	 */
+	<C> ListenableFuture<C> convertSendAndReceiveAsType(String exchange, String routingKey, Object object,
+			MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<C> responseType);
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SmartMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SmartMessageConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support.converter;
+
+import org.springframework.amqp.core.Message;
+
+/**
+ * An extended {@link MessageConverter} SPI with conversion hint support.
+ *
+ * <p>In case of a conversion hint being provided, the framework will call
+ * these extended methods if a converter implements this interface, instead
+ * of calling the regular {@code fromMessage} / {@code toMessage} variants.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public interface SmartMessageConverter extends MessageConverter {
+
+	/**
+	 * A variant of {@link #fromMessage(Message)} which takes an extra
+	 * conversion context as an argument.
+	 * @param message the input message.
+	 * @param conversionHint an extra object passed to the {@link MessageConverter}.
+	 * @return the result of the conversion, or {@code null} if the converter cannot
+	 * perform the conversion.
+	 * @see #fromMessage(Message)
+	 * @throws MessageConversionException if the conversion fails.
+	 */
+	Object fromMessage(Message message, Object conversionHint) throws MessageConversionException;
+
+}

--- a/spring-amqp/src/test/java/org/springframework/amqp/remoting/testhelper/AbstractAmqpTemplate.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/remoting/testhelper/AbstractAmqpTemplate.java
@@ -22,6 +22,7 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.core.ReceiveAndReplyCallback;
 import org.springframework.amqp.core.ReplyToAddressCallback;
+import org.springframework.core.ParameterizedTypeReference;
 
 /**
  * @author David Bilge
@@ -196,6 +197,59 @@ public abstract class AbstractAmqpTemplate implements AmqpTemplate {
 	public Object convertSendAndReceive(String exchange, String routingKey, Object message,
 			MessagePostProcessor messagePostProcessor) throws AmqpException {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <T> T convertSendAndReceiveAsType(final String exchange, final String routingKey, final Object message, final MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<T> responseType)
+			throws AmqpException {
+		return null;
+	}
+
+	@Override
+	public <T> T convertSendAndReceiveAsType(final String routingKey, final Object message, final MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<T> responseType)
+			throws AmqpException {
+		return null;
+	}
+
+	@Override
+	public <T> T convertSendAndReceiveAsType(final Object message, final MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<T> responseType) throws AmqpException {
+		return null;
+	}
+
+	@Override
+	public <T> T convertSendAndReceiveAsType(final String exchange, final String routingKey, final Object message, ParameterizedTypeReference<T> responseType)
+			throws AmqpException {
+		return null;
+	}
+
+	@Override
+	public <T> T convertSendAndReceiveAsType(final String routingKey, final Object message, ParameterizedTypeReference<T> responseType) throws AmqpException {
+		return null;
+	}
+
+	@Override
+	public <T> T convertSendAndReceiveAsType(final Object message, ParameterizedTypeReference<T> responseType) throws AmqpException {
+		return null;
+	}
+
+	@Override
+	public <T> T receiveAndConvert(String queueName, long timeoutMillis, ParameterizedTypeReference<T> type) throws AmqpException {
+		return null;
+	}
+
+	@Override
+	public <T> T receiveAndConvert(long timeoutMillis, ParameterizedTypeReference<T> type) throws AmqpException {
+		return null;
+	}
+
+	@Override
+	public <T> T receiveAndConvert(String queueName, ParameterizedTypeReference<T> type) throws AmqpException {
+		return null;
+	}
+
+	@Override
+	public <T> T receiveAndConvert(ParameterizedTypeReference<T> type) throws AmqpException {
+		return null;
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
@@ -18,21 +18,26 @@ package org.springframework.amqp.rabbit.core;
 
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.support.CorrelationData;
+import org.springframework.core.ParameterizedTypeReference;
 
 /**
  * Rabbit specific methods for Amqp functionality.
  * @author Mark Pollack
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public interface RabbitOperations extends AmqpTemplate {
 
 	/**
-	 * Execute the callback with a channel and reliably close the channel
-	 * afterwards.
+	 * Execute the callback with a channel and reliably close the channel afterwards.
 	 * @param action the call back.
 	 * @param <T> the return type.
-	 * @return the result from the {@link ChannelCallback#doInRabbit(com.rabbitmq.client.Channel)}.
+	 * @return the result from the
+	 * {@link ChannelCallback#doInRabbit(com.rabbitmq.client.Channel)}.
 	 * @throws AmqpException if one occurs.
 	 */
 	<T> T execute(ChannelCallback<T> action) throws AmqpException;
@@ -43,5 +48,302 @@ public interface RabbitOperations extends AmqpTemplate {
 	 * @since 2.0
 	 */
 	ConnectionFactory getConnectionFactory();
+
+	/**
+	 * Send a message to a specific exchange with a specific routing key.
+	 *
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param correlationData data to correlate publisher confirms.
+	 * @throws AmqpException if there is a problem
+	 */
+	void send(String exchange, String routingKey, Message message, CorrelationData correlationData)
+			throws AmqpException;
+
+	/**
+	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange
+	 * with a default routing key.
+	 *
+	 * @param message a message to send
+	 * @param correlationData data to correlate publisher confirms.
+	 * @throws AmqpException if there is a problem
+	 */
+	void correlationConvertAndSend(Object message, CorrelationData correlationData) throws AmqpException;
+
+	/**
+	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange
+	 * with a specific routing key.
+	 *
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param correlationData data to correlate publisher confirms.
+	 * @throws AmqpException if there is a problem
+	 */
+	void convertAndSend(String routingKey, Object message, CorrelationData correlationData) throws AmqpException;
+
+	/**
+	 * Convert a Java object to an Amqp {@link Message} and send it to a specific exchange
+	 * with a specific routing key.
+	 *
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param correlationData data to correlate publisher confirms.
+	 * @throws AmqpException if there is a problem
+	 */
+	void convertAndSend(String exchange, String routingKey, Object message, CorrelationData correlationData)
+			throws AmqpException;
+
+	/**
+	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange
+	 * with a default routing key.
+	 *
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param correlationData data to correlate publisher confirms.
+	 * @throws AmqpException if there is a problem
+	 */
+	void convertAndSend(Object message, MessagePostProcessor messagePostProcessor, CorrelationData correlationData)
+			throws AmqpException;
+
+	/**
+	 * Convert a Java object to an Amqp {@link Message} and send it to a default exchange
+	 * with a specific routing key.
+	 *
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param correlationData data to correlate publisher confirms.
+	 * @throws AmqpException if there is a problem
+	 */
+	void convertAndSend(String routingKey, Object message, MessagePostProcessor messagePostProcessor,
+			CorrelationData correlationData) throws AmqpException;
+
+	/**
+	 * Convert a Java object to an Amqp {@link Message} and send it to a specific exchange
+	 * with a specific routing key.
+	 *
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param correlationData data to correlate publisher confirms.
+	 * @throws AmqpException if there is a problem
+	 */
+	void convertAndSend(String exchange, String routingKey, Object message, MessagePostProcessor messagePostProcessor,
+			CorrelationData correlationData) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a default routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 *
+	 * @param message a message to send.
+	 * @param correlationData data to correlate publisher confirms.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	Object convertSendAndReceive(Object message, CorrelationData correlationData) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 *
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param correlationData data to correlate publisher confirms.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	Object convertSendAndReceive(String routingKey, Object message, CorrelationData correlationData)
+			throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * specific exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 *
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param correlationData data to correlate publisher confirms.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	Object convertSendAndReceive(String exchange, String routingKey, Object message,
+			CorrelationData correlationData) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a default routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 *
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param correlationData data to correlate publisher confirms.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	Object convertSendAndReceive(Object message, MessagePostProcessor messagePostProcessor,
+			CorrelationData correlationData) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 *
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param correlationData data to correlate publisher confirms.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	Object convertSendAndReceive(String routingKey, Object message,
+			MessagePostProcessor messagePostProcessor, CorrelationData correlationData) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * specific exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 *
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param correlationData data to correlate publisher confirms.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	Object convertSendAndReceive(String exchange, String routingKey, Object message,
+			MessagePostProcessor messagePostProcessor, CorrelationData correlationData)
+			throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a default routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param message a message to send.
+	 * @param correlationData data to correlate publisher confirms.
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one.
+	 * @throws AmqpException if there is a problem.
+	 */
+	<T> T convertSendAndReceiveAsType(Object message, CorrelationData correlationData,
+			ParameterizedTypeReference<T> responseType) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param correlationData data to correlate publisher confirms.
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(String routingKey, Object message, CorrelationData correlationData,
+			ParameterizedTypeReference<T> responseType) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * specific exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param correlationData data to correlate publisher confirms.
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(String exchange, String routingKey, Object message,
+			CorrelationData correlationData, ParameterizedTypeReference<T> responseType) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a default routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param correlationData data to correlate publisher confirms.
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(Object message, MessagePostProcessor messagePostProcessor,
+			CorrelationData correlationData, ParameterizedTypeReference<T> responseType) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * default exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param correlationData data to correlate publisher confirms.
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(String routingKey, Object message,
+			MessagePostProcessor messagePostProcessor, CorrelationData correlationData,
+			ParameterizedTypeReference<T> responseType) throws AmqpException;
+
+	/**
+	 * Basic RPC pattern with conversion. Send a Java object converted to a message to a
+	 * specific exchange with a specific routing key and attempt to receive a response,
+	 * converting that to a Java object. Implementations will normally set the reply-to
+	 * header to an exclusive queue and wait up for some time limited by a timeout.
+	 * Requires a
+	 * {@link org.springframework.amqp.support.converter.SmartMessageConverter}.
+	 *
+	 * @param exchange the name of the exchange
+	 * @param routingKey the routing key
+	 * @param message a message to send
+	 * @param messagePostProcessor a processor to apply to the message before it is sent
+	 * @param correlationData data to correlate publisher confirms.
+	 * @param responseType the type to convert the reply to.
+	 * @param <T> the type.
+	 * @return the response if there is one
+	 * @throws AmqpException if there is a problem
+	 */
+	<T> T convertSendAndReceiveAsType(String exchange, String routingKey, Object message,
+			MessagePostProcessor messagePostProcessor, CorrelationData correlationData,
+			ParameterizedTypeReference<T> responseType) throws AmqpException;
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/ComplexTypeJsonIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/ComplexTypeJsonIntegrationTests.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Level;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.amqp.rabbit.AsyncRabbitTemplate;
+import org.springframework.amqp.rabbit.AsyncRabbitTemplate.RabbitConverterFuture;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.junit.BrokerRunning;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
+import org.springframework.amqp.rabbit.test.LogLevelAdjuster;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+@RunWith(SpringRunner.class)
+public class ComplexTypeJsonIntegrationTests {
+
+	private static final String TEST_QUEUE = "test.complex.send.and.receive";
+
+	private static final String TEST_QUEUE2 = "test.complex.receive";
+
+	@ClassRule
+	public static BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues(TEST_QUEUE, TEST_QUEUE2);
+
+	@Rule
+	public LogLevelAdjuster adjuster = new LogLevelAdjuster(Level.DEBUG, RabbitTemplate.class,
+			MessagingMessageListenerAdapter.class,
+			SimpleMessageListenerContainer.class);
+
+	@Autowired
+	private RabbitTemplate rabbitTemplate;
+
+	@Autowired
+	private AsyncRabbitTemplate asyncTemplate;
+
+	@AfterClass
+	public static void tearDown() {
+		brokerRunning.removeTestQueues();
+	}
+
+	private static Foo<Bar<Baz, Qux>> makeAFoo() {
+		Foo<Bar<Baz, Qux>> foo = new Foo<>();
+		Bar<Baz, Qux> bar = new Bar<>();
+		bar.setaField(new Baz("foo"));
+		bar.setbField(new Qux(42));
+		foo.setField(bar);
+		return foo;
+	}
+
+	/*
+	 * Covers all flovors of convertSendAndReceiveAsType
+	 */
+	@Test
+	public void testSendAndReceive() throws Exception {
+		verifyFooBarBazQux(this.rabbitTemplate.convertSendAndReceiveAsType("foo",
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.rabbitTemplate.convertSendAndReceiveAsType("foo",
+				m -> m,
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.rabbitTemplate.convertSendAndReceiveAsType(TEST_QUEUE, "foo",
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.rabbitTemplate.convertSendAndReceiveAsType(TEST_QUEUE, "foo",
+				m -> m,
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.rabbitTemplate.convertSendAndReceiveAsType("", TEST_QUEUE, "foo",
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.rabbitTemplate.convertSendAndReceiveAsType("", TEST_QUEUE, "foo",
+				m -> m,
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+	}
+
+	@Test
+	public void testReceive() {
+		this.rabbitTemplate.convertAndSend(TEST_QUEUE2, makeAFoo(), m -> {
+			m.getMessageProperties().getHeaders().remove("__TypeId__");
+			return m;
+		});
+		verifyFooBarBazQux(
+			this.rabbitTemplate.receiveAndConvert(10_000, new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+	}
+
+	@Test
+	public void testReceiveNoWait() throws Exception {
+		this.rabbitTemplate.convertAndSend(TEST_QUEUE2, makeAFoo(), m -> {
+			m.getMessageProperties().getHeaders().remove("__TypeId__");
+			return m;
+		});
+		Foo<Bar<Baz, Qux>> foo =
+				this.rabbitTemplate.receiveAndConvert(new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { });
+		int n = 0;
+		while (n++ < 100 && foo == null) {
+			Thread.sleep(100);
+			foo = this.rabbitTemplate.receiveAndConvert(new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { });
+		}
+		verifyFooBarBazQux(foo);
+	}
+
+	@Test
+	public void testAsyncSendAndReceive() throws Exception {
+		verifyFooBarBazQux(this.asyncTemplate.convertSendAndReceiveAsType("foo",
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.asyncTemplate.convertSendAndReceiveAsType("foo",
+				m -> m,
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.asyncTemplate.convertSendAndReceiveAsType(TEST_QUEUE, "foo",
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.asyncTemplate.convertSendAndReceiveAsType(TEST_QUEUE, "foo",
+				m -> m,
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.asyncTemplate.convertSendAndReceiveAsType("", TEST_QUEUE, "foo",
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+		verifyFooBarBazQux(this.asyncTemplate.convertSendAndReceiveAsType("", TEST_QUEUE, "foo",
+				m -> m,
+				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
+	}
+
+	private void verifyFooBarBazQux(RabbitConverterFuture<Foo<Bar<Baz, Qux>>> future) throws Exception {
+		verifyFooBarBazQux(future.get(10, TimeUnit.SECONDS));
+	}
+
+	private void verifyFooBarBazQux(Foo<?> foo) {
+		assertNotNull(foo);
+		Bar<?, ?> bar;
+		assertThat(foo.getField(), instanceOf(Bar.class));
+		bar = (Bar<?, ?>) foo.getField();
+		assertThat(bar.getaField(), instanceOf(Baz.class));
+		assertThat(bar.getbField(), instanceOf(Qux.class));
+	}
+
+	@Configuration
+	@EnableRabbit
+	public static class ContextConfig {
+
+		@Bean
+		public ConnectionFactory cf() {
+			return new CachingConnectionFactory("localhost");
+		}
+
+		@Bean
+		public RabbitTemplate template() {
+			RabbitTemplate rabbitTemplate = new RabbitTemplate(cf());
+			rabbitTemplate.setRoutingKey(TEST_QUEUE);
+			rabbitTemplate.setQueue(TEST_QUEUE2);
+			rabbitTemplate.setMessageConverter(jsonMessageConverter());
+			return rabbitTemplate;
+		}
+
+		@Bean
+		public AsyncRabbitTemplate asyncTemplate() {
+			return new AsyncRabbitTemplate(template());
+		}
+
+		@Bean
+		public MessageConverter jsonMessageConverter() {
+			return new Jackson2JsonMessageConverter();
+		}
+
+		@Bean
+		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() {
+			SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+			factory.setConnectionFactory(cf());
+			factory.setMessageConverter(jsonMessageConverter());
+			return factory;
+		}
+
+		@Bean
+		public Listener listener() {
+			return new Listener();
+		}
+
+	}
+
+	public static class Listener {
+
+		@RabbitListener(queues = TEST_QUEUE)
+		public Foo<Bar<Baz, Qux>> listen(String in) {
+			return makeAFoo();
+		}
+
+	}
+
+	public static class Foo<T> {
+
+		private T field;
+
+		public T getField() {
+			return this.field;
+		}
+
+		public void setField(T field) {
+			this.field = field;
+		}
+
+		@Override
+		public String toString() {
+			return "Foo [field=" + this.field + "]";
+		}
+
+	}
+
+	public static class Bar<A, B>  {
+
+		private A aField;
+
+		private B bField;
+
+		public A getaField() {
+			return this.aField;
+		}
+
+		public void setaField(A aField) {
+			this.aField = aField;
+		}
+
+		public B getbField() {
+			return this.bField;
+		}
+
+		public void setbField(B bField) {
+			this.bField = bField;
+		}
+
+		@Override
+		public String toString() {
+			return "Bar [aField=" + this.aField + ", bField=" + this.bField + "]";
+		}
+
+	}
+
+	public static class Baz {
+
+		private String baz;
+
+		Baz() {
+			super();
+		}
+
+		public Baz(String string) {
+			this.baz = string;
+		}
+
+		public String getBaz() {
+			return this.baz;
+		}
+
+		public void setBaz(String baz) {
+			this.baz = baz;
+		}
+
+		@Override
+		public String toString() {
+			return "Baz [baz=" + this.baz + "]";
+		}
+
+	}
+
+	public static class Qux {
+
+		private Integer qux;
+
+		Qux() {
+			super();
+		}
+
+		public Qux(int i) {
+			this.qux = i;
+		}
+
+		public Integer getQux() {
+			return this.qux;
+		}
+
+		public void setQux(Integer qux) {
+			this.qux = qux;
+		}
+
+		@Override
+		public String toString() {
+			return "Qux [qux=" + this.qux + "]";
+		}
+
+	}
+
+}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1183,6 +1183,9 @@ Message receiveAndConvert(long timeoutMillis) throws AmqpException;
 Message receiveAndConvert(String queueName, long timeoutMillis) throws AmqpException;
 ----
 
+Starting with __version 2.0__, there are variants of these methods that take an additional `ParameterizedTypeReference` argument to convert complex types.
+The template must be configured with a `SmartMessageConverter`; see <<json-complex>> for more information.
+
 Similar to `sendAndReceive` methods, beginning with _version 1.3_, the `AmqpTemplate` has several convenience `receiveAndReply` methods for synchronously receiving, processing and replying to messages:
 [source,java]
 ----
@@ -2537,6 +2540,20 @@ For this reason, the infrastructure provides the `targetObject` message property
 converter to determine the type.
 ====
 
+[[json-complex]]
+====== Converting From a Message With RabbitTemplate
+
+As mentioned above, type information is conveyed in message headers to assist the converter when converting from a message.
+This works fine in most cases, but when using generic types, it can only convert simple objects and known "container" objects (lists, arrays, maps).
+Starting with __version 2.0__, the `Jackson2JsonMessageConverter` implements `SmartMessageConverter` which allows it to be used with the new `Rabbit` template methods that take a `ParameterizedTypeReference` argument; this allows conversion of complex generic types.
+For example:
+
+[source, java]
+----
+Foo<Bar<Baz, Qux>> foo =
+    rabbitTemplate.receiveAndConvert(new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { });
+----
+
 ===== MarshallingMessageConverter
 
 Yet another option is the `MarshallingMessageConverter`.
@@ -2695,11 +2712,15 @@ Those methods are quite useful for request/reply scenarios since they handle the
 
 Similar request/reply methods are also available where the `MessageConverter` is applied to both the request and reply.
 Those methods are named `convertSendAndReceive`.
-See the Javadoc of `AmqpTemplate` for more detail.
+See the the Javadoc of `AmqpTemplate` for more detail.
 
 Starting with _version 1.5.0_, each of the `sendAndReceive` method variants has an overloaded version that takes `CorrelationData`.
 Together with a properly configured connection factory, this enables the receipt of publisher confirms for the send side of the operation.
-See <<template-confirms>> for more information.
+See <<template-confirms>> and the javadoc for `RabbitOperations` for more information.
+
+Starting with __version 2.0__, there are variants of these methods (`convertSendAndReceiveAsType`) that take an additional `ParameterizedTypeReference` argument to convert complex returned types.
+The template must be configured with a `SmartMessageConverter`; see <<json-complex>> for more information.
+
 
 [[reply-timeout]]
 ===== Reply Timeout
@@ -2960,6 +2981,9 @@ public AsyncRabbitTemplate(RabbitTemplate template)
 ----
 
 See <<direct-reply-to>> to use Direct reply-to with the synchronous `RabbitTemplate`.
+
+Starting with __version 2.0__, there are variants of these methods (`convertSendAndReceiveAsType`) that take an additional `ParameterizedTypeReference` argument to convert complex returned types.
+The underlying `RabbitTemplate` must be configured with a `SmartMessageConverter`; see <<json-complex>> for more information.
 
 [[remoting]]
 ===== Spring Remoting with AMQP

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -31,6 +31,11 @@ See <<direct-reply-to>> for more information.
 
 The `AsyncRabbitTemplate` now supports Direct reply-to; see <<async-template>> for more information.
 
+The `RabbitTemplate` and `AsyncRabbitTemplate` now have `receiveAndConvert` and `convertSendAndReceiveAsType` methods that take a `ParameterizedTypeReference<T>` argument, allowing the caller to specify the type to convert the result to.
+This is particularly useful for complex types or when type information is not conveyed in message headers.
+Requires a `SmartMessageConverter` such as the `Jackson2JsonMessageConverter`.
+See <<receiving-messages>>, <<request-reply>>, <<async-template>>, and <<json-complex>> for more information.
+
 ===== Listener Adapter
 
 A convenient `FunctionalInterface` is available for using lambdas with the `MessageListenerAdapter`.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-675

Add variants to `RabbitTemplate` `receiveAndConvert` and `convertSendAndReceive` methods
that take a `ParameterizedTypeReference` argument.

Also `AsyncRabbitTemplate`.

Add `SmartMessageConverter` (similar to other spring projects) that take a conversion hint.
Implement this interface in the `Jackson2JsonMessageConverter`.

Also, pull up the method variants that take `CorrelationData` to `RabbitOperations`.