### PR TITLE
AMQP-701: @RabbitListener BPP Performance

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,6 +77,8 @@ import org.springframework.messaging.handler.annotation.support.MessageHandlerMe
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -139,6 +142,16 @@ public class RabbitListenerAnnotationBeanPostProcessor
 	private final RabbitListenerEndpointRegistrar registrar = new RabbitListenerEndpointRegistrar();
 
 	private final AtomicInteger counter = new AtomicInteger();
+
+	private final MultiValueMap<Class<?>, Method> methodCache = new LinkedMultiValueMap<Class<?>, Method>();
+
+	private final MultiValueMap<Method, RabbitListener> annotationCache =
+			new LinkedMultiValueMap<Method, RabbitListener>();
+
+	private final MultiValueMap<Class<?>, RabbitListener> classAnnotationCache =
+			new LinkedMultiValueMap<Class<?>, RabbitListener>();
+
+	private final Map<Class<?>, List<Method>> multiMethodCache = new LinkedHashMap<Class<?>, List<Method>>();
 
 	private BeanExpressionResolver resolver = new StandardBeanExpressionResolver();
 
@@ -249,6 +262,12 @@ public class RabbitListenerAnnotationBeanPostProcessor
 
 		// Actually register all listeners
 		this.registrar.afterPropertiesSet();
+
+		// clear the cache - prototype beans will be re-cached.
+		this.classAnnotationCache.clear();
+		this.annotationCache.clear();
+		this.methodCache.clear();
+		this.multiMethodCache.clear();
 	}
 
 
@@ -260,15 +279,40 @@ public class RabbitListenerAnnotationBeanPostProcessor
 	@Override
 	public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
 		Class<?> targetClass = AopUtils.getTargetClass(bean);
+		if (methodCache.get(targetClass) == null) {
+			findMethods(targetClass);
+		}
+		List<RabbitListener> classLevelListeners = this.classAnnotationCache.get(targetClass);
+		List<Method> methods = this.methodCache.get(targetClass);
+		List<Method> multiMethods = this.multiMethodCache.get(targetClass);
+		for (Method method : methods) {
+			List<RabbitListener> listenerAnnotations = this.annotationCache.get(method);
+			if (listenerAnnotations != null) {
+				for (RabbitListener rabbitListener : listenerAnnotations) {
+					processAmqpListener(rabbitListener, method, bean, beanName);
+				}
+			}
+		}
+		if (multiMethods.size() > 0) {
+			processMultiMethodListeners(classLevelListeners, multiMethods, bean, beanName);
+		}
+		return bean;
+	}
+
+	private void findMethods(Class<?> targetClass) {
 		Collection<RabbitListener> classLevelListeners = findListenerAnnotations(targetClass);
 		final boolean hasClassLevelListeners = classLevelListeners.size() > 0;
+		final MultiValueMap<Method, RabbitListener> annotations = new LinkedMultiValueMap<Method, RabbitListener>();
+		final List<Method> methods = new ArrayList<Method>();
 		final List<Method> multiMethods = new ArrayList<Method>();
 		ReflectionUtils.doWithMethods(targetClass, new ReflectionUtils.MethodCallback() {
 
 			@Override
 			public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
-				for (RabbitListener rabbitListener : findListenerAnnotations(method)) {
-					processAmqpListener(rabbitListener, method, bean, beanName);
+				Collection<RabbitListener> listenerAnnotations = findListenerAnnotations(method);
+				if (listenerAnnotations.size() > 0) {
+					methods.add(method);
+					annotations.put(method, new ArrayList<RabbitListener>(listenerAnnotations));
 				}
 				if (hasClassLevelListeners) {
 					RabbitHandler rabbitHandler = AnnotationUtils.findAnnotation(method, RabbitHandler.class);
@@ -277,11 +321,14 @@ public class RabbitListenerAnnotationBeanPostProcessor
 					}
 				}
 			}
+
 		}, ReflectionUtils.USER_DECLARED_METHODS);
-		if (hasClassLevelListeners) {
-			processMultiMethodListeners(classLevelListeners, multiMethods, bean, beanName);
+		this.methodCache.put(targetClass, methods);
+		for (Method method : methods) {
+			this.annotationCache.put(method, annotations.get(method));
 		}
-		return bean;
+		this.classAnnotationCache.put(targetClass, new ArrayList<RabbitListener>(classLevelListeners));
+		this.multiMethodCache.put(targetClass, multiMethods);
 	}
 
 	/*


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-701

`RabbitListenerAnnotationBeanPostProcessor` introspects the class each
time a bean of that type is instantiated.

When complex beans with many methods are scoped as prototype, the process
can be inordinately expensive.

Cache the results of the introspection.

Since we have no need for the cache of non-prototype beans after context
initialization, clear the cache.

The cache will be initialized for the prototype bean on first access.

__cherry-pick to 1.7.x and master__

It might need some rework on master; let me know if its non-trivial and I'll issue a separate PR.