### PR TITLE
AMQP-684: Recovery Listener and Naming Strategy [Backport]

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParser.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 /**
  * @author Dave Syer
  * @author Gary Russell
+ * @author Artem Bilan
  */
 class ConnectionFactoryParser extends AbstractSingleBeanDefinitionParser {
 
@@ -106,7 +107,7 @@ class ConnectionFactoryParser extends AbstractSingleBeanDefinitionParser {
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, THREAD_FACTORY, "connectionThreadFactory");
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, FACTORY_TIMEOUT, "channelCheckoutTimeout");
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, CONNECTION_LIMIT);
-
+		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, "connection-name-strategy");
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionNameStrategy.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionNameStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+/**
+ * A strategy to build an application-specific connection name,
+ * which can be displayed in the management UI if RabbitMQ server supports it.
+ * The value doesn't have to be unique and cannot be used
+ * as a connection identifier e.g. in HTTP API requests.
+ * The value is supposed to be human-readable.
+ *
+ * @author Artem Bilan
+ * @since 1.7
+ * @see com.rabbitmq.client.ConnectionFactory#newConnection(com.rabbitmq.client.Address[], String)
+ */
+@FunctionalInterface
+public interface ConnectionNameStrategy {
+
+	String obtainNewConnectionName(ConnectionFactory connectionFactory);
+
+}

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.7.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-1.7.xsd
@@ -399,7 +399,7 @@
 		<xsd:attribute name="ignore-declaration-exceptions">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	Specifies whether exceptions encountered while declraring this element should be ignored.
+	Specifies whether exceptions encountered while declaring this element should be ignored.
 	If 'false', the equivalent setting on the rabbit admin applies.
 	Default value is 'false'.
 				]]></xsd:documentation>
@@ -1331,7 +1331,7 @@
 			<xsd:attribute name="virtual-host" type="xsd:string" use="optional">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	Virtual host name to connect to broker.  Default is "/".  Virtual hosts are logical partitions of the broker with separate queues, excchanges, users, etc.
