### PR TITLE
Various Test Performance Fixes

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactory.java
@@ -362,7 +362,9 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 	@Override
 	public void destroy() throws Exception {
 		for (ConnectionFactory connectionFactory : this.nodeFactories.values()) {
-			((DisposableBean) connectionFactory).destroy();
+			if (connectionFactory instanceof DisposableBean) {
+				((DisposableBean) connectionFactory).destroy();
+			}
 		}
 		if (this.defaultConnectionFactory instanceof DisposableBean) {
 			((DisposableBean) this.defaultConnectionFactory).destroy();

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactory.java
@@ -364,6 +364,9 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 		for (ConnectionFactory connectionFactory : this.nodeFactories.values()) {
 			((DisposableBean) connectionFactory).destroy();
 		}
+		if (this.defaultConnectionFactory instanceof DisposableBean) {
+			((DisposableBean) this.defaultConnectionFactory).destroy();
+		}
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplate.java
@@ -95,11 +95,11 @@ public class BatchingRabbitTemplate extends RabbitTemplate implements Lifecycle 
 	}
 
 	@Override
-	public void start() {
+	public void doStart() {
 	}
 
 	@Override
-	public void stop() {
+	public void doStop() {
 		flush();
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
@@ -273,6 +273,7 @@ public class CachingConnectionFactoryIntegrationTests {
 		template.convertAndSend(queue.getName(), "message");
 		String result = (String) template.receiveAndConvert(queue.getName());
 		assertEquals("message", result);
+		template.stop();
 
 	}
 
@@ -304,7 +305,7 @@ public class CachingConnectionFactoryIntegrationTests {
 
 		String result = (String) template.receiveAndConvert(queue.getName());
 		assertEquals("message", result);
-
+		template.stop();
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryIntegrationTests.java
@@ -55,7 +55,7 @@ public class LocalizedQueueConnectionFactoryIntegrationTests {
 	}
 
 	@Test
-	public void testConnect() {
+	public void testConnect() throws Exception {
 		RabbitAdmin admin = new RabbitAdmin(this.lqcf);
 		Queue queue = new Queue(UUID.randomUUID().toString(), false, false, true);
 		admin.declareQueue(queue);
@@ -64,6 +64,7 @@ public class LocalizedQueueConnectionFactoryIntegrationTests {
 		template.convertAndSend("", queue.getName(), "foo");
 		assertEquals("foo", template.receiveAndConvert(queue.getName()));
 		admin.deleteQueue(queue.getName());
+		lqcf.destroy();
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitBindingIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitBindingIntegrationTests.java
@@ -65,9 +65,8 @@ public class RabbitBindingIntegrationTests {
 	@After
 	public void cleanUp() {
 		this.brokerIsRunning.removeTestQueues();
-		if (connectionFactory != null) {
-			connectionFactory.destroy();
-		}
+		this.template.stop();
+		this.connectionFactory.destroy();
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateDirectReplyToContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateDirectReplyToContainerIntegrationTests.java
@@ -29,6 +29,7 @@ public class RabbitTemplateDirectReplyToContainerIntegrationTests extends Rabbit
 	protected RabbitTemplate createSendAndReceiveRabbitTemplate(ConnectionFactory connectionFactory) {
 		RabbitTemplate template = super.createSendAndReceiveRabbitTemplate(connectionFactory);
 		template.setUseDirectReplyToContainer(true);
+		template.setBeanName(this.testName.getMethodName() + "SendReceiveRabbitTemplate");
 		return template;
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -590,6 +590,7 @@ public class RabbitTemplateIntegrationTests {
 		// Message was consumed so nothing left on queue
 		reply = template.receive();
 		assertEquals(null, reply);
+		template.stop();
 		cachingConnectionFactory.destroy();
 	}
 
@@ -648,6 +649,7 @@ public class RabbitTemplateIntegrationTests {
 		assertEquals(null, reply);
 
 		assertTrue(execConfiguredOk.get());
+		template.stop();
 		connectionFactory.destroy();
 	}
 
@@ -679,6 +681,7 @@ public class RabbitTemplateIntegrationTests {
 		// Message was consumed so nothing left on queue
 		reply = template.receive(ROUTE);
 		assertEquals(null, reply);
+		template.stop();
 		cachingConnectionFactory.destroy();
 	}
 
@@ -710,6 +713,7 @@ public class RabbitTemplateIntegrationTests {
 		// Message was consumed so nothing left on queue
 		reply = template.receive(ROUTE);
 		assertEquals(null, reply);
+		template.stop();
 		cachingConnectionFactory.destroy();
 	}
 
@@ -741,6 +745,7 @@ public class RabbitTemplateIntegrationTests {
 		// Message was consumed so nothing left on queue
 		result = (String) template.receiveAndConvert();
 		assertEquals(null, result);
+		template.stop();
 		cachingConnectionFactory.destroy();
 	}
 
@@ -768,6 +773,7 @@ public class RabbitTemplateIntegrationTests {
 		// Message was consumed so nothing left on queue
 		result = (String) template.receiveAndConvert(ROUTE);
 		assertEquals(null, result);
+		template.stop();
 	}
 
 	@Test
@@ -794,6 +800,7 @@ public class RabbitTemplateIntegrationTests {
 		// Message was consumed so nothing left on queue
 		result = (String) template.receiveAndConvert(ROUTE);
 		assertEquals(null, result);
+		template.stop();
 	}
 
 	@Test
@@ -832,6 +839,7 @@ public class RabbitTemplateIntegrationTests {
 		// Message was consumed so nothing left on queue
 		result = (String) template.receiveAndConvert();
 		assertEquals(null, result);
+		template.stop();
 		cachingConnectionFactory.destroy();
 	}
 
@@ -867,6 +875,7 @@ public class RabbitTemplateIntegrationTests {
 		// Message was consumed so nothing left on queue
 		result = (String) template.receiveAndConvert(ROUTE);
 		assertEquals(null, result);
+		template.stop();
 	}
 
 	@Test
@@ -902,6 +911,7 @@ public class RabbitTemplateIntegrationTests {
 		// Message was consumed so nothing left on queue
 		result = (String) template.receiveAndConvert(ROUTE);
 		assertEquals(null, result);
+		template.stop();
 	}
 
 	@Test
@@ -1145,6 +1155,7 @@ public class RabbitTemplateIntegrationTests {
 		assertNotNull(result);
 		assertEquals("TEST", new String(result.getBody()));
 		assertEquals(messageId, result.getMessageProperties().getCorrelationId());
+		template.stop();
 	}
 
 	@Test
@@ -1168,8 +1179,8 @@ public class RabbitTemplateIntegrationTests {
 	}
 
 	private void sendAndReceiveFastGuts(boolean tempQueue, boolean setDirectReplyToExplicitly, boolean expectUsedTemp) {
+		RabbitTemplate template = createSendAndReceiveRabbitTemplate(this.connectionFactory);
 		try {
-			RabbitTemplate template = createSendAndReceiveRabbitTemplate(this.connectionFactory);
 			template.execute(channel -> {
 				channel.queueDeclarePassive(Address.AMQ_RABBITMQ_REPLY_TO);
 				return null;
@@ -1210,6 +1221,9 @@ public class RabbitTemplateIntegrationTests {
 			assertThat(e.getCause().getCause().getMessage(), containsString("404"));
 			logger.info("Broker does not support fast replies; test skipped " + e.getMessage());
 		}
+		finally {
+			template.stop();
+		}
 	}
 
 	@Test
@@ -1229,8 +1243,8 @@ public class RabbitTemplateIntegrationTests {
 		container.setReceiveTimeout(100);
 		container.afterPropertiesSet();
 		container.start();
+		RabbitTemplate template = createSendAndReceiveRabbitTemplate(this.template.getConnectionFactory());
 		try {
-			RabbitTemplate template = createSendAndReceiveRabbitTemplate(this.template.getConnectionFactory());
 			MessageProperties props = new MessageProperties();
 			props.setContentType("text/plain");
 			Message message = new Message("foo".getBytes(), props);
@@ -1242,6 +1256,7 @@ public class RabbitTemplateIntegrationTests {
 			assertEquals("FOO", new String(reply.getBody()));
 		}
 		finally {
+			template.stop();
 			container.stop();
 		}
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -63,6 +63,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
@@ -159,6 +160,9 @@ public class RabbitTemplateIntegrationTests {
 	public LogLevelAdjuster logAdjuster = new LogLevelAdjuster(Level.DEBUG, RabbitTemplate.class,
 			RabbitAdmin.class, RabbitTemplateIntegrationTests.class, BrokerRunning.class);
 
+	@Rule
+	public TestName testName = new TestName();
+
 	private CachingConnectionFactory connectionFactory;
 
 	private RabbitTemplate template;
@@ -185,10 +189,12 @@ public class RabbitTemplateIntegrationTests {
 		when(cf.getUsername()).thenReturn("guest");
 		when(bf.getBean("cf")).thenReturn(cf);
 		this.template.setBeanFactory(bf);
+		template.setBeanName(this.testName.getMethodName() + "RabbitTemplate");
 	}
 
 	@After
 	public void cleanup() throws Exception {
+		this.template.stop();
 		((DisposableBean) template.getConnectionFactory()).destroy();
 		this.brokerIsRunning.removeTestQueues();
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePerformanceIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePerformanceIntegrationTests.java
@@ -84,9 +84,8 @@ public class RabbitTemplatePerformanceIntegrationTests {
 		if (!repeat.isFinalizing()) {
 			return;
 		}
-		if (connectionFactory != null) {
-			connectionFactory.destroy();
-		}
+		this.template.stop();
+		this.connectionFactory.destroy();
 		this.brokerIsRunning.removeTestQueues();
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
@@ -128,17 +128,11 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 
 	@After
 	public void cleanUp() {
-		if (connectionFactory != null) {
-			connectionFactory.destroy();
-		}
-
-		if (connectionFactoryWithConfirmsEnabled != null) {
-			connectionFactoryWithConfirmsEnabled.destroy();
-		}
-
-		if (connectionFactoryWithReturnsEnabled != null) {
-			connectionFactoryWithReturnsEnabled.destroy();
-		}
+		this.templateWithConfirmsEnabled.stop();
+		this.templateWithReturnsEnabled.stop();
+		this.connectionFactory.destroy();
+		this.connectionFactoryWithConfirmsEnabled.destroy();
+		this.connectionFactoryWithReturnsEnabled.destroy();
 		this.brokerIsRunning.removeTestQueues();
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
@@ -147,6 +147,7 @@ public class DirectMessageListenerContainerTests {
 		assertTrue(consumersOnQueue(Q2, 0));
 		assertTrue(activeConsumerCount(container, 0));
 		assertEquals(0, TestUtils.getPropertyValue(container, "consumersByQueue", MultiValueMap.class).size());
+		template.stop();
 		cf.destroy();
 	}
 
@@ -217,6 +218,7 @@ public class DirectMessageListenerContainerTests {
 		assertTrue(consumersOnQueue(Q2, 0));
 		assertTrue(activeConsumerCount(container, 0));
 		assertEquals(0, TestUtils.getPropertyValue(container, "consumersByQueue", MultiValueMap.class).size());
+		template.stop();
 		cf.destroy();
 	}
 
@@ -258,6 +260,7 @@ public class DirectMessageListenerContainerTests {
 		assertTrue(consumersOnQueue(Q2, 0));
 		assertTrue(activeConsumerCount(container, 0));
 		assertEquals(0, TestUtils.getPropertyValue(container, "consumersByQueue", MultiValueMap.class).size());
+		template.stop();
 		cf.destroy();
 	}
 
@@ -496,6 +499,7 @@ public class DirectMessageListenerContainerTests {
 		});
 		container.releaseConsumerFor(channelHolder, true, "foo");
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		container.stop();
 		cf.destroy();
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerTests.java
@@ -98,6 +98,11 @@ public class DirectMessageListenerContainerTests {
 	@ClassRule
 	public static BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues(Q1, Q2, EQ1, EQ2, DLQ1);
 
+	private static CachingConnectionFactory adminCf =
+			new CachingConnectionFactory(brokerRunning.getConnectionFactory());
+
+	private static RabbitAdmin admin = new RabbitAdmin(adminCf);
+
 	@Rule
 	public LogLevelAdjuster adjuster = new LogLevelAdjuster(Level.DEBUG,
 			CachingConnectionFactory.class, DirectReplyToMessageListenerContainer.class,
@@ -109,6 +114,7 @@ public class DirectMessageListenerContainerTests {
 	@AfterClass
 	public static void tearDown() {
 		brokerRunning.removeTestQueues();
+		adminCf.destroy();
 	}
 
 	@Test
@@ -490,6 +496,7 @@ public class DirectMessageListenerContainerTests {
 		});
 		container.releaseConsumerFor(channelHolder, true, "foo");
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		cf.destroy();
 	}
 
 	@Test
@@ -564,8 +571,6 @@ public class DirectMessageListenerContainerTests {
 
 	private boolean consumersOnQueue(String queue, int expected) throws Exception {
 		int n = 0;
-		CachingConnectionFactory cf = new CachingConnectionFactory(brokerRunning.getConnectionFactory());
-		RabbitAdmin admin = new RabbitAdmin(cf);
 		Properties queueProperties = admin.getQueueProperties(queue);
 		LogFactory.getLog(getClass()).debug(queue + " waiting for " + expected + " : " + queueProperties);
 		while (n++ < 600
@@ -574,7 +579,6 @@ public class DirectMessageListenerContainerTests {
 			queueProperties = admin.getQueueProperties(queue);
 			LogFactory.getLog(getClass()).debug(queue + " waiting for " + expected + " : " + queueProperties);
 		}
-		cf.destroy();
 		return queueProperties.get(RabbitAdmin.QUEUE_CONSUMER_COUNT).equals(expected);
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainerTests.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 
 import org.springframework.amqp.core.Address;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerContainer.ChannelHolder;
 import org.springframework.amqp.rabbit.test.LogLevelAdjuster;
@@ -68,7 +67,7 @@ public class DirectReplyToMessageListenerContainerTests {
 
 	@Test
 	public void testReleaseConsumerRace() throws Exception {
-		ConnectionFactory connectionFactory = new CachingConnectionFactory("localhost");
+		CachingConnectionFactory connectionFactory = new CachingConnectionFactory("localhost");
 		DirectReplyToMessageListenerContainer container = new DirectReplyToMessageListenerContainer(connectionFactory);
 		final CountDownLatch latch = new CountDownLatch(1);
 		container.setMessageListener(m -> latch.countDown());
@@ -95,6 +94,8 @@ public class DirectReplyToMessageListenerContainerTests {
 		assertThat(inUse.size(), equalTo(1));
 		container.releaseConsumerFor(channel2, false, null);
 		assertThat(inUse.size(), equalTo(0));
+		container.stop();
+		connectionFactory.destroy();
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryCachingConnectionIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryCachingConnectionIntegrationTests.java
@@ -416,7 +416,7 @@ public class MessageListenerRecoveryCachingConnectionIntegrationTests {
 			throws InterruptedException {
 		RabbitAdmin admin = new RabbitAdmin(connectionFactory);
 		// queue doesn't exist during startup - verify we started, create queue and verify recovery
-		Thread.sleep(5000);
+		Thread.sleep(1000);
 		assertEquals(messageCount, latch.getCount());
 		admin.declareQueue(new Queue("nonexistent"));
 		RabbitTemplate template = new RabbitTemplate(connectionFactory);
@@ -430,7 +430,7 @@ public class MessageListenerRecoveryCachingConnectionIntegrationTests {
 
 		// delete the queue and verify we recover again when it is recreated.
 		admin.deleteQueue("nonexistent");
-		Thread.sleep(3000);
+		Thread.sleep(1000);
 		latch = new CountDownLatch(messageCount);
 		container.setMessageListener(new MessageListenerAdapter(new VanillaListener(latch)));
 		assertEquals(messageCount, latch.getCount());
@@ -462,6 +462,8 @@ public class MessageListenerRecoveryCachingConnectionIntegrationTests {
 		container.setConcurrentConsumers(concurrentConsumers);
 		container.setChannelTransacted(transactional);
 		container.setAcknowledgeMode(acknowledgeMode);
+		container.setRecoveryInterval(100);
+		container.setFailedDeclarationRetryInterval(100);
 		container.afterPropertiesSet();
 		return container;
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/transaction/RabbitTransactionManagerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/transaction/RabbitTransactionManagerIntegrationTests.java
@@ -59,6 +59,7 @@ public class RabbitTransactionManagerIntegrationTests {
 
 	@After
 	public void cleanup() throws Exception {
+		this.template.stop();
 		((DisposableBean) this.template.getConnectionFactory()).destroy();
 		this.brokerIsRunning.removeTestQueues();
 	}


### PR DESCRIPTION
Including:

- add `Lifecycle` to `RabbitTemplate` and `stop()` it
in non-spring-managed tests where send and receive operations
have been done - prevent the replyTo container from
reopening the connection
- use a shared admin for several tests
- close connections - a few remain which we can track down later