### PR TITLE
AMQP-696: RabbitManagementTemplate Fix

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,14 @@ public final class ExchangeBuilder extends AbstractBuilder {
 
 	private boolean delayed;
 
-	private ExchangeBuilder(String name, String type) {
+	/**
+	 * Construct an instance of the appropriate type.
+	 * @param name the exchange name
+	 * @param type the type name
+	 * @see ExchangeTypes
+	 * @since 1.6.7
+	 */
+	public ExchangeBuilder(String name, String type) {
 		this.name = name;
 		this.type = type;
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitManagementTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.core.AbstractExchange;
 import org.springframework.amqp.core.AmqpManagementOperations;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Binding.DestinationType;
@@ -238,22 +239,30 @@ public class RabbitManagementTemplate implements AmqpManagementOperations {
 	}
 
 	private Exchange convert(ExchangeInfo ei) {
+		boolean delayed = false;
+		if (ei.getType().equals("x-delayed-message")) {
+			ei.setType((String) ei.getArguments().get("x-delayed-type"));
+			delayed = true;
+		}
+		AbstractExchange exchange;
 		if (ei.getType().equals("direct")) {
-			return new DirectExchange(ei.getName(), ei.isDurable(), ei.isAutoDelete(), ei.getArguments());
+			exchange = new DirectExchange(ei.getName(), ei.isDurable(), ei.isAutoDelete(), ei.getArguments());
 		}
 		else if (ei.getType().equals("fanout")) {
-			return new FanoutExchange(ei.getName(), ei.isDurable(), ei.isAutoDelete(), ei.getArguments());
+			exchange = new FanoutExchange(ei.getName(), ei.isDurable(), ei.isAutoDelete(), ei.getArguments());
 		}
 		else if (ei.getType().equals("headers")) {
-			return new HeadersExchange(ei.getName(), ei.isDurable(), ei.isAutoDelete(), ei.getArguments());
+			exchange = new HeadersExchange(ei.getName(), ei.isDurable(), ei.isAutoDelete(), ei.getArguments());
 		}
 		else if (ei.getType().equals("topic")) {
-			return new TopicExchange(ei.getName(), ei.isDurable(), ei.isAutoDelete(), ei.getArguments());
+			exchange = new TopicExchange(ei.getName(), ei.isDurable(), ei.isAutoDelete(), ei.getArguments());
 		}
 		else {
 			return null;
 		}
-
+		exchange.setDelayed(delayed);
+		exchange.setInternal(ei.isInternal());
+		return exchange;
 	}
 
 	private List<Binding> convertBindingList(List<BindingInfo> bindings) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-695
JIRA: https://jira.spring.io/browse/AMQP-696

Also make `ExhangeBuilder` ctor public to enable building by type name (e.g. from a boot property).

__cherry-pick to 1.7.x, 1.6.x__