+	Virtual host name to connect to broker.  Default is "/".  Virtual hosts are logical partitions of the broker with separate queues, exchanges, users, etc.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -1450,6 +1450,19 @@
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type type="java.util.concurrent.ThreadFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-name-strategy">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to a 'ConnectionNameStrategy' to provide client-specific name for the target RabbitMQ connection.
+	It can be displayed in the management UI if RabbitMQ server supports it.
+				]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.rabbit.connection.ConnectionNameStrategy" />
 						</tool:annotation>
 					</xsd:appinfo>
 				</xsd:annotation>

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionNameStrategy;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -41,6 +42,7 @@ import com.rabbitmq.client.ConnectionFactory;
  *
  * @author Dave Syer
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
 public final class ConnectionFactoryParserTests {
@@ -68,6 +70,8 @@ public final class ConnectionFactoryParserTests {
 		assertEquals(CachingConnectionFactory.CacheMode.CHANNEL, connectionFactory.getCacheMode());
 		assertEquals(234L, TestUtils.getPropertyValue(connectionFactory, "channelCheckoutTimeout"));
 		assertEquals(456,  TestUtils.getPropertyValue(connectionFactory, "connectionLimit"));
+		assertSame(beanFactory.getBean(ConnectionNameStrategy.class),
+				TestUtils.getPropertyValue(connectionFactory, "connectionNameStrategy"));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
@@ -27,6 +27,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.springframework.amqp.utils.test.TestUtils.getPropertyValue;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -80,12 +81,15 @@ import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
  * @author Dave Syer
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 1.0
  *
  */
 public class CachingConnectionFactoryIntegrationTests {
 
 	private static final String CF_INTEGRATION_TEST_QUEUE = "cfIntegrationTest";
+
+	private static final String CF_INTEGRATION_CONNECTION_NAME = "cfIntegrationTestConnectionName";
 
 	private static Log logger = LogFactory.getLog(CachingConnectionFactoryIntegrationTests.class);
 
@@ -103,6 +107,7 @@ public class CachingConnectionFactoryIntegrationTests {
 		connectionFactory.setHost("localhost");
 		connectionFactory.setPort(BrokerTestUtils.getPort());
 		connectionFactory.getRabbitConnectionFactory().getClientProperties().put("foo", "bar");
+		connectionFactory.setConnectionNameStrategy(cf -> CF_INTEGRATION_CONNECTION_NAME);
 	}
 
 	@After
@@ -119,7 +124,7 @@ public class CachingConnectionFactoryIntegrationTests {
 		connectionFactory.setCacheMode(CacheMode.CONNECTION);
 		connectionFactory.setConnectionCacheSize(5);
 		connectionFactory.setExecutor(Executors.newCachedThreadPool());
-		List<Connection> connections = new ArrayList<Connection>();
+		List<Connection> connections = new ArrayList<>();
 		connections.add(connectionFactory.createConnection());
 		connections.add(connectionFactory.createConnection());
 		assertNotSame(connections.get(0), connections.get(1));
@@ -127,14 +132,12 @@ public class CachingConnectionFactoryIntegrationTests {
 		connections.add(connectionFactory.createConnection());
 		connections.add(connectionFactory.createConnection());
 		connections.add(connectionFactory.createConnection());
-		Set<?> allocatedConnections = TestUtils.getPropertyValue(connectionFactory, "allocatedConnections", Set.class);
+		Set<?> allocatedConnections = getPropertyValue(connectionFactory, "allocatedConnections", Set.class);
 		assertEquals(6, allocatedConnections.size());
-		for (Connection connection : connections) {
-			connection.close();
-		}
+		connections.forEach(Connection::close);
 		assertEquals(6, allocatedConnections.size());
 		assertEquals("5", connectionFactory.getCacheProperties().get("openConnections"));
-		BlockingQueue<?> idleConnections = TestUtils.getPropertyValue(connectionFactory, "idleConnections",
+		BlockingQueue<?> idleConnections = getPropertyValue(connectionFactory, "idleConnections",
 				BlockingQueue.class);
 		assertEquals(6, idleConnections.size());
 		connections.clear();
@@ -142,9 +145,7 @@ public class CachingConnectionFactoryIntegrationTests {
 		connections.add(connectionFactory.createConnection());
 		assertEquals(6, allocatedConnections.size());
 		assertEquals(4, idleConnections.size());
-		for (Connection connection : connections) {
-			connection.close();
-		}
+		connections.forEach(Connection::close);
 	}
 
 	@Test
@@ -178,9 +179,7 @@ public class CachingConnectionFactoryIntegrationTests {
 		assertSame(channels.get(1), channels.get(3));
 		channels.get(2).close();
 		channels.get(3).close();
-		for (Connection connection : connections) {
-			connection.close();
-		}
+		connections.forEach(Connection::close);
 	}
 
 	@Test
@@ -193,7 +192,7 @@ public class CachingConnectionFactoryIntegrationTests {
 		List<Connection> connections = new ArrayList<Connection>();
 		connections.add(connectionFactory.createConnection());
 		connections.add(connectionFactory.createConnection());
-		Set<?> allocatedConnections = TestUtils.getPropertyValue(connectionFactory, "allocatedConnections", Set.class);
+		Set<?> allocatedConnections = getPropertyValue(connectionFactory, "allocatedConnections", Set.class);
 		assertEquals(2, allocatedConnections.size());
 		assertNotSame(connections.get(0), connections.get(1));
 		List<Channel> channels = new ArrayList<Channel>();
@@ -204,12 +203,12 @@ public class CachingConnectionFactoryIntegrationTests {
 			channels.add(connections.get(1).createChannel(true));
 		}
 		@SuppressWarnings("unchecked")
-		Map<?, List<?>> cachedChannels = TestUtils.getPropertyValue(connectionFactory,
+		Map<?, List<?>> cachedChannels = getPropertyValue(connectionFactory,
 				"allocatedConnectionNonTransactionalChannels", Map.class);
 		assertEquals(0, cachedChannels.get(connections.get(0)).size());
 		assertEquals(0, cachedChannels.get(connections.get(1)).size());
 		@SuppressWarnings("unchecked")
-		Map<?, List<?>> cachedTxChannels = TestUtils.getPropertyValue(connectionFactory,
+		Map<?, List<?>> cachedTxChannels = getPropertyValue(connectionFactory,
 				"allocatedConnectionTransactionalChannels", Map.class);
 		assertEquals(0, cachedTxChannels.get(connections.get(0)).size());
 		assertEquals(0, cachedTxChannels.get(connections.get(1)).size());
@@ -245,7 +244,7 @@ public class CachingConnectionFactoryIntegrationTests {
 		assertEquals("1", connectionFactory.getCacheProperties().get("openConnections"));
 
 		Connection connection = connectionFactory.createConnection();
-		Connection rabbitConnection = TestUtils.getPropertyValue(connection, "target", Connection.class);
+		Connection rabbitConnection = getPropertyValue(connection, "target", Connection.class);
 		rabbitConnection.close();
 		Channel channel = connection.createChannel(false);
 		assertEquals(2, allocatedConnections.size());
@@ -473,12 +472,21 @@ public class CachingConnectionFactoryIntegrationTests {
 
 	@Test
 	public void testConnectionCloseLog() {
-		Log logger = spy(TestUtils.getPropertyValue(this.connectionFactory, "logger", Log.class));
+		Log logger = spy(getPropertyValue(this.connectionFactory, "logger", Log.class));
 		new DirectFieldAccessor(this.connectionFactory).setPropertyValue("logger", logger);
 		Connection conn = this.connectionFactory.createConnection();
 		conn.createChannel(false);
 		this.connectionFactory.destroy();
 		verify(logger, never()).error(anyString());
+	}
+
+	@Test
+	public void testConnectionName() {
+		Connection connection = this.connectionFactory.createConnection();
+		com.rabbitmq.client.Connection rabbitConnection = TestUtils.getPropertyValue(connection, "target.delegate",
+				com.rabbitmq.client.Connection.class);
+		assertEquals(CF_INTEGRATION_CONNECTION_NAME, rabbitConnection.getClientProperties().get("connection_name"));
+		this.connectionFactory.destroy();
 	}
 
 	@Test
@@ -488,38 +496,15 @@ public class CachingConnectionFactoryIntegrationTests {
 		final ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(2765);
 		final AtomicBoolean hangOnClose = new AtomicBoolean();
 		// create a simple proxy so we can drop the close response
-		Executors.newSingleThreadExecutor().execute(new Runnable() {
-
-			@Override
-			public void run() {
-				try {
-					final Socket socket = server.accept();
-					Executors.newSingleThreadExecutor().execute(new Runnable() {
-
-						@Override
-						public void run() {
-							while (!socket.isClosed()) {
-								try {
-									int c = socket.getInputStream().read();
-									if (c >= 0) {
-										proxy.getOutputStream().write(c);
-									}
-								}
-								catch (Exception e) {
-									try {
-										socket.close();
-										proxy.close();
-									}
-									catch (Exception ee) { }
-								}
-							}
-						}
-					});
-					while (!proxy.isClosed()) {
+		Executors.newSingleThreadExecutor().execute(() -> {
+			try {
+				final Socket socket = server.accept();
+				Executors.newSingleThreadExecutor().execute(() -> {
+					while (!socket.isClosed()) {
 						try {
-							int c = proxy.getInputStream().read();
-							if (c >= 0 && !hangOnClose.get()) {
-								socket.getOutputStream().write(c);
+							int c = socket.getInputStream().read();
+							if (c >= 0) {
+								proxy.getOutputStream().write(c);
 							}
 						}
 						catch (Exception e) {
@@ -530,11 +515,26 @@ public class CachingConnectionFactoryIntegrationTests {
 							catch (Exception ee) { }
 						}
 					}
-					socket.close();
+				});
+				while (!proxy.isClosed()) {
+					try {
+						int c = proxy.getInputStream().read();
+						if (c >= 0 && !hangOnClose.get()) {
+							socket.getOutputStream().write(c);
+						}
+					}
+					catch (Exception e) {
+						try {
+							socket.close();
+							proxy.close();
+						}
+						catch (Exception ee) { }
+					}
 				}
-				catch (Exception e) {
-					e.printStackTrace();
-				}
+				socket.close();
+			}
+			catch (Exception e) {
+				e.printStackTrace();
 			}
 		});
 		CachingConnectionFactory factory = new CachingConnectionFactory(2765);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -24,7 +24,9 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -90,7 +92,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 		when(mockChannel.isOpen()).thenReturn(true);
 		when(mockConnection.isOpen()).thenReturn(true);
@@ -124,7 +126,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		Channel mockChannel2 = mock(Channel.class);
 		Channel mockTxChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel1, mockChannel2, mockTxChannel);
 
@@ -182,7 +184,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		Channel mockChannel2 = mock(Channel.class);
 		Channel mockChannel3 = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.createChannel()).thenReturn(mockChannel1).thenReturn(mockChannel2).thenReturn(mockChannel3);
 		when(mockConnection.isOpen()).thenReturn(true);
 
@@ -236,7 +238,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel1 = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.createChannel()).thenReturn(mockChannel1);
 		when(mockConnection.isOpen()).thenReturn(true);
 
@@ -282,7 +284,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 
 		final CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
@@ -348,7 +350,8 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		Channel mockChannel3 = mock(Channel.class);
 		Channel mockChannel4 = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection1, mockConnection2);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString()))
+				.thenReturn(mockConnection1, mockConnection2);
 		when(mockConnection1.createChannel()).thenReturn(mockChannel1, mockChannel2);
 		when(mockConnection1.isOpen()).thenReturn(true);
 		when(mockConnection2.createChannel()).thenReturn(mockChannel3, mockChannel4);
@@ -432,7 +435,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel1 = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.createChannel()).thenReturn(mockChannel1);
 		when(mockConnection.isOpen()).thenReturn(true);
 
@@ -488,7 +491,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		com.rabbitmq.client.Connection mockConnection1 = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel1 = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection1);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection1);
 		when(mockConnection1.createChannel()).thenReturn(mockChannel1);
 		when(mockConnection1.isOpen()).thenReturn(true);
 
@@ -541,7 +544,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		com.rabbitmq.client.Connection mockConnection1 = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel1 = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection1);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection1);
 		when(mockConnection1.createChannel()).thenReturn(mockChannel1);
 		when(mockConnection1.isOpen()).thenReturn(true);
 
@@ -588,7 +591,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		Channel mockChannel1 = mock(Channel.class);
 		Channel mockChannel2 = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.createChannel()).thenReturn(mockChannel1).thenReturn(mockChannel2);
 		when(mockConnection.isOpen()).thenReturn(true);
 
@@ -635,7 +638,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		Channel mockChannel1 = mock(Channel.class);
 		Channel mockChannel2 = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.createChannel()).thenReturn(mockChannel1).thenReturn(mockChannel2);
 		when(mockConnection.isOpen()).thenReturn(true);
 
@@ -697,7 +700,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 		assertNotSame(mockChannel1, mockChannel2);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection1, mockConnection2);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection1, mockConnection2);
 		when(mockConnection1.createChannel()).thenReturn(mockChannel1, mockChannel2);
 		when(mockConnection1.isOpen()).thenReturn(true);
 		when(mockConnection2.createChannel()).thenReturn(mockChannel3);
@@ -765,7 +768,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockChannel.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
@@ -795,7 +798,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		connectionFactory.destroy();
 		verify(mockConnection, atLeastOnce()).close(anyInt());
 
-		verify(mockConnectionFactory).newConnection((ExecutorService) null);
+		verify(mockConnectionFactory).newConnection(any(ExecutorService.class), anyString());
 
 	}
 
@@ -809,7 +812,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		when(mockConnection2.toString()).thenReturn("conn2");
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection1, mockConnection2);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection1, mockConnection2);
 		when(mockConnection1.isOpen()).thenReturn(true);
 		when(mockChannel.isOpen()).thenReturn(true);
 		when(mockConnection1.createChannel()).thenReturn(mockChannel);
@@ -864,7 +867,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		assertSame(notSame, closed.get());
 		assertEquals(2, timesClosed.get());
 
-		verify(mockConnectionFactory, times(2)).newConnection((ExecutorService) null);
+		verify(mockConnectionFactory, times(2)).newConnection(any(ExecutorService.class), anyString());
 	}
 
 	@Test
