### PR TITLE
AMQP-692: Fix MessagingMessageLA missed argument

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import com.rabbitmq.client.Channel;
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 1.4
  */
 public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageListener {
@@ -166,11 +167,11 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 		}
 		catch (MessagingException ex) {
 			throw new ListenerExecutionFailedException(createMessagingErrorMessage("Listener method could not " +
-					"be invoked with the incoming message", message.getPayload()), ex);
+					"be invoked with the incoming message", message.getPayload()), ex, amqpMessage);
 		}
 		catch (Exception ex) {
 			throw new ListenerExecutionFailedException("Listener method '" +
-					this.handlerMethod.getMethodAsString(message.getPayload()) + "' threw exception", ex);
+					this.handlerMethod.getMethodAsString(message.getPayload()) + "' threw exception", ex, amqpMessage);
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/exception/ListenerExecutionFailedException.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/exception/ListenerExecutionFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
  *
  * @author Juergen Hoeller
  * @author Gary Russell
+ *
  * @see MessageListenerAdapter
  */
 @SuppressWarnings("serial")
@@ -37,7 +38,9 @@ public class ListenerExecutionFailedException extends AmqpException {
 	 * Constructor for ListenerExecutionFailedException.
 	 * @param msg the detail message
 	 * @param cause the exception thrown by the listener method
+	 * @deprecated in favor of {@link #ListenerExecutionFailedException(String, Throwable, Message)}
 	 */
+	@Deprecated
 	public ListenerExecutionFailedException(String msg, Throwable cause) {
 		this(msg, cause, null);
 	}
@@ -47,7 +50,6 @@ public class ListenerExecutionFailedException extends AmqpException {
 	 * @param msg the detail message
 	 * @param cause the exception thrown by the listener method
 	 * @param failedMessage the message that failed
-	 *
 	 */
 	public ListenerExecutionFailedException(String msg, Throwable cause, Message failedMessage) {
 		super(msg, cause);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ErrorHandlerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ErrorHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ import org.springframework.messaging.handler.annotation.support.MethodArgumentTy
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.6
  *
  */
@@ -49,10 +51,12 @@ public class ErrorHandlerTests {
 		Log logger = spy(TestUtils.getPropertyValue(handler, "logger", Log.class));
 		willDoNothing().given(logger).warn(anyString(), any(Throwable.class));
 		new DirectFieldAccessor(handler).setPropertyValue("logger", logger);
-		handler.handleError(new ListenerExecutionFailedException("intended", new RuntimeException()));
+		handler.handleError(new ListenerExecutionFailedException("intended", new RuntimeException(),
+				mock(org.springframework.amqp.core.Message.class)));
 
 		try {
-			handler.handleError(new ListenerExecutionFailedException("intended", new MessageConversionException("")));
+			handler.handleError(new ListenerExecutionFailedException("intended", new MessageConversionException(""),
+					mock(org.springframework.amqp.core.Message.class)));
 			fail("Expected exception");
 		}
 		catch (AmqpRejectAndDontRequeueException e) {
@@ -60,7 +64,8 @@ public class ErrorHandlerTests {
 
 		try {
 			handler.handleError(new ListenerExecutionFailedException("intended",
-					new org.springframework.messaging.converter.MessageConversionException("")));
+					new org.springframework.messaging.converter.MessageConversionException(""),
+					mock(org.springframework.amqp.core.Message.class)));
 			fail("Expected exception");
 		}
 		catch (AmqpRejectAndDontRequeueException e) {
@@ -70,7 +75,8 @@ public class ErrorHandlerTests {
 		MethodParameter mp = new MethodParameter(Foo.class.getMethod("foo", String.class), 0);
 		try {
 			handler.handleError(new ListenerExecutionFailedException("intended",
-					new MethodArgumentNotValidException(message, mp)));
+					new MethodArgumentNotValidException(message, mp),
+					mock(org.springframework.amqp.core.Message.class)));
 			fail("Expected exception");
 		}
 		catch (AmqpRejectAndDontRequeueException e) {
@@ -78,7 +84,8 @@ public class ErrorHandlerTests {
 
 		try {
 			handler.handleError(new ListenerExecutionFailedException("intended",
-					new MethodArgumentTypeMismatchException(message, mp, "")));
+					new MethodArgumentTypeMismatchException(message, mp, ""),
+					mock(org.springframework.amqp.core.Message.class)));
 			fail("Expected exception");
 		}
 		catch (AmqpRejectAndDontRequeueException e) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,8 @@ import com.rabbitmq.client.Channel;
  * @author Dave Syer
  * @author Gunar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.0
  *
  */
@@ -165,7 +167,8 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		int messageCount = 3;
 		CountDownLatch latch = new CountDownLatch(messageCount);
 		doTest(messageCount, errorHandler, latch, new ThrowingExceptionListener(latch,
-				new ListenerExecutionFailedException("Listener throws specific runtime exception", null)));
+				new ListenerExecutionFailedException("Listener throws specific runtime exception", null,
+						mock(Message.class))));
 	}
 
 	@Test
@@ -258,7 +261,8 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 
 		container.stop();
 
-		Exception e = new ListenerExecutionFailedException("foo", new MessageConversionException("bar"));
+		Exception e = new ListenerExecutionFailedException("foo", new MessageConversionException("bar"),
+				mock(Message.class));
 		try {
 			eh.handleError(e);
 			fail("expected exception");
@@ -267,7 +271,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 			assertSame(e, aradre.getCause());
 		}
 		e = new ListenerExecutionFailedException("foo", new MessageConversionException("bar",
-				new AmqpRejectAndDontRequeueException("baz")));
+				new AmqpRejectAndDontRequeueException("baz")), mock(Message.class));
 		eh.handleError(e);
 		((DisposableBean) template.getConnectionFactory()).destroy();
 	}
@@ -403,4 +407,5 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 			}
 		}
 	}
+
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-692
Fixes GH-535 (https://github.com/spring-projects/spring-amqp/issues/535)

The `ListenerExecutionFailedException` does not make sense without a `failedMessage`.
So, fix `MessagingMessageListenerAdapter` to use another `ListenerExecutionFailedException` ctor with the `amqpMessage` param as a `failedMessage` arg

**Cherry-pick to 1.6.x & 1.7.x**

Note: a `@Deprecated` ctor should be removed for `master`