### PR TITLE
AMQP-693: AsyncRabbitTemplate TaskScheduler Fixes

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -331,6 +331,7 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 	 * @see #setReceiveTimeout(long)
 	 */
 	public synchronized void setTaskScheduler(TaskScheduler taskScheduler) {
+		Assert.notNull(taskScheduler, "'taskScheduler' cannot be null");
 		this.internalTaskScheduler = false;
 		this.taskScheduler = taskScheduler;
 	}
@@ -722,7 +723,7 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 
 		void startTimer() {
 			if (AsyncRabbitTemplate.this.receiveTimeout > 0) {
-				synchronized (AsyncRabbitTemplate.this.taskScheduler) {
+				synchronized (AsyncRabbitTemplate.this) {
 					this.timeoutTask = AsyncRabbitTemplate.this.taskScheduler.schedule(new TimeoutTask(),
 							new Date(System.currentTimeMillis() + AsyncRabbitTemplate.this.receiveTimeout));
 				}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
@@ -356,6 +356,7 @@ public class AsyncRabbitTemplateTests {
 		assertEquals(0, TestUtils.getPropertyValue(this.asyncTemplate, "pending", Map.class).size());
 		assertTrue(callback.latch.await(10, TimeUnit.SECONDS));
 		assertTrue(future.isCancelled());
+		assertNull(TestUtils.getPropertyValue(this.asyncTemplate, "taskScheduler"));
 
 		/*
 		 * Test there's no harm if the reply is received after the cancel. This


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-693

- Destroy the internal scheduler (if used) in stop() to allow the JVM to terminate
- Fix synchronization around `this.taskScheduler`
- Assert that the template is started to avoid NPEs

__cherry-pick to 1.7.x, 1.6.x__