@@ -897,7 +900,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 				mockConnections.add(connection);
 				return connection;
 			}
-		}).when(mockConnectionFactory).newConnection((ExecutorService) null);
+		}).when(mockConnectionFactory).newConnection(any(ExecutorService.class), anyString());
 
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
 		ccf.setCacheMode(CacheMode.CONNECTION);
@@ -1096,7 +1099,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 				mockConnections.add(connection);
 				return connection;
 			}
-		}).when(mockConnectionFactory).newConnection((ExecutorService) null);
+		}).when(mockConnectionFactory).newConnection(any(ExecutorService.class), anyString());
 
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
 		ccf.setCacheMode(CacheMode.CONNECTION);
@@ -1314,7 +1317,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 				mockConnections.add(connection);
 				return connection;
 			}
-		}).when(mockConnectionFactory).newConnection((ExecutorService) null);
+		}).when(mockConnectionFactory).newConnection(any(ExecutorService.class), anyString());
 
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
 		ccf.setCacheMode(CacheMode.CONNECTION);
@@ -1376,7 +1379,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.setAddresses("");
 		ccf.createConnection();
 		verify(mock).setHost("abc");
-		verify(mock).newConnection((ExecutorService) null);
+		verify(mock).newConnection(any(ExecutorService.class), anyString());
 		verifyNoMoreInteractions(mock);
 	}
 
