### PR TITLE
AMQP-617: Don't alias Queue and Exchange name attr

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/QueueParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/QueueParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,21 +32,40 @@ import org.springframework.util.xml.DomUtils;
  * @author Dave Syer
  * @author Gary Russell
  * @author Felipe Gutierrez
+ * @author Artem Bilan
  *
  */
 public class QueueParser extends AbstractSingleBeanDefinitionParser {
 
+	private static final ThreadLocal<Element> CURRENT_ELEMENT = new ThreadLocal<>();
+
 	/**  Element OR attribute */
 	private static final String ARGUMENTS = "queue-arguments";
+
 	private static final String DURABLE_ATTRIBUTE = "durable";
+
 	private static final String EXCLUSIVE_ATTRIBUTE = "exclusive";
+
 	private static final String AUTO_DELETE_ATTRIBUTE = "auto-delete";
+
 	private static final String REF_ATTRIBUTE = "ref";
+
 	private static final String NAMING_STRATEGY = "naming-strategy";
 
 	@Override
 	protected boolean shouldGenerateIdAsFallback() {
 		return true;
+	}
+
+	@Override
+	protected boolean shouldParseNameAsAliases() {
+		Element element = CURRENT_ELEMENT.get();
+		try {
+			return element == null || !element.hasAttribute(ID_ATTRIBUTE);
+		}
+		finally {
+			CURRENT_ELEMENT.remove();
+		}
 	}
 
 	@Override
@@ -124,6 +143,7 @@ public class QueueParser extends AbstractSingleBeanDefinitionParser {
 		}
 
 		NamespaceUtils.parseDeclarationControls(element, builder);
+		CURRENT_ELEMENT.set(element);
 	}
 
 	private boolean attributeHasIllegalOverride(Element element, String name, String allowed) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitNamespaceHandlerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitNamespaceHandlerTests.java
@@ -66,9 +66,8 @@ public final class RabbitNamespaceHandlerTests {
 
 	@Test
 	public void testAliasQueue() throws Exception {
-		Queue queue = beanFactory.getBean("spam", Queue.class);
+		Queue queue = beanFactory.getBean("bar", Queue.class);
 		assertNotNull(queue);
-		assertNotSame("spam", queue.getName());
 		assertEquals("bar", queue.getName());
 	}
 
@@ -92,7 +91,7 @@ public final class RabbitNamespaceHandlerTests {
 	public void testBindings() throws Exception {
 		Map<String, Binding> bindings = beanFactory.getBeansOfType(Binding.class);
 		// 4 for each exchange type
-		assertEquals(17, bindings.size());
+		assertEquals(13, bindings.size());
 		for (Map.Entry<String, Binding> bindingEntry : bindings.entrySet()) {
 			Binding binding = bindingEntry.getValue();
 			if ("headers-test".equals(binding.getExchange()) && "bucket".equals(binding.getDestination())) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/TemplateParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ public final class TemplateParserTests {
 		assertNull(dfa.getPropertyValue("correlationKey"));
 		String replyQueue = (String) dfa.getPropertyValue("replyAddress");
 		assertNotNull(replyQueue);
-		Queue queueBean = beanFactory.getBean("reply.queue", Queue.class);
+		Queue queueBean = beanFactory.getBean("replyQId", Queue.class);
 		assertEquals(queueBean.getName(), replyQueue);
 		SimpleMessageListenerContainer container =
 				beanFactory.getBean("withReplyQ.replyListener", SimpleMessageListenerContainer.class);

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/RabbitNamespaceHandlerTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/RabbitNamespaceHandlerTests-context.xml
@@ -10,7 +10,6 @@
 		<bindings>
 			<binding queue="foo" key="foo" />
 			<binding queue="bar" />
-			<binding queue="spam" />
 			<binding queue="bucket" />
 		</bindings>
 	</direct-exchange>
@@ -20,7 +19,6 @@
 		<bindings>
 			<binding queue="foo" pattern="foo.#" />
 			<binding queue="bar" pattern="bar.#" />
-			<binding queue="spam" pattern="spam.#"/>
 			<binding queue="bucket" pattern="bucket.#"/>
 			<binding exchange="direct-test" pattern="qux" />
 		</bindings>
@@ -31,7 +29,6 @@
 		<bindings>
 			<binding queue="foo" />
 			<binding queue="bar" />
-			<binding queue="spam" />
 			<binding queue="bucket" />
 		</bindings>
 	</fanout-exchange>
@@ -40,7 +37,6 @@
 		<rabbit:bindings>
 			<rabbit:binding queue="foo" key="type" value="foo" />
 			<rabbit:binding queue="bar" key="type" value="bar" />
-			<rabbit:binding queue="spam" key="type" value="spam" />
 			<rabbit:binding queue="bucket">
 				<rabbit:binding-arguments>
 					<entry key="type" value="bucket"/>
@@ -53,7 +49,7 @@
 
 	<rabbit:queue name="foo" />
 
-	<rabbit:queue id="spam" name="bar" />
+	<rabbit:queue name="bar" />
 
 	<rabbit:queue id="bucket" />
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -88,6 +88,10 @@ See <<json-message-converter>> for more information.
 When the `__TypeId__` is set to `Hashtable` for an inbound JSON message, the default conversion type is now `LinkedHashMap`; previously it was `Hashtable`.
 To revert to a `Hashtable` use `setDefaultMapType` on the `DefaultClassMapper`.
 
+===== XML Parsers
+
+The `Queue` and `Exchange` XML components parses now don't register the `name` attribute value as a bean alias if an `id` attribute is present.
+
 ==== Earlier Releases
 
 See <<previous-whats-new>> for changes in previous versions.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-617

If `id` attribute is present don't register a bean alias for the `name` attribute