### PR TITLE
AMQP-709: Disable Auto Recovery By Default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ subprojects { subproject ->
 		log4jVersion = '2.7'
 		logbackVersion = '1.1.2'
 		mockitoVersion = '2.5.4'
-		rabbitmqVersion = project.hasProperty('rabbitmqVersion') ? project.rabbitmqVersion : '4.0.0'
+		rabbitmqVersion = project.hasProperty('rabbitmqVersion') ? project.rabbitmqVersion : '4.0.2'
 		rabbitmqHttpClientVersion = '1.1.1.RELEASE'
 
 		springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.0.0.BUILD-SNAPSHOT'

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -188,7 +188,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	 * @param port the port number
 	 */
 	public CachingConnectionFactory(String hostname, int port) {
-		super(new com.rabbitmq.client.ConnectionFactory());
+		super(newRabbitConnectionFactory());
 		if (!StringUtils.hasText(hostname)) {
 			hostname = getDefaultHostName();
 		}
@@ -202,7 +202,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	 * @since 1.5
 	 */
 	public CachingConnectionFactory(URI uri) {
-		super(new com.rabbitmq.client.ConnectionFactory());
+		super(newRabbitConnectionFactory());
 		setUri(uri);
 	}
 
@@ -229,6 +229,18 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	 */
 	public CachingConnectionFactory(com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory) {
 		super(rabbitConnectionFactory);
+		if (rabbitConnectionFactory.isAutomaticRecoveryEnabled()) {
+			logger.warn("***\nAutomatic Recovery is Enabled in the provided connection factory;\n"
+					+ "while Spring AMQP is compatible with this feature, it\n"
+					+ "prefers to use its own recovery mechanisms; when this option is true, you may receive\n"
+					+ "'AutoRecoverConnectionNotCurrentlyOpenException's until the connection is recovered.");
+		}
+	}
+
+	private static com.rabbitmq.client.ConnectionFactory newRabbitConnectionFactory() {
+		com.rabbitmq.client.ConnectionFactory connectionFactory = new com.rabbitmq.client.ConnectionFactory();
+		connectionFactory.setAutomaticRecoveryEnabled(false);
+		return connectionFactory;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -125,6 +125,9 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	private boolean skipServerCertificateValidation;
 
+	public RabbitConnectionFactoryBean() {
+		this.connectionFactory.setAutomaticRecoveryEnabled(false);
+	}
 
 	/**
 	 * Whether or not Server Side certificate has to be validated or not.
@@ -563,6 +566,27 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	 */
 	public void setMetricsCollector(MetricsCollector metricsCollector) {
 		this.connectionFactory.setMetricsCollector(metricsCollector);
+	}
+
+	/**
+	 * Set to true to enable amqp-client automatic recovery. Note: Spring AMQP
+	 * implements its own connection recovery and this is generally not needed.
+	 * @param automaticRecoveryEnabled true to enable.
+	 * @since 1.7.1
+	 */
+	public void setAutomaticRecoveryEnabled(boolean automaticRecoveryEnabled) {
+		this.connectionFactory.setAutomaticRecoveryEnabled(automaticRecoveryEnabled);
+	}
+
+	/**
+	 * Set to true to enable amqp-client topology recovery. Note: if there is a
+	 * Rabbit admin in the application context, Spring AMQP
+	 * implements its own recovery and this is generally not needed.
+	 * @param topologyRecoveryEnabled true to enable.
+	 * @since 1.7.1
+	 */
+	public void setTopologyRecoveryEnabled(boolean topologyRecoveryEnabled) {
+		this.connectionFactory.setTopologyRecoveryEnabled(topologyRecoveryEnabled);
 	}
 
 	@Override

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
@@ -372,6 +372,7 @@ public class CachingConnectionFactoryIntegrationTests {
 
 	@Test
 	public void testHardErrorAndReconnectAuto() throws Exception {
+		this.connectionFactory.getRabbitConnectionFactory().setAutomaticRecoveryEnabled(true);
 		Log cfLogger = spyOnLogger(this.connectionFactory);
 		willReturn(true).given(cfLogger).isDebugEnabled();
 		RabbitTemplate template = new RabbitTemplate(connectionFactory);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -1424,6 +1425,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.setHost("abc");
 		ccf.setAddresses("");
 		ccf.createConnection();
+		verify(mock).isAutomaticRecoveryEnabled();
 		verify(mock).setHost("abc");
 		verify(mock).newConnection(any(ExecutorService.class), anyString());
 		verifyNoMoreInteractions(mock);
@@ -1435,6 +1437,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
 		ccf.setAddresses("mq1");
 		ccf.createConnection();
+		verify(mock).isAutomaticRecoveryEnabled();
 		verify(mock)
 				.newConnection(isNull(), aryEq(new Address[] { new Address("mq1") }), anyString());
 		verifyNoMoreInteractions(mock);
@@ -1443,9 +1446,11 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	@Test
 	public void setAddressesTwoHosts() throws Exception {
 		ConnectionFactory mock = mock(com.rabbitmq.client.ConnectionFactory.class);
+		doReturn(true).when(mock).isAutomaticRecoveryEnabled();
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mock);
 		ccf.setAddresses("mq1,mq2");
 		ccf.createConnection();
+		verify(mock).isAutomaticRecoveryEnabled();
 		verify(mock).newConnection(isNull(),
 				aryEq(new Address[] { new Address("mq1"), new Address("mq2") }), anyString());
 		verifyNoMoreInteractions(mock);
@@ -1463,6 +1468,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.createConnection();
 
 		InOrder order = inOrder(mock);
+		order.verify(mock).isAutomaticRecoveryEnabled();
 		order.verify(mock).setUri(uri);
 		order.verify(mock).newConnection(any(ExecutorService.class), anyString());
 		verifyNoMoreInteractions(mock);

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -366,6 +366,11 @@ For convenience, a factory bean is provided to assist in configuring the connect
       id="connectionFactory" connection-factory="rabbitConnectionFactory"/>
 ----
 
+NOTE: The 4.0.x client enables automatic recovery by default; while compatible with this feature, Spring AMQP has its own recovery mechanisms and the client recovery feature generally isn't needed.
+It is recommended to disable `amqp-client` automatic recovery, to avoid getting `AutoRecoverConnectionNotCurrentlyOpenException` s when the broker is available, but the connection has not yet recovered.
+Starting with _version 1.7.1_, Spring AMQP disables it unless you explicitly create your own RabbitMQ connection factory and provide it to the `CachingConnectionFactory`.
+RabbitMQ `ConnectionFactory` instances created by the `RabbitConnectionFactoryBean` will also have the option disabled by default.
+
 ===== RabbitConnectionFactoryBean and Configuring SSL
 
 Starting with _version 1.4_, a convenient `RabbitConnectionFactoryBean` is provided to enable convenient configuration of SSL properties on the underlying client connection factory, using dependency injection.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -8,6 +8,11 @@
 Spring AMQP now uses the new 4.0.x version of the `amqp-client` library provided by the RabbitMQ team.
 This client has auto recovery configured by default; see <<auto-recovery>>.
 
+NOTE: The 4.0.x client enables automatic recovery by default; while compatible with this feature, Spring AMQP has its own recovery mechanisms and the client recovery feature generally isn't needed.
+It is recommended to disable `amqp-client` automatic recovery, to avoid getting `AutoRecoverConnectionNotCurrentlyOpenException` s when the broker is available, but the connection has not yet recovered.
+Starting with _version 1.7.1_, Spring AMQP disables it unless you explicitly create your own RabbitMQ connection factory and provide it to the `CachingConnectionFactory`.
+RabbitMQ `ConnectionFactory` instances created by the `RabbitConnectionFactoryBean` will also have the option disabled by default.
+
 ===== New Listener Container
 
 The `DirectMessageListenerContainer` has been added alongside the existing `SimpleMessageListenerContainer`.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-709

Avoid `AutoRecoverConnectionNotCurrentlyOpenException` when the broker is available, but
the connection is not yet recovered.

__cherry-pick to 1.7.x__