### PR TITLE
AMQP-708: Fix Leaked AutoRecovered Channel

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -1072,9 +1072,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 				catch (Exception e2) { }
 				finally {
 					try {
-						if (channel.isOpen()) {
-							channel.close();
-						}
+						channel.close();
 					}
 					catch (IOException e3) { }
 					catch (AlreadyClosedException e4) { }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
 import org.springframework.util.Assert;
 
 import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Method;
 import com.rabbitmq.client.ShutdownSignalException;
@@ -56,6 +57,9 @@ public abstract class RabbitUtils {
 			try {
 				connection.close();
 			}
+			catch (AlreadyClosedException ace) {
+				// empty
+			}
 			catch (Exception ex) {
 				logger.debug("Ignoring Connection exception - assuming already closed: " + ex.getMessage(), ex);
 			}
@@ -71,6 +75,9 @@ public abstract class RabbitUtils {
 		if (channel != null) {
 			try {
 				channel.close();
+			}
+			catch (AlreadyClosedException ace) {
+				// empty
 			}
 			catch (IOException ex) {
 				logger.debug("Could not close RabbitMQ Channel", ex);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -119,8 +119,8 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		assertSame(channel, channel2);
 		verify(mockConnection, never()).close();
 		verify(mockChannel, never()).close();
-
 	}
+
 	@Test
 	public void testWithConnectionFactoryCacheSize() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
@@ -1354,6 +1354,52 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		assertEquals(3, allocatedConnections.size());
 		assertEquals(3, idleConnections.size());
 		assertEquals("0", ccf.getCacheProperties().get("openConnections"));
+	}
+
+	@Test
+	public void testConsumerChannelPhysicallyClosedWhenNotIsOpen() throws Exception {
+		testConsumerChannelPhysicallyClosedWhenNotIsOpenGuts(false);
+	}
+
+	@Test
+	public void testConsumerChannelWithPubConfPhysicallyClosedWhenNotIsOpen() throws Exception {
+		testConsumerChannelPhysicallyClosedWhenNotIsOpenGuts(true);
+	}
+
+	public void testConsumerChannelPhysicallyClosedWhenNotIsOpenGuts(boolean confirms) throws Exception {
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
+			com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
+			Channel mockChannel = mock(Channel.class);
+
+			when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
+			when(mockConnection.createChannel()).thenReturn(mockChannel);
+			when(mockChannel.isOpen()).thenReturn(true);
+			when(mockConnection.isOpen()).thenReturn(true);
+
+			CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+			ccf.setExecutor(executor);
+			ccf.setPublisherConfirms(confirms);
+			Connection con = ccf.createConnection();
+
+			Channel channel = con.createChannel(false);
+			RabbitUtils.setPhysicalCloseRequired(true);
+			when(mockChannel.isOpen()).thenReturn(false);
+			final CountDownLatch physicalCloseLatch = new CountDownLatch(1);
+			doAnswer(i -> {
+				physicalCloseLatch.countDown();
+				return null;
+			}).when(mockChannel).close();
+			channel.close();
+			con.close(); // should be ignored
+
+			assertTrue(physicalCloseLatch.await(10, TimeUnit.SECONDS));
+		}
+		finally {
+			RabbitUtils.setPhysicalCloseRequired(false);
+			executor.shutdownNow();
+		}
 	}
 
 	private void verifyConnectionIs(com.rabbitmq.client.Connection mockConnection, Object con) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-708

When publisher confirms or returns are enabled, and a container is stopped
while the broker is down, an auto-recover channel is leaked. It is later
recovered by the client library but has no code actually consuming from it.

While the channel is flagged to physically close it (to prevent the client
from recovering it), that close is avoided because `isOpen()` returns false
until the connection/channel is recovered.

Unconditionaly close the channel if physical closure is required.

Add a test with mocks; also tested with the SI sample and a real broker.
Before the patch, observe the leaked consumer on the admin console.
After the patch, the consumer is no longer retained after recovery.

Also, ignore `AlreadyClosedException` s in `RabbitUtils`.

__cherry-pick to 1.7.x, 1.6.x__