### PR TITLE
AMQP-699: Suppress Stack Trace in RabbitAdmin

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -589,10 +589,19 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 			this.applicationEventPublisher.publishEvent(event);
 		}
 		if (this.ignoreDeclarationExceptions || (element != null && element.isIgnoreDeclarationExceptions())) {
-			if (this.logger.isWarnEnabled()) {
-				this.logger.warn("Failed to declare " + elementType
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("Failed to declare " + elementType
 						+ (element == null ? "broker-generated" : ": " + element)
 						+ ", continuing...", t);
+			}
+			else if (this.logger.isWarnEnabled()) {
+				Throwable cause = t;
+				if (t instanceof IOException && t.getCause() != null) {
+					cause = t.getCause();
+				}
+				this.logger.warn("Failed to declare " + elementType
+						+ (element == null ? "broker-generated" : ": " + element)
+						+ ", continuing... " + cause);
 			}
 		}
 		else {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-699

When `ignoreDeclarationExceptions` is true, only log exception stack traces under DEBUG logging.
Just log the exception and its message under WARN.

For `IOException`, extract the cause to get a useful message in the WARN log.

__cherry-pick to 1.7.x, 1.6.x__