### PR TITLE
Fixing a race condition in SimpleMessageListenerContainer

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -634,7 +634,9 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	private int getConsumersThatHaveNotInitiatedStopping() {
-		return (int) this.consumers.values().stream().filter(x -> x = Boolean.TRUE).count();
+		synchronized (this.consumersMonitor) {
+			return (int) this.consumers.values().stream().filter(x -> x = Boolean.TRUE).count();
+		}
 	}
 
 	private void considerStoppingAConsumer(BlockingQueueConsumer consumer) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -633,9 +633,13 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		}
 	}
 
+	private int getConsumersThatHaveNotInitiatedStopping() {
+		return (int) this.consumers.values().stream().filter(x -> x = Boolean.TRUE).count();
+	}
+
 	private void considerStoppingAConsumer(BlockingQueueConsumer consumer) {
 		synchronized (this.consumersMonitor) {
-			if (this.consumers != null && this.consumers.size() > this.concurrentConsumers) {
+			if (this.consumers != null && this.getConsumersThatHaveNotInitiatedStopping() > this.concurrentConsumers) {
 				long now = System.currentTimeMillis();
 				if (this.lastConsumerStopped + this.stopConsumerMinInterval < now) {
 					consumer.basicCancel();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -131,7 +131,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		new DirectFieldAccessor(container).setPropertyValue("logger", logger);
 		template.convertAndSend(queue.getName(), "baz");
 		assertTrue(messageReceived.await(10, TimeUnit.SECONDS));
-		Object consumer = TestUtils.getPropertyValue(container, "activeConsumers", Set.class)
+		Object consumer = TestUtils.getPropertyValue(container, "consumers", Set.class)
 				.iterator().next();
 		Log qLogger = spy(TestUtils.getPropertyValue(consumer, "logger", Log.class));
 		doReturn(true).when(qLogger).isDebugEnabled();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -131,8 +131,8 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		new DirectFieldAccessor(container).setPropertyValue("logger", logger);
 		template.convertAndSend(queue.getName(), "baz");
 		assertTrue(messageReceived.await(10, TimeUnit.SECONDS));
-		Object consumer = TestUtils.getPropertyValue(container, "consumers", Map.class)
-				.keySet().iterator().next();
+		Object consumer = TestUtils.getPropertyValue(container, "activeConsumers", Set.class)
+				.iterator().next();
 		Log qLogger = spy(TestUtils.getPropertyValue(consumer, "logger", Log.class));
 		doReturn(true).when(qLogger).isDebugEnabled();
 		new DirectFieldAccessor(consumer).setPropertyValue("logger", qLogger);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -436,7 +436,7 @@ public class SimpleMessageListenerContainerTests {
 
 		container.start();
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
-		Set<?> consumers = TestUtils.getPropertyValue(container, "activeConsumers", Set.class);
+		Set<?> consumers = TestUtils.getPropertyValue(container, "consumers", Set.class);
 		container.stop();
 		assertTrue(latch2.await(10, TimeUnit.SECONDS));
 
@@ -511,7 +511,7 @@ public class SimpleMessageListenerContainerTests {
 			final boolean cancel, final CountDownLatch latch) {
 		return invocation -> {
 			String returnValue = null;
-			Set<?> consumers = TestUtils.getPropertyValue(container, "activeConsumers", Set.class);
+			Set<?> consumers = TestUtils.getPropertyValue(container, "consumers", Set.class);
 			for (Object consumer : consumers) {
 				ChannelProxy channel = TestUtils.getPropertyValue(consumer, "channel", ChannelProxy.class);
 				if (channel != null && channel.getTargetChannel() == mockChannel) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -436,7 +436,7 @@ public class SimpleMessageListenerContainerTests {
 
 		container.start();
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
-		Set<?> consumers = TestUtils.getPropertyValue(container, "consumers", Map.class).keySet();
+		Set<?> consumers = TestUtils.getPropertyValue(container, "activeConsumers", Set.class);
 		container.stop();
 		assertTrue(latch2.await(10, TimeUnit.SECONDS));
 
@@ -511,7 +511,7 @@ public class SimpleMessageListenerContainerTests {
 			final boolean cancel, final CountDownLatch latch) {
 		return invocation -> {
 			String returnValue = null;
-			Set<?> consumers = TestUtils.getPropertyValue(container, "consumers", Map.class).keySet();
+			Set<?> consumers = TestUtils.getPropertyValue(container, "activeConsumers", Set.class);
 			for (Object consumer : consumers) {
 				ChannelProxy channel = TestUtils.getPropertyValue(consumer, "channel", ChannelProxy.class);
 				if (channel != null && channel.getTargetChannel() == mockChannel) {


### PR DESCRIPTION
JIRA: [https://jira.spring.io/browse/AMQP-690](https://jira.spring.io/browse/AMQP-690)

Fixing race condition causing SimpleMessageListenerContainer to drop consumers to zero. The introduced method should take into consideration only the count of the consumers that have not started their shutdown procedure.

This quite the simple fix to a pretty elusive problem. I have been thinking of a way to actually write a test for this but to be frank, I have not come up with a good idea. 

Additionally I must say that to me the set of states that a consumer can be in (active,not active) is not complete. I mean for example: 

```
@ManagedMetric(metricType = MetricType.GAUGE)
public int getActiveConsumerCount() {
        return this.cancellationLock.getCount();
}
```

This piece of code if called gets the count of the consumers that have still not unregistered themselves from the ActiveObjectCounter. However does that mean that they are "active". I mean  surely they can still be processing messages. However if they have been subject to the considerStoppingAConsumer method, they are not going to be active for a lot longer. That being said, somebody can mistakenly use this method to do things such as what caused this original bug.

If I have to define the states of a consumer they would be: 

- active
- shutting down
- shut down

Its just my two cents.