### PR TITLE
AMQP-697: CorrelationAwareMessagePostProcessor

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/CorrelationAwareMessagePostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/CorrelationAwareMessagePostProcessor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.core;
+
+/**
+ * A message post processor that can also use/manipulate correlation data.
+ *
+ * @author Gary Russell
+ * @since 1.6.7
+ * @deprecated in 2.0, the method has been moved to {@link MessagePostProcessor}.
+ */
+@Deprecated
+public interface CorrelationAwareMessagePostProcessor extends MessagePostProcessor {
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessagePostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessagePostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,13 @@
 package org.springframework.amqp.core;
 
 import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.support.Correlation;
 
 /**
  * To be used with the send method of Amqp template classes (such as RabbitTemplate)
  * that convert an object to a message.
  * It allows for further modification of the message after it has been processed
- * by the converter. This is useful for setting of Header and Properties.
+ * by the converter. This is useful for setting of Headers and Properties.
  *
  * <p>This often as an anonymous class within a method implementation.
  * @author Mark Pollack
@@ -31,6 +32,23 @@ import org.springframework.amqp.AmqpException;
 @FunctionalInterface
 public interface MessagePostProcessor {
 
+	/**
+	 * Change (or replace) the message.
+	 * @param message the message.
+	 * @return the message.
+	 * @throws AmqpException an exception.
+	 */
 	Message postProcessMessage(Message message) throws AmqpException;
+
+	/**
+	 * Change (or replace) the message and/or change its correlation data.
+	 * @param message the message.
+	 * @param correlation the correlation data.
+	 * @return the message.
+	 * @since 1.6.7
+	 */
+	default Message postProcessMessage(Message message, Correlation correlation) {
+		return postProcessMessage(message);
+	}
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/Correlation.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/Correlation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support;
+
+/**
+ * A marker interface for data used to correlate information about sent messages.
+ * One example might be used to correlate a send confirmation.
+ *
+ * @author Gary Russell
+ * @since 1.6.7
+ *
+ */
+public interface Correlation {
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerCont
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.support.CorrelationData;
 import org.springframework.amqp.rabbit.support.PublisherCallbackChannel;
+import org.springframework.amqp.support.Correlation;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SmartMessageConverter;
 import org.springframework.beans.factory.BeanNameAware;
@@ -102,6 +103,9 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 
 	@SuppressWarnings("rawtypes")
 	private final ConcurrentMap<String, RabbitFuture> pending = new ConcurrentHashMap<String, RabbitFuture>();
+
+	@SuppressWarnings("rawtypes")
+	private final CorrelationMessagePostProcessor messagePostProcessor = new CorrelationMessagePostProcessor<>();
 
 	private volatile boolean running;
 
@@ -453,14 +457,10 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 
 	private <C> RabbitConverterFuture<C> convertSendAndReceive(String exchange, String routingKey, Object object,
 			MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<C> responseType) {
-		CorrelationData correlationData = null;
-		if (this.enableConfirms) {
-			correlationData = new CorrelationData(null);
-		}
-		CorrelationMessagePostProcessor<C> correlationPostProcessor = new CorrelationMessagePostProcessor<>(
-				messagePostProcessor, correlationData, responseType);
+		AsyncCorrelationData<C> correlationData = new AsyncCorrelationData<C>(messagePostProcessor, responseType,
+				this.enableConfirms);
 		if (this.container != null) {
-			this.template.convertAndSend(exchange, routingKey, object, correlationPostProcessor, correlationData);
+			this.template.convertAndSend(exchange, routingKey, object, this.messagePostProcessor, correlationData);
 		}
 		else {
 			MessageConverter converter = this.template.getMessageConverter();
@@ -469,12 +469,12 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 						"No 'messageConverter' specified. Check configuration of RabbitTemplate.");
 			}
 			Message message = converter.toMessage(object, new MessageProperties());
-			correlationPostProcessor.postProcessMessage(message);
+			this.messagePostProcessor.postProcessMessage(message, correlationData);
 			ChannelHolder channelHolder = this.directReplyToContainer.getChannelHolder();
-			correlationPostProcessor.getFuture().setChannelHolder(channelHolder);
+			correlationData.future.setChannelHolder(channelHolder);
 			sendDirect(channelHolder.getChannel(), exchange, routingKey, message, correlationData);
 		}
-		RabbitConverterFuture<C> future = correlationPostProcessor.getFuture();
+		RabbitConverterFuture<C> future = correlationData.future;
 		future.startTimer();
 		return future;
 	}
@@ -789,40 +789,51 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 
 	private final class CorrelationMessagePostProcessor<C> implements MessagePostProcessor {
 
-		private final MessagePostProcessor userPostProcessor;
-
-		private final CorrelationData correlationData;
-
-		private final ParameterizedTypeReference<C> returnType;
-
-		private volatile RabbitConverterFuture<C> future;
-
-		CorrelationMessagePostProcessor(MessagePostProcessor userPostProcessor,
-				CorrelationData correlationData, ParameterizedTypeReference<C> returnType) {
-			this.userPostProcessor = userPostProcessor;
-			this.correlationData = correlationData;
-			this.returnType = returnType;
+		CorrelationMessagePostProcessor() {
+			super();
 		}
 
 		@Override
 		public Message postProcessMessage(Message message) throws AmqpException {
+			throw new UnsupportedOperationException();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public Message postProcessMessage(Message message, Correlation correlation) throws AmqpException {
 			Message messageToSend = message;
-			if (this.userPostProcessor != null) {
-				messageToSend = this.userPostProcessor.postProcessMessage(message);
+			AsyncCorrelationData<C> correlationData = (AsyncCorrelationData<C>) correlation;
+			if (correlationData.userPostProcessor != null) {
+				messageToSend = correlationData.userPostProcessor.postProcessMessage(message);
 			}
 			String correlationId = getOrSetCorrelationIdAndSetReplyTo(messageToSend);
-			this.future = new RabbitConverterFuture<C>(correlationId, message);
-			if (this.correlationData != null && this.correlationData.getId() == null) {
-				this.correlationData.setId(correlationId);
-				this.future.setConfirm(new SettableListenableFuture<>());
+			correlationData.future = new RabbitConverterFuture<C>(correlationId, message);
+			if (correlationData.enableConfirms && correlationData.getId() == null) {
+				correlationData.setId(correlationId);
+				correlationData.future.setConfirm(new SettableListenableFuture<>());
 			}
-			this.future.setReturnType(this.returnType);
-			AsyncRabbitTemplate.this.pending.put(correlationId, this.future);
+			correlationData.future.setReturnType(correlationData.returnType);
+			AsyncRabbitTemplate.this.pending.put(correlationId, correlationData.future);
 			return messageToSend;
 		}
 
-		private RabbitConverterFuture<C> getFuture() {
-			return this.future;
+	}
+
+	private static class AsyncCorrelationData<C> extends CorrelationData {
+
+		private final MessagePostProcessor userPostProcessor;
+
+		private final ParameterizedTypeReference<C> returnType;
+
+		private final boolean enableConfirms;
+
+		private volatile RabbitConverterFuture<C> future;
+
+		AsyncCorrelationData(MessagePostProcessor userPostProcessor, ParameterizedTypeReference<C> returnType,
+				boolean enableConfirms) {
+			this.userPostProcessor = userPostProcessor;
+			this.returnType = returnType;
+			this.enableConfirms = enableConfirms;
 		}
 
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -895,7 +895,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	public void convertAndSend(String exchange, String routingKey, final Object message,
 			final MessagePostProcessor messagePostProcessor, CorrelationData correlationData) throws AmqpException {
 		Message messageToSend = convertMessageIfNecessary(message);
-		messageToSend = messagePostProcessor.postProcessMessage(messageToSend);
+		messageToSend = messagePostProcessor.postProcessMessage(messageToSend, correlationData);
 		send(exchange, routingKey, messageToSend, correlationData);
 	}
 
@@ -1448,7 +1448,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			final MessagePostProcessor messagePostProcessor, final CorrelationData correlationData) {
 		Message requestMessage = convertMessageIfNecessary(message);
 		if (messagePostProcessor != null) {
-			requestMessage = messagePostProcessor.postProcessMessage(requestMessage);
+			requestMessage = messagePostProcessor.postProcessMessage(requestMessage, correlationData);
 		}
 		Message replyMessage = doSendAndReceive(exchange, routingKey, requestMessage, correlationData);
 		return replyMessage;
@@ -1792,7 +1792,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 		}
 		if (this.beforePublishPostProcessors != null) {
 			for (MessagePostProcessor processor : this.beforePublishPostProcessors) {
-				messageToUse = processor.postProcessMessage(messageToUse);
+				messageToUse = processor.postProcessMessage(messageToUse, correlationData);
 			}
 		}
 		if (this.userIdExpression != null && messageProperties.getUserId() == null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/CorrelationData.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/CorrelationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.amqp.rabbit.support;
 
+import org.springframework.amqp.support.Correlation;
+
 /**
  * Base class for correlating publisher confirms to sent messages.
  * Use the {@link org.springframework.amqp.rabbit.core.RabbitTemplate}
@@ -26,10 +28,22 @@ package org.springframework.amqp.rabbit.support;
  * @since 1.0.1
  *
  */
-public class CorrelationData {
+public class CorrelationData implements Correlation {
 
 	private volatile String id;
 
+	/**
+	 * Construct an instance with a null Id.
+	 * @since 1.6.7
+	 */
+	public CorrelationData() {
+		super();
+	}
+
+	/**
+	 * Construct an instance with the supplied id.
+	 * @param id the id.
+	 */
 	public CorrelationData(String id) {
 		this.id = id;
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Rule;
@@ -91,8 +92,13 @@ public class AsyncRabbitTemplateTests {
 
 	@Test
 	public void testConvert1Arg() throws Exception {
-		ListenableFuture<String> future = this.asyncTemplate.convertSendAndReceive("foo");
+		final AtomicBoolean mppCalled = new AtomicBoolean();
+		ListenableFuture<String> future = this.asyncTemplate.convertSendAndReceive("foo", m -> {
+			mppCalled.set(true);
+			return m;
+		});
 		checkConverterResult(future, "FOO");
+		assertTrue(mppCalled.get());
 	}
 
 	@Test

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1083,6 +1083,15 @@ With the `RabbitTemplate` implementation of `AmqpTemplate`, each of the `send()`
 When publisher confirms are enabled, this object is returned in the callback described in <<amqp-template>>.
 This allows the sender to correlate a confirm (ack or nack) with the sent message.
 
+Starting with version 1.6.7, the `CorrelationAwareMessagePostProcessor` interface was introduced, allowing the correlation data to be modified after the message has been converted:
+
+[source, java]
+----
+Message postProcessMessage(Message message, Correlation correlation);
+----
+
+In version 2.0, this interface is deprecated; the method has been moved to `MessagePostProcessor` with a default implementation that delegates to `postProcessMessage(Message message)`.
+
 ===== Publisher Returns
 
 When the template's `mandatory` property is 'true' returned messages are provided by the callback described in <<amqp-template>>.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-697

Add support for modifying publisher confirms `CorrelationData` during message post processing.

Change `AsyncRabbitTemplate` to use a stateless MPP, move all state to the `CorrelationData`.

__master only - I will issue a new 1.x backport PR after review/merge__