@@ -1386,7 +1389,8 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
 		ccf.setAddresses("mq1");
 		ccf.createConnection();
-		verify(mock).newConnection(isNull(ExecutorService.class), aryEq(new Address[] { new Address("mq1") }));
+		verify(mock)
+				.newConnection(isNull(ExecutorService.class), aryEq(new Address[] { new Address("mq1") }), anyString());
 		verifyNoMoreInteractions(mock);
 	}
 
@@ -1397,7 +1401,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.setAddresses("mq1,mq2");
 		ccf.createConnection();
 		verify(mock).newConnection(isNull(ExecutorService.class),
-				aryEq(new Address[] { new Address("mq1"), new Address("mq2") }));
+				aryEq(new Address[] { new Address("mq1"), new Address("mq2") }), anyString());
 		verifyNoMoreInteractions(mock);
 	}
 
@@ -1413,7 +1417,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 		InOrder order = inOrder(mock);
 		order.verify(mock).setUri(uri);
-		order.verify(mock).newConnection((ExecutorService) null);
+		order.verify(mock).newConnection(any(ExecutorService.class), anyString());
 		verifyNoMoreInteractions(mock);
 	}
 
@@ -1423,7 +1427,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 		when(mockChannel.isOpen()).thenReturn(true).thenReturn(false);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ClientRecoveryCompatibilityTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ClientRecoveryCompatibilityTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -30,14 +31,13 @@ import static org.mockito.Mockito.when;
 import java.util.concurrent.ExecutorService;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 1.4
  *
  */
@@ -52,13 +52,7 @@ public class ClientRecoveryCompatibilityTests {
 		final com.rabbitmq.client.Connection rabbitConn = mock(AutorecoveringConnection.class);
 		when(rabbitConn.isOpen()).thenReturn(true);
 		com.rabbitmq.client.ConnectionFactory cf = mock(com.rabbitmq.client.ConnectionFactory.class);
-		doAnswer(new Answer<com.rabbitmq.client.Connection>() {
-
-			@Override
-			public com.rabbitmq.client.Connection answer(InvocationOnMock invocation) throws Throwable {
-				return rabbitConn;
-			}
-		}).when(cf).newConnection(any(ExecutorService.class));
+		doAnswer(invocation -> rabbitConn).when(cf).newConnection(any(ExecutorService.class), anyString());
 		when(rabbitConn.createChannel()).thenReturn(channel1).thenReturn(channel2);
 
 		CachingConnectionFactory ccf = new CachingConnectionFactory(cf);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SingleConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SingleConnectionFactoryTests.java
@@ -17,14 +17,16 @@
 package org.springframework.amqp.rabbit.connection;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -50,17 +52,14 @@ public class SingleConnectionFactoryTests extends AbstractConnectionFactoryTests
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 
 		final AtomicInteger called = new AtomicInteger(0);
 		AbstractConnectionFactory connectionFactory = createConnectionFactory(mockConnectionFactory);
-		connectionFactory.setChannelListeners(Arrays.asList(new ChannelListener() {
-			public void onCreate(Channel channel, boolean transactional) {
-				called.incrementAndGet();
-			}
-		}));
+		connectionFactory.setChannelListeners(Collections.singletonList(
+				(channel, transactional) -> called.incrementAndGet()));
 
 		Connection con = connectionFactory.createConnection();
 		Channel channel = con.createChannel(false);
@@ -77,7 +76,7 @@ public class SingleConnectionFactoryTests extends AbstractConnectionFactoryTests
 		connectionFactory.destroy();
 		verify(mockConnection, atLeastOnce()).close(anyInt());
 
-		verify(mockConnectionFactory).newConnection((ExecutorService) null);
+		verify(mockConnectionFactory).newConnection(any(ExecutorService.class), anyString());
 
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
@@ -169,7 +169,7 @@ public class RabbitAdminTests {
 		Properties props = rabbitAdmin.getQueueProperties(queueName);
 		assertNotNull(props);
 		assertNotNull(props.get(RabbitAdmin.QUEUE_MESSAGE_COUNT));
-		return Integer.valueOf((Integer) props.get(RabbitAdmin.QUEUE_MESSAGE_COUNT));
+		return (Integer) props.get(RabbitAdmin.QUEUE_MESSAGE_COUNT);
 	}
 
 	@Test
@@ -274,7 +274,7 @@ public class RabbitAdminTests {
 		com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory = mock(
 				com.rabbitmq.client.ConnectionFactory.class);
 		TimeoutException toBeThrown = new TimeoutException("test");
-		doThrow(toBeThrown).when(rabbitConnectionFactory).newConnection(any(ExecutorService.class));
+		doThrow(toBeThrown).when(rabbitConnectionFactory).newConnection(any(ExecutorService.class), anyString());
 		CachingConnectionFactory ccf = new CachingConnectionFactory(rabbitConnectionFactory);
 		RabbitAdmin admin = new RabbitAdmin(ccf);
 		List<DeclarationExceptionEvent> events = new ArrayList<DeclarationExceptionEvent>();
@@ -285,7 +285,7 @@ public class RabbitAdminTests {
 		admin.declareExchange(new DirectExchange("foo"));
 		admin.declareBinding(new Binding("foo", DestinationType.QUEUE, "bar", "baz", null));
 		assertThat(events.size(), equalTo(4));
-		assertThat((RabbitAdmin) events.get(0).getSource(), sameInstance(admin));
+		assertThat(events.get(0).getSource(), sameInstance(admin));
 		assertThat(events.get(0).getDeclarable(), instanceOf(AnonymousQueue.class));
 		assertSame(toBeThrown, events.get(0).getThrowable().getCause());
 		assertNull(events.get(1).getDeclarable());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateHeaderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateHeaderTests.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,8 +35,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
@@ -71,7 +71,7 @@ public class RabbitTemplateHeaderTests {
 		Connection mockConnection = mock(Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 
@@ -87,25 +87,22 @@ public class RabbitTemplateHeaderTests {
 		Message message = new Message("Hello, world!".getBytes(), messageProperties);
 		final AtomicReference<String> replyTo = new AtomicReference<String>();
 		final AtomicReference<String> correlationId = new AtomicReference<String>();
-		doAnswer(new Answer<Object>() {
-			@Override
-			public Object answer(InvocationOnMock invocation) throws Throwable {
-				BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
-				replyTo.set(basicProps.getReplyTo());
-				if (standardHeader) {
-					correlationId.set(basicProps.getCorrelationId());
-				}
-				else {
-					correlationId.set((String) basicProps.getHeaders().get(CORRELATION_HEADER));
-				}
-				MessageProperties springProps = new DefaultMessagePropertiesConverter()
-						.toMessageProperties(basicProps, null, "UTF-8");
-				Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
-				template.onMessage(replyMessage);
-				return null;
-			} }
-		).when(mockChannel).basicPublish(Mockito.any(String.class), Mockito.any(String.class), Mockito.anyBoolean(),
-				Mockito.any(BasicProperties.class), Mockito.any(byte[].class));
+		doAnswer(invocation -> {
+			BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
+			replyTo.set(basicProps.getReplyTo());
+			if (standardHeader) {
+				correlationId.set(basicProps.getCorrelationId());
+			}
+			else {
+				correlationId.set((String) basicProps.getHeaders().get(CORRELATION_HEADER));
+			}
+			MessageProperties springProps = new DefaultMessagePropertiesConverter()
+					.toMessageProperties(basicProps, null, "UTF-8");
+			Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
+			template.onMessage(replyMessage);
+			return null;
+		}).when(mockChannel).basicPublish(any(String.class), any(String.class), Mockito.anyBoolean(),
+				any(BasicProperties.class), any(byte[].class));
 		Message reply = template.sendAndReceive(message);
 		assertNotNull(reply);
 
@@ -127,7 +124,7 @@ public class RabbitTemplateHeaderTests {
 		Connection mockConnection = mock(Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 
@@ -143,20 +140,17 @@ public class RabbitTemplateHeaderTests {
 		Message message = new Message("Hello, world!".getBytes(), messageProperties);
 		final AtomicReference<String> replyTo = new AtomicReference<String>();
 		final AtomicReference<String> correlationId = new AtomicReference<String>();
-		doAnswer(new Answer<Object>() {
-			@Override
-			public Object answer(InvocationOnMock invocation) throws Throwable {
-				BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
-				replyTo.set(basicProps.getReplyTo());
-				correlationId.set(basicProps.getCorrelationId());
-				MessageProperties springProps = new DefaultMessagePropertiesConverter()
-						.toMessageProperties(basicProps, null, "UTF-8");
-				Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
-				template.onMessage(replyMessage);
-				return null;
-			} }
-		).when(mockChannel).basicPublish(Mockito.any(String.class), Mockito.any(String.class), Mockito.anyBoolean(),
-				Mockito.any(BasicProperties.class), Mockito.any(byte[].class));
+		doAnswer(invocation -> {
+			BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
+			replyTo.set(basicProps.getReplyTo());
+			correlationId.set(basicProps.getCorrelationId());
+			MessageProperties springProps = new DefaultMessagePropertiesConverter()
+					.toMessageProperties(basicProps, null, "UTF-8");
+			Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
+			template.onMessage(replyMessage);
+			return null;
+		}).when(mockChannel).basicPublish(any(String.class), any(String.class), Mockito.anyBoolean(),
+				any(BasicProperties.class), any(byte[].class));
 		Message reply = template.sendAndReceive(message);
 		assertNotNull(reply);
 
@@ -174,7 +168,7 @@ public class RabbitTemplateHeaderTests {
 		Connection mockConnection = mock(Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 
@@ -192,27 +186,24 @@ public class RabbitTemplateHeaderTests {
 		final List<String> nestedReplyTo = new ArrayList<String>();
 		final List<String> nestedCorrelation = new ArrayList<String>();
 		final String replyAddress3 = "replyTo3";
-		doAnswer(new Answer<Object>() {
-			@Override
-			public Object answer(InvocationOnMock invocation) throws Throwable {
-				BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
-				nestedReplyTo.add(basicProps.getReplyTo());
-				nestedCorrelation.add(basicProps.getCorrelationId());
-				MessageProperties springProps = new DefaultMessagePropertiesConverter()
-						.toMessageProperties(basicProps, null, "UTF-8");
-				Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
-				if (count.incrementAndGet() < 2) {
-					Message anotherMessage = new Message("Second".getBytes(), springProps);
-					template.setReplyAddress(replyAddress3);
-					replyMessage = template.sendAndReceive(anotherMessage);
-					nestedReplyTo.add(replyMessage.getMessageProperties().getReplyTo());
-					nestedCorrelation.add(new String(replyMessage.getMessageProperties().getCorrelationId(), "UTF-8"));
-				}
-				template.onMessage(replyMessage);
-				return null;
-			} }
-		).when(mockChannel).basicPublish(Mockito.any(String.class), Mockito.any(String.class), Mockito.anyBoolean(),
-				Mockito.any(BasicProperties.class), Mockito.any(byte[].class));
+		doAnswer(invocation -> {
+			BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
+			nestedReplyTo.add(basicProps.getReplyTo());
+			nestedCorrelation.add(basicProps.getCorrelationId());
+			MessageProperties springProps = new DefaultMessagePropertiesConverter()
+					.toMessageProperties(basicProps, null, "UTF-8");
+			Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
+			if (count.incrementAndGet() < 2) {
+				Message anotherMessage = new Message("Second".getBytes(), springProps);
+				template.setReplyAddress(replyAddress3);
+				replyMessage = template.sendAndReceive(anotherMessage);
+				nestedReplyTo.add(replyMessage.getMessageProperties().getReplyTo());
+				nestedCorrelation.add(replyMessage.getMessageProperties().getCorrelationIdString());
+			}
+			template.onMessage(replyMessage);
+			return null;
+		}).when(mockChannel).basicPublish(any(String.class), any(String.class), Mockito.anyBoolean(),
+				any(BasicProperties.class), any(byte[].class));
 		Message reply = template.sendAndReceive(message);
 		assertNotNull(reply);
 
@@ -232,7 +223,7 @@ public class RabbitTemplateHeaderTests {
 		Connection mockConnection = mock(Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 
@@ -249,21 +240,18 @@ public class RabbitTemplateHeaderTests {
 		Message message = new Message("Hello, world!".getBytes(), messageProperties);
 		final AtomicReference<String> replyTo = new AtomicReference<String>();
 		final AtomicReference<String> correlationId = new AtomicReference<String>();
-		doAnswer(new Answer<Object>() {
-			@Override
-			public Object answer(InvocationOnMock invocation) throws Throwable {
-				BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
-				replyTo.set(basicProps.getReplyTo());
-				correlationId.set((String) basicProps.getHeaders().get(CORRELATION_HEADER));
+		doAnswer(invocation -> {
+			BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
+			replyTo.set(basicProps.getReplyTo());
+			correlationId.set((String) basicProps.getHeaders().get(CORRELATION_HEADER));
 
-				MessageProperties springProps = new DefaultMessagePropertiesConverter()
-						.toMessageProperties(basicProps, null, "UTF-8");
-				Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
-				template.onMessage(replyMessage);
-				return null;
-			} }
-		).when(mockChannel).basicPublish(Mockito.any(String.class), Mockito.any(String.class), Mockito.anyBoolean(),
-				Mockito.any(BasicProperties.class), Mockito.any(byte[].class));
+			MessageProperties springProps = new DefaultMessagePropertiesConverter()
+					.toMessageProperties(basicProps, null, "UTF-8");
+			Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
+			template.onMessage(replyMessage);
+			return null;
+		}).when(mockChannel).basicPublish(any(String.class), any(String.class), Mockito.anyBoolean(),
+				any(BasicProperties.class), any(byte[].class));
 		Message reply = template.sendAndReceive(message);
 		assertNotNull(reply);
 
@@ -282,7 +270,7 @@ public class RabbitTemplateHeaderTests {
 		Connection mockConnection = mock(Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 
@@ -301,27 +289,24 @@ public class RabbitTemplateHeaderTests {
 		final List<String> nestedReplyTo = new ArrayList<String>();
 		final List<String> nestedCorrelation = new ArrayList<String>();
 		final String replyTo3 = "replyTo3";
-		doAnswer(new Answer<Object>() {
-			@Override
-			public Object answer(InvocationOnMock invocation) throws Throwable {
-				BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
-				nestedReplyTo.add(basicProps.getReplyTo());
-				nestedCorrelation.add(basicProps.getCorrelationId());
-				MessageProperties springProps = new DefaultMessagePropertiesConverter()
-						.toMessageProperties(basicProps, null, "UTF-8");
-				Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
-				if (count.incrementAndGet() < 2) {
-					Message anotherMessage = new Message("Second".getBytes(), springProps);
-					template.setReplyAddress(replyTo3);
-					replyMessage = template.sendAndReceive(anotherMessage);
-					nestedReplyTo.add(replyMessage.getMessageProperties().getReplyTo());
-					nestedCorrelation.add((String) replyMessage.getMessageProperties().getHeaders().get(CORRELATION_HEADER));
-				}
-				template.onMessage(replyMessage);
-				return null;
-			} }
-		).when(mockChannel).basicPublish(Mockito.any(String.class), Mockito.any(String.class), Mockito.anyBoolean(),
-				Mockito.any(BasicProperties.class), Mockito.any(byte[].class));
+		doAnswer(invocation -> {
+			BasicProperties basicProps = (BasicProperties) invocation.getArguments()[3];
+			nestedReplyTo.add(basicProps.getReplyTo());
+			nestedCorrelation.add(basicProps.getCorrelationId());
+			MessageProperties springProps = new DefaultMessagePropertiesConverter()
+					.toMessageProperties(basicProps, null, "UTF-8");
+			Message replyMessage = new Message("!dlrow olleH".getBytes(), springProps);
+			if (count.incrementAndGet() < 2) {
+				Message anotherMessage = new Message("Second".getBytes(), springProps);
+				template.setReplyAddress(replyTo3);
+				replyMessage = template.sendAndReceive(anotherMessage);
+				nestedReplyTo.add(replyMessage.getMessageProperties().getReplyTo());
+				nestedCorrelation.add((String) replyMessage.getMessageProperties().getHeaders().get(CORRELATION_HEADER));
+			}
+			template.onMessage(replyMessage);
+			return null;
+		}).when(mockChannel).basicPublish(any(String.class), any(String.class), Mockito.anyBoolean(),
+				any(BasicProperties.class), any(byte[].class));
 		Message reply = template.sendAndReceive(message);
 		assertNotNull(reply);
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -351,7 +352,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		Channel mockChannel = mock(Channel.class);
 		when(mockChannel.isOpen()).thenReturn(true);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		doReturn(new PublisherCallbackChannelImpl(mockChannel)).when(mockConnection).createChannel();
 
@@ -386,7 +387,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		when(mockChannel1.getNextPublishSeqNo()).thenReturn(1L, 2L, 3L, 4L);
 		when(mockChannel2.getNextPublishSeqNo()).thenReturn(1L, 2L, 3L, 4L);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		PublisherCallbackChannelImpl channel1 = new PublisherCallbackChannelImpl(mockChannel1);
 		PublisherCallbackChannelImpl channel2 = new PublisherCallbackChannelImpl(mockChannel2);
@@ -464,7 +465,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		Channel mockChannel = mock(Channel.class);
 		when(mockChannel.isOpen()).thenReturn(true);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		doReturn(new PublisherCallbackChannelImpl(mockChannel)).when(mockConnection).createChannel();
 
@@ -508,7 +509,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		Channel mockChannel = mock(Channel.class);
 		when(mockChannel.isOpen()).thenReturn(true);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		PublisherCallbackChannelImpl callbackChannel = new PublisherCallbackChannelImpl(mockChannel);
 		when(mockConnection.createChannel()).thenReturn(callbackChannel);
@@ -555,7 +556,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		Channel mockChannel = mock(Channel.class);
 		when(mockChannel.isOpen()).thenReturn(true);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		PublisherCallbackChannelImpl callbackChannel = new PublisherCallbackChannelImpl(mockChannel);
 		when(mockConnection.createChannel()).thenReturn(callbackChannel);
@@ -628,7 +629,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		when(mockChannel.isOpen()).thenReturn(true);
 		when(mockChannel.getNextPublishSeqNo()).thenReturn(1L, 2L, 3L, 4L);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		final PublisherCallbackChannelImpl channel = new PublisherCallbackChannelImpl(mockChannel);
 		when(mockConnection.createChannel()).thenReturn(channel);
@@ -787,7 +788,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 			}
 		}).when(mockChannel).getNextPublishSeqNo();
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		doReturn(mockChannel).when(mockConnection).createChannel();
 
@@ -869,7 +870,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 			}
 		}).when(mockChannel2).getNextPublishSeqNo();
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel1, mockChannel2);
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -107,7 +109,7 @@ public class RabbitTemplateTests {
 		Connection mockConnection = mock(Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 
@@ -130,7 +132,7 @@ public class RabbitTemplateTests {
 				return null;
 			}
 		});
-		verify(mockConnectionFactory, Mockito.times(1)).newConnection(Mockito.any(ExecutorService.class));
+		verify(mockConnectionFactory, Mockito.times(1)).newConnection(any(ExecutorService.class), anyString());
 		// ensure we used the same channel
 		verify(mockConnection, Mockito.times(1)).createChannel();
 	}
@@ -174,7 +176,7 @@ public class RabbitTemplateTests {
 		Connection mockConnection = mock(Connection.class);
 		Channel mockChannel = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null)).thenReturn(mockConnection);
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
 		when(mockConnection.isOpen()).thenReturn(true);
 		when(mockConnection.createChannel()).thenReturn(mockChannel);
 
@@ -188,7 +190,7 @@ public class RabbitTemplateTests {
 				return null;
 			}
 		}).when(mockChannel).basicConsume(Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyString(),
-				Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyMap(), Mockito.any(Consumer.class));
+				Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyMap(), any(Consumer.class));
 		RabbitTemplate template = new RabbitTemplate(new SingleConnectionFactory(mockConnectionFactory));
 		template.setReplyTimeout(1);
 		Message input = new Message("Hello, world!".getBytes(), new MessageProperties());
@@ -202,14 +204,10 @@ public class RabbitTemplateTests {
 	public void testRetry() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		final AtomicInteger count = new AtomicInteger();
-		doAnswer(new Answer<Void>() {
-
-			@Override
-			public Void answer(InvocationOnMock invocation) throws Throwable {
-				count.incrementAndGet();
-				throw new AuthenticationFailureException("foo");
-			}
-		}).when(mockConnectionFactory).newConnection((ExecutorService) null);
+		doAnswer(invocation -> {
+			count.incrementAndGet();
+			throw new AuthenticationFailureException("foo");
+		}).when(mockConnectionFactory).newConnection(any(ExecutorService.class), anyString());
 
 		RabbitTemplate template = new RabbitTemplate(new SingleConnectionFactory(mockConnectionFactory));
 		template.setRetryTemplate(new RetryTemplate());
@@ -226,14 +224,10 @@ public class RabbitTemplateTests {
 	public void testRecovery() throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		final AtomicInteger count = new AtomicInteger();
-		doAnswer(new Answer<Void>() {
-
-			@Override
-			public Void answer(InvocationOnMock invocation) throws Throwable {
-				count.incrementAndGet();
-				throw new AuthenticationFailureException("foo");
-			}
-		}).when(mockConnectionFactory).newConnection((ExecutorService) null);
+		doAnswer(invocation -> {
+			count.incrementAndGet();
+			throw new AuthenticationFailureException("foo");
+		}).when(mockConnectionFactory).newConnection(any(ExecutorService.class), anyString());
 
 		RabbitTemplate template = new RabbitTemplate(new SingleConnectionFactory(mockConnectionFactory));
 		template.setRetryTemplate(new RetryTemplate());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -89,7 +89,7 @@ public class ExternalTxManagerTests {
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
 
-		given(mockConnectionFactory.newConnection(any(ExecutorService.class))).willReturn(mockConnection);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
 		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
@@ -261,9 +261,9 @@ public class ExternalTxManagerTests {
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(listenerConnectionFactory);
 		final CachingConnectionFactory cachingTemplateConnectionFactory = new CachingConnectionFactory(templateConnectionFactory);
 
-		given(listenerConnectionFactory.newConnection((ExecutorService) null)).willReturn(listenerConnection);
+		given(listenerConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(listenerConnection);
 		given(listenerConnection.isOpen()).willReturn(true);
-		given(templateConnectionFactory.newConnection((ExecutorService) null)).willReturn(templateConnection);
+		given(templateConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(templateConnection);
 		given(templateConnection.isOpen()).willReturn(true);
 		given(templateConnection.createChannel()).willReturn(templateChannel);
 
@@ -373,7 +373,7 @@ public class ExternalTxManagerTests {
 
 		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory(mockConnectionFactory);
 
-		given(mockConnectionFactory.newConnection((ExecutorService) null)).willReturn(mockConnection);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
 		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
@@ -475,7 +475,7 @@ public class ExternalTxManagerTests {
 
 		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory(mockConnectionFactory);
 
-		given(mockConnectionFactory.newConnection((ExecutorService) null)).willReturn(mockConnection);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
 		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
@@ -578,7 +578,7 @@ public class ExternalTxManagerTests {
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
 
-		given(mockConnectionFactory.newConnection((ExecutorService) null)).willReturn(mockConnection);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
 		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
@@ -80,7 +80,7 @@ public class LocallyTransactedTests {
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
 
-		given(mockConnectionFactory.newConnection(any(ExecutorService.class))).willReturn(mockConnection);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
 		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
@@ -211,7 +211,7 @@ public class LocallyTransactedTests {
 
 		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
 
-		given(mockConnectionFactory.newConnection((ExecutorService) null)).willReturn(mockConnection);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
 		given(mockConnection.isOpen()).willReturn(true);
 
 		final Channel channel1 = mock(Channel.class);
@@ -323,7 +323,7 @@ public class LocallyTransactedTests {
 
 		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory(mockConnectionFactory);
 
-		given(mockConnectionFactory.newConnection((ExecutorService) null)).willReturn(mockConnection);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
 		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
@@ -426,7 +426,7 @@ public class LocallyTransactedTests {
 
 		final SingleConnectionFactory singleConnectionFactory = new SingleConnectionFactory(mockConnectionFactory);
 
-		given(mockConnectionFactory.newConnection((ExecutorService) null)).willReturn(mockConnection);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
 		given(mockConnection.isOpen()).willReturn(true);
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -484,7 +484,7 @@ public class SimpleMessageListenerContainerTests {
 		Channel mockChannel1 = mock(Channel.class);
 		Channel mockChannel2 = mock(Channel.class);
 
-		when(mockConnectionFactory.newConnection((ExecutorService) null))
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString()))
 			.thenReturn(mockConnection1)
 			.thenReturn(mockConnection2)
 			.thenReturn(null);

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
@@ -3,17 +3,20 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:task="http://www.springframework.org/schema/task"
-	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
 		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:connection-factory id="kitchenSink" host="foo" virtual-host="/bar"
 		channel-cache-size="10" port="6888" username="user" password="password"
 		publisher-confirms="true" publisher-returns="true" connection-timeout="789"
 		factory-timeout="234" connection-limit="456"
-		requested-heartbeat="123"/>
+		requested-heartbeat="123"
+		connection-name-strategy="connectionNameStrategy"/>
+
+	<bean id="connectionNameStrategy" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.amqp.rabbit.connection.ConnectionNameStrategy"/>
+	</bean>
 
 	<rabbit:connection-factory id="native" connection-factory="connectionFactory" channel-cache-size="10" />
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -336,6 +336,21 @@ Here's an example with a custom thread factory that prefixes thread names with `
 
 ----
 
+Starting with _version 1.7_ a `ConnectionNameStrategy` is provided for the injection into the `AbstractionConnectionFactory`.
+The generated name is used for the application-specific identification of the target RabbitMQ connection.
+The connection name is displayed in the management UI if RabbitMQ server supports it.
+This value doesn't have to be unique and cannot be used as a connection identifier e.g. in HTTP API requests.
+This value is supposed to be human-readable and is a part of `ClientProperties` under `connection_name` key.
+Can be used as a simple Lambda:
+[source, java]
+----
+connectionFactory.setConnectionNameStrategy(connectionFactory -> "MY_CONNECTION");
+----
+
+The `ConnectionFactory` argument can be used to distinguish target connection names by some logic.
+By default a `beanName` of the `AbstractConnectionFactory` and an internal counter are used to generate `connection_name`.
+The `<rabbit:connection-factory>` namespace component is also supplied with the `connection-name-strategy` attribute.
+
 [[connection-factory]]
 ===== Configuring the Underlying Client Connection Factory
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -33,7 +33,11 @@ See <<junit-rules>> for more information.
 
 When using an external transaction manager (e.g. JDBC), rule-based rollback is now supported when providing the container with a transaction attribute.
 It is also now more flexible when using a transaction advice.
-See <<conditional-rollback>> for more information.
+
+===== Connection Naming Strategy
+
+A new `ConnectionNameStrategy` is now provided to populate the application-specific identification of the target RabbitMQ connection from the `AbstractConnectionFactory`.
+See <<connections>> for more information.
 
 ==== Earlier Releases
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-684

Backport

AMQP-631: Add `ConnectionNameStrategy` for `CF`

JIRA: https://jira.spring.io/browse/AMQP-631

To allow to identify application connections in the Broker or other monitoring and tracing tools, the Rabbit Connection can be supplied with `connection_name` property.

* Introduce `ConnectionNameStrategy` for injection into the `AbstractConnectionFactory` which is used to generate name for the underlying `rabbitConnectionFactory.newConnection()` operation

* Fix language
* Fix redundant import in the `ConnectionNameStrategy`
* Change FQCN (`getClass()`) to the `SpringAMQP` identifier

Conflicts:
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
	src/reference/asciidoc/whats-new.adoc
Resolved.

RecoveryListener

AMQP-631: Fix mocks test for new method in charge

JIRA: https://jira.spring.io/browse/AMQP-631

Conflicts:
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ClientRecoveryCompatibilityTests.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SingleConnectionFactoryTests.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateHeaderTests.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
Resolved.

Polishing