### PR TITLE
AMQP-697: CorrelationAwareMessagePostProcessor [1.7.x]

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/CorrelationAwareMessagePostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/CorrelationAwareMessagePostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,23 @@
 
 package org.springframework.amqp.core;
 
-import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.support.Correlation;
 
 /**
- * To be used with the send method of Amqp template classes (such as RabbitTemplate)
- * that convert an object to a message.
- * It allows for further modification of the message after it has been processed
- * by the converter. This is useful for setting of Headers and Properties.
+ * A message post processor that can also use/manipulate correlation data.
  *
- * <p>This often as an anonymous class within a method implementation.
- * @author Mark Pollack
+ * @author Gary Russell
+ * @since 1.6.7
  */
-public interface MessagePostProcessor {
+public interface CorrelationAwareMessagePostProcessor extends MessagePostProcessor {
 
 	/**
-	 * Change (or replace) the message.
+	 * Change (or replace) the message and/or change its correlation data.
 	 * @param message the message.
+	 * @param correlation the correlation data.
 	 * @return the message.
-	 * @throws AmqpException an exception.
+	 * @since 1.6.7
 	 */
-	Message postProcessMessage(Message message) throws AmqpException;
+	Message postProcessMessage(Message message, Correlation correlation);
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/Correlation.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/Correlation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support;
+
+/**
+ * A marker interface for data used to correlate information about sent messages.
+ * One example might be used to correlate a send confirmation.
+ *
+ * @author Gary Russell
+ * @since 1.6.7
+ *
+ */
+public interface Correlation {
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.amqp.AmqpIllegalStateException;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.Address;
 import org.springframework.amqp.core.AmqpMessageReturnedException;
+import org.springframework.amqp.core.CorrelationAwareMessagePostProcessor;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.MessagePostProcessor;
@@ -792,7 +793,10 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	public void convertAndSend(String exchange, String routingKey, final Object message,
 			final MessagePostProcessor messagePostProcessor, CorrelationData correlationData) throws AmqpException {
 		Message messageToSend = convertMessageIfNecessary(message);
-		messageToSend = messagePostProcessor.postProcessMessage(messageToSend);
+		messageToSend = messagePostProcessor instanceof CorrelationAwareMessagePostProcessor
+				? ((CorrelationAwareMessagePostProcessor) messagePostProcessor)
+						.postProcessMessage(messageToSend, correlationData)
+				: messagePostProcessor.postProcessMessage(messageToSend);
 		send(exchange, routingKey, messageToSend, correlationData);
 	}
 
@@ -1193,7 +1197,10 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			final MessagePostProcessor messagePostProcessor, final CorrelationData correlationData) {
 		Message requestMessage = convertMessageIfNecessary(message);
 		if (messagePostProcessor != null) {
-			requestMessage = messagePostProcessor.postProcessMessage(requestMessage);
+			requestMessage = messagePostProcessor instanceof CorrelationAwareMessagePostProcessor
+					? ((CorrelationAwareMessagePostProcessor) messagePostProcessor)
+							.postProcessMessage(requestMessage, correlationData)
+					: messagePostProcessor.postProcessMessage(requestMessage);
 		}
 		Message replyMessage = doSendAndReceive(exchange, routingKey, requestMessage, correlationData);
 		return replyMessage;
@@ -1495,7 +1502,10 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 		}
 		if (this.beforePublishPostProcessors != null) {
 			for (MessagePostProcessor processor : this.beforePublishPostProcessors) {
-				messageToUse = processor.postProcessMessage(messageToUse);
+				messageToUse = processor instanceof CorrelationAwareMessagePostProcessor
+						? ((CorrelationAwareMessagePostProcessor) processor)
+								.postProcessMessage(messageToUse, correlationData)
+						: processor.postProcessMessage(messageToUse);
 			}
 		}
 		if (this.userIdExpression != null && messageProperties.getUserId() == null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/CorrelationData.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/CorrelationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.amqp.rabbit.support;
 
+import org.springframework.amqp.support.Correlation;
+
 /**
  * Base class for correlating publisher confirms to sent messages.
  * Use the {@link org.springframework.amqp.rabbit.core.RabbitTemplate}
@@ -26,10 +28,22 @@ package org.springframework.amqp.rabbit.support;
  * @since 1.0.1
  *
  */
-public class CorrelationData {
+public class CorrelationData implements Correlation {
 
 	private volatile String id;
 
+	/**
+	 * Construct an instance with a null Id.
+	 * @since 1.6.7
+	 */
+	public CorrelationData() {
+		super();
+	}
+
+	/**
+	 * Construct an instance with the supplied id.
+	 * @param id the id.
+	 */
 	public CorrelationData(String id) {
 		this.id = id;
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Rule;
@@ -86,8 +87,13 @@ public class AsyncRabbitTemplateTests {
 
 	@Test
 	public void testConvert1Arg() throws Exception {
-		ListenableFuture<String> future = this.template.convertSendAndReceive("foo");
+		final AtomicBoolean mppCalled = new AtomicBoolean();
+		ListenableFuture<String> future = this.template.convertSendAndReceive("foo", m -> {
+			mppCalled.set(true);
+			return m;
+		});
 		checkConverterResult(future, "FOO");
+		assertTrue(mppCalled.get());
 	}
 
 	@Test

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1006,6 +1006,13 @@ With the `RabbitTemplate` implementation of `AmqpTemplate`, each of the `send()`
 When publisher confirms are enabled, this object is returned in the callback described in <<amqp-template>>.
 This allows the sender to correlate a confirm (ack or nack) with the sent message.
 
+Starting with version 1.6.7, the `CorrelationAwareMessagePostProcessor` interface was introduced, allowing the correlation data to be modified after the message has been converted:
+
+[source, java]
+----
+Message postProcessMessage(Message message, Correlation correlation);
+----
+
 ===== Publisher Returns
 
 When the template's `mandatory` property is 'true' returned messages are provided by the callback described in <<amqp-template>>.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-697

Add support for modifying publisher confirms `CorrelationData` during message post processing.

Change `AsyncRabbitTemplate` to use a stateless MPP, move all state to the `CorrelationData`.

Conflicts:
	spring-amqp/src/main/java/org/springframework/amqp/core/MessagePostProcessor.java
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
Resolved.

__cherry-pick to 1.6.x__