### PR TITLE
AMQP-711: Make Transaction Rollback Consistent

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,11 +167,11 @@ public final class ConnectionFactoryUtils {
 		RabbitUtils.closeConnection(resourceHolder.getConnection());
 	}
 
-	public static void bindResourceToTransaction(RabbitResourceHolder resourceHolder,
+	public static RabbitResourceHolder bindResourceToTransaction(RabbitResourceHolder resourceHolder,
 			ConnectionFactory connectionFactory, boolean synched) {
 		if (TransactionSynchronizationManager.hasResource(connectionFactory)
 				|| !TransactionSynchronizationManager.isActualTransactionActive() || !synched) {
-			return;
+			return (RabbitResourceHolder) TransactionSynchronizationManager.getResource(connectionFactory);
 		}
 		TransactionSynchronizationManager.bindResource(connectionFactory, resourceHolder);
 		resourceHolder.setSynchronizedWithTransaction(true);
@@ -179,6 +179,7 @@ public final class ConnectionFactoryUtils {
 			TransactionSynchronizationManager.registerSynchronization(new RabbitResourceSynchronization(resourceHolder,
 					connectionFactory));
 		}
+		return resourceHolder;
 	}
 
 	public static void registerDeliveryTag(ConnectionFactory connectionFactory, Channel channel, Long tag) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1542,6 +1542,20 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 		return false;
 	}
 
+	/**
+	 * A null resource holder is rare, but possible if the transaction attribute caused no
+	 * transaction to be started (e.g. {@code TransactionDefinition.PROPAGATION_NONE}). In
+	 * that case the delivery tags will have been processed manually.
+	 * @param resourceHolder the bound resource holder (if a transaction is active).
+	 * @param exception the exception.
+	 */
+	protected void prepareHolderForRollback(RabbitResourceHolder resourceHolder, RuntimeException exception) {
+		if (resourceHolder != null) {
+			resourceHolder.setRequeueOnRollback(isAlwaysRequeueWithTxManagerRollback() ||
+					RabbitUtils.shouldRequeue(isDefaultRequeueRejected(), exception, logger));
+		}
+	}
+
 	@FunctionalInterface
 	private interface ContainerDelegate {
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -195,6 +195,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	private ConditionalExceptionLogger exclusiveConsumerExceptionLogger = new DefaultExclusiveConsumerLogger();
 
+	private boolean alwaysRequeueWithTxManagerRollback;
 
 	/**
 	 * {@inheritDoc}
@@ -876,6 +877,28 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	protected ConditionalExceptionLogger getExclusiveConsumerExceptionLogger() {
 		return this.exclusiveConsumerExceptionLogger;
+	}
+
+	/**
+	 * Set to true to always requeue on transaction rollback with an external
+	 * {@link #setTransactionManager(PlatformTransactionManager) TransactionManager}.
+	 * With earlier releases, when a transaction manager was configured, a transaction
+	 * rollback always requeued the message. This was inconsistent with local transactions
+	 * where the normal {@link #setDefaultRequeueRejected(boolean) defaultRequeueRejected}
+	 * and {@link AmqpRejectAndDontRequeueException} logic was honored to determine whether
+	 * the message was requeued. RabbitMQ does not consider the message delivery to be part
+	 * of the transaction.
+	 * This boolean was introduced in 1.7.1, set to true by default, to be consistent with
+	 * previous behavior. Starting with version 2.0, it is false by default.
+	 * @param alwaysRequeueWithTxManagerRollback true to always requeue on rollback.
+	 * @since 1.7.1.
+	 */
+	public void setAlwaysRequeueWithTxManagerRollback(boolean alwaysRequeueWithTxManagerRollback) {
+		this.alwaysRequeueWithTxManagerRollback = alwaysRequeueWithTxManagerRollback;
+	}
+
+	protected boolean isAlwaysRequeueWithTxManagerRollback() {
+		return this.alwaysRequeueWithTxManagerRollback;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -53,6 +53,7 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.interceptor.TransactionAttribute;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -700,14 +701,15 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 					this.transactionTemplate.execute(s -> {
 						RabbitResourceHolder resourceHolder = ConnectionFactoryUtils.bindResourceToTransaction(
 								new RabbitResourceHolder(getChannel(), false), this.connectionFactory, true);
-						resourceHolder.addDeliveryTag(getChannel(), deliveryTag);
+						if (resourceHolder != null) {
+							resourceHolder.addDeliveryTag(getChannel(), deliveryTag);
+						}
 						// unbound in ResourceHolderSynchronization.beforeCompletion()
 						try {
 							callExecuteListener(message, deliveryTag);
 						}
 						catch (RuntimeException e1) {
-							resourceHolder.setRequeueOnRollback(isAlwaysRequeueWithTxManagerRollback() ||
-									RabbitUtils.shouldRequeue(isDefaultRequeueRejected(), e1, this.logger));
+							prepareHolderForRollback(resourceHolder, e1);
 							throw e1;
 						}
 						catch (Throwable e2) { //NOSONAR ok to catch Throwable here because we re-throw it below
@@ -762,6 +764,15 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 					this.logger.error("Failed to invoke listener", e);
 					if (this.transactionManager != null) {
 						if (this.transactionAttribute.rollbackOn(e)) {
+							RabbitResourceHolder resourceHolder = (RabbitResourceHolder) TransactionSynchronizationManager
+									.getResource(getConnectionFactory());
+							if (resourceHolder == null) {
+								/*
+								 * If we don't actually have a transaction, we have to roll back
+								 * manually. See prepareHolderForRollback().
+								 */
+								rollback(deliveryTag, e);
+							}
 							throw e; // encompassing transaction will handle the rollback.
 						}
 						else {
@@ -779,13 +790,19 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		}
 
 		private void handleAck(long deliveryTag, boolean channelLocallyTransacted) throws IOException {
+			/*
+			 * If we have a TX Manager, but no TX, act like we are locally transacted.
+			 */
+			boolean isLocallyTransacted = channelLocallyTransacted
+					|| (isChannelTransacted()
+							&& TransactionSynchronizationManager.getResource(this.connectionFactory) == null);
 			try {
 				if (this.ackRequired) {
-					if (!isChannelTransacted() || channelLocallyTransacted) {
+					if (!isChannelTransacted() || isLocallyTransacted) {
 						getChannel().basicAck(deliveryTag, false);
 					}
 				}
-				if (channelLocallyTransacted) {
+				if (isLocallyTransacted) {
 					RabbitUtils.commitIfNecessary(getChannel());
 				}
 			}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -707,6 +707,8 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 							callExecuteListener(message, deliveryTag);
 						}
 						catch (RuntimeException e1) {
+							resourceHolder.setRequeueOnRollback(isAlwaysRequeueWithTxManagerRollback() ||
+									RabbitUtils.shouldRequeue(isDefaultRequeueRejected(), e1, this.logger));
 							throw e1;
 						}
 						catch (Throwable e2) { //NOSONAR ok to catch Throwable here because we re-throw it below

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -698,10 +698,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 								new TransactionTemplate(this.transactionManager, this.transactionAttribute);
 					}
 					this.transactionTemplate.execute(s -> {
-						RabbitResourceHolder resourceHolder = new RabbitResourceHolder(getChannel(), false);
+						RabbitResourceHolder resourceHolder = ConnectionFactoryUtils.bindResourceToTransaction(
+								new RabbitResourceHolder(getChannel(), false), this.connectionFactory, true);
 						resourceHolder.addDeliveryTag(getChannel(), deliveryTag);
-						ConnectionFactoryUtils.bindResourceToTransaction(resourceHolder,
-								this.connectionFactory, true);
 						// unbound in ResourceHolderSynchronization.beforeCompletion()
 						try {
 							callExecuteListener(message, deliveryTag);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -727,10 +727,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				}
 				return this.transactionTemplate
 						.execute(status -> {
-							RabbitResourceHolder resourceHolder = new RabbitResourceHolder(consumer.getChannel(),
-									false);
-							ConnectionFactoryUtils.bindResourceToTransaction(
-									resourceHolder,
+							RabbitResourceHolder resourceHolder = ConnectionFactoryUtils.bindResourceToTransaction(
+									new RabbitResourceHolder(consumer.getChannel(), false),
 									getConnectionFactory(), true);
 							// unbound in ResourceHolderSynchronization.beforeCompletion()
 							try {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -51,6 +51,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.jmx.export.annotation.ManagedMetric;
 import org.springframework.jmx.support.MetricType;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -735,8 +736,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 								return doReceiveAndExecute(consumer);
 							}
 							catch (RuntimeException e1) {
-								resourceHolder.setRequeueOnRollback(isAlwaysRequeueWithTxManagerRollback() ||
-										RabbitUtils.shouldRequeue(isDefaultRequeueRejected(), e1, logger));
+								prepareHolderForRollback(resourceHolder, e1);
 								throw e1;
 							}
 							catch (Throwable e2) { //NOSONAR
@@ -785,7 +785,18 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				}
 				if (getTransactionManager() != null) {
 					if (getTransactionAttribute().rollbackOn(ex)) {
-						consumer.clearDeliveryTags();
+						RabbitResourceHolder resourceHolder = (RabbitResourceHolder) TransactionSynchronizationManager
+								.getResource(getConnectionFactory());
+						if (resourceHolder != null) {
+							consumer.clearDeliveryTags();
+						}
+						else {
+							/*
+							 * If we don't actually have a transaction, we have to roll back
+							 * manually. See prepareHolderForRollback().
+							 */
+							consumer.rollbackOnExceptionIfNecessary(ex);
+						}
 						throw ex; // encompassing transaction will handle the rollback.
 					}
 					else {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtilsTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtilsTests.java
@@ -38,6 +38,7 @@ public class ConnectionFactoryUtilsTests {
 		TransactionSynchronizationManager.setActualTransactionActive(true);
 		ConnectionFactoryUtils.bindResourceToTransaction(h1, connectionFactory, true);
 		assertSame(h1, ConnectionFactoryUtils.bindResourceToTransaction(h2, connectionFactory, true));
+		TransactionSynchronizationManager.clear();
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtilsTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtilsTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * @author Gary Russell
+ * @since 1.7.1
+ *
+ */
+public class ConnectionFactoryUtilsTests {
+
+	@Test
+	public void testResourceHolder() {
+		RabbitResourceHolder h1 = new RabbitResourceHolder();
+		RabbitResourceHolder h2 = new RabbitResourceHolder();
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		ConnectionFactoryUtils.bindResourceToTransaction(h1, connectionFactory, true);
+		assertSame(h1, ConnectionFactoryUtils.bindResourceToTransaction(h2, connectionFactory, true));
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -329,8 +329,8 @@ public abstract class ExternalTxManagerTests {
 		verify(mockConnection, times(1)).createChannel();
 		assertTrue(rejectLatch.await(10, TimeUnit.SECONDS));
 
+		assertTrue(rollbackLatch.await(10, TimeUnit.SECONDS));
 		if (propagation != TransactionDefinition.PROPAGATION_NEVER) {
-			assertTrue(rollbackLatch.await(10, TimeUnit.SECONDS));
 			verify(channel).basicReject(anyLong(), eq(expectRequeue));
 		}
 		else {
@@ -418,9 +418,7 @@ public abstract class ExternalTxManagerTests {
 		verify(mockConnection, times(1)).createChannel();
 
 		assertTrue(ackLatch.await(10, TimeUnit.SECONDS));
-		if (propagation != TransactionDefinition.PROPAGATION_NEVER) {
-			assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
-		}
+		assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
 		verify(channel).basicAck(anyLong(), anyBoolean());
 		container.stop();
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -56,6 +56,7 @@ import org.springframework.amqp.rabbit.transaction.RabbitTransactionManager;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 import org.springframework.transaction.interceptor.NoRollbackRuleAttribute;
 import org.springframework.transaction.interceptor.RollbackRuleAttribute;
 import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute;
@@ -232,18 +233,28 @@ public abstract class ExternalTxManagerTests {
 
 	@Test
 	public void testMessageListenerRollback() throws Exception {
-		testMessageListenerRollbackGuts(true);
+		testMessageListenerRollbackGuts(true, TransactionDefinition.PROPAGATION_REQUIRED);
 	}
 
 	@Test
 	public void testMessageListenerRollbackDontRequeue() throws Exception {
-		testMessageListenerRollbackGuts(false);
+		testMessageListenerRollbackGuts(false, TransactionDefinition.PROPAGATION_REQUIRED);
+	}
+
+	@Test
+	public void testMessageListenerRollbackNoBoundTransaction() throws Exception {
+		testMessageListenerRollbackGuts(true, TransactionDefinition.PROPAGATION_NEVER);
+	}
+
+	@Test
+	public void testMessageListenerRollbackDontRequeueNoBoundTransaction() throws Exception {
+		testMessageListenerRollbackGuts(false, TransactionDefinition.PROPAGATION_NEVER);
 	}
 
 	/**
 	 * Verifies that the channel is rolled back after an exception.
 	 */
-	private void testMessageListenerRollbackGuts(boolean expectRequeue) throws Exception {
+	private void testMessageListenerRollbackGuts(boolean expectRequeue, int propagation) throws Exception {
 		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
 		Connection mockConnection = mock(Connection.class);
 		final Channel channel = mock(Channel.class);
@@ -282,9 +293,15 @@ public abstract class ExternalTxManagerTests {
 			rejectLatch.countDown();
 			return null;
 		}).given(channel).basicReject(anyLong(), anyBoolean());
+		willAnswer(invocation -> {
+			rejectLatch.countDown();
+			return null;
+		}).given(channel).basicNack(anyLong(), anyBoolean(), anyBoolean());
+
 
 		final CountDownLatch latch = new CountDownLatch(1);
 		AbstractMessageListenerContainer container = createContainer(cachingConnectionFactory);
+		container.setTransactionAttribute(new DefaultTransactionAttribute(propagation));
 		container.setMessageListener(message -> {
 			latch.countDown();
 			throw expectRequeue
@@ -310,9 +327,101 @@ public abstract class ExternalTxManagerTests {
 		}
 
 		verify(mockConnection, times(1)).createChannel();
-		assertTrue(rollbackLatch.await(10, TimeUnit.SECONDS));
 		assertTrue(rejectLatch.await(10, TimeUnit.SECONDS));
-		verify(channel).basicReject(anyLong(), eq(expectRequeue));
+
+		if (propagation != TransactionDefinition.PROPAGATION_NEVER) {
+			assertTrue(rollbackLatch.await(10, TimeUnit.SECONDS));
+			verify(channel).basicReject(anyLong(), eq(expectRequeue));
+		}
+		else {
+			verify(channel).basicNack(anyLong(), eq(Boolean.TRUE), eq(expectRequeue));
+		}
+		container.stop();
+	}
+
+	@Test
+	public void testMessageListenerCommit() throws Exception {
+		testMessageListenerCommitGuts(TransactionDefinition.PROPAGATION_REQUIRED);
+	}
+
+	@Test
+	public void testMessageListenerCommitNoBoundTransaction() throws Exception {
+		testMessageListenerCommitGuts(TransactionDefinition.PROPAGATION_NEVER);
+	}
+
+	/**
+	 * Verifies that the channel is committed.
+	 */
+	private void testMessageListenerCommitGuts(int propagation) throws Exception {
+		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
+		Connection mockConnection = mock(Connection.class);
+		final Channel channel = mock(Channel.class);
+		given(channel.isOpen()).willReturn(true);
+
+		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
+		cachingConnectionFactory.setExecutor(mock(ExecutorService.class));
+
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
+
+		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
+		willAnswer(ensureOneChannelAnswer(channel, tooManyChannels)).given(mockConnection).createChannel();
+
+		willAnswer(invocation -> channel).given(mockConnection).createChannel();
+
+		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
+		final CountDownLatch consumerLatch = new CountDownLatch(1);
+
+		willAnswer(invocation -> {
+			consumer.set(invocation.getArgument(6));
+			consumerLatch.countDown();
+			return "consumerTag";
+		}).given(channel)
+				.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(),
+						any(Consumer.class));
+
+		final CountDownLatch commitLatch = new CountDownLatch(1);
+		willAnswer(invocation -> {
+			commitLatch.countDown();
+			return null;
+		}).given(channel).txCommit();
+		final CountDownLatch ackLatch = new CountDownLatch(1);
+		willAnswer(invocation -> {
+			ackLatch.countDown();
+			return null;
+		}).given(channel).basicAck(anyLong(), anyBoolean());
+
+		final CountDownLatch latch = new CountDownLatch(1);
+		AbstractMessageListenerContainer container = createContainer(cachingConnectionFactory);
+		container.setTransactionAttribute(new DefaultTransactionAttribute(propagation));
+		container.setMessageListener(message -> {
+			latch.countDown();
+		});
+		container.setQueueNames("queue");
+		container.setChannelTransacted(true);
+		container.setShutdownTimeout(100);
+		container.setTransactionManager(new DummyTxManager());
+		container.afterPropertiesSet();
+		container.start();
+		assertTrue(consumerLatch.await(10, TimeUnit.SECONDS));
+
+		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
+				new byte[] { 0 });
+
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+		Exception e = tooManyChannels.get();
+		if (e != null) {
+			throw e;
+		}
+
+		verify(mockConnection, times(1)).createChannel();
+
+		assertTrue(ackLatch.await(10, TimeUnit.SECONDS));
+		if (propagation != TransactionDefinition.PROPAGATION_NEVER) {
+			assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
+		}
+		verify(channel).basicAck(anyLong(), anyBoolean());
 		container.stop();
 	}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3870,6 +3870,7 @@ The default `FatalExceptionStrategy` logs a warning message when an exception is
 
 Since _version 1.6.3_ a convenient way to add user exceptions to the fatal list is to subclass `ConditionalRejectingErrorHandler.DefaultExceptionStrategy` and override the method `isUserCauseFatal(Throwable cause)` to return true for fatal exceptions.
 
+[[transactions]]
 ==== Transactions
 
 ===== Introduction
@@ -3961,6 +3962,7 @@ public AbstractMessageListenerContainer container() {
 }
 ----
 
+[[transaction-rollback]]
 ===== A note on Rollback of Received Messages
 
 AMQP transactions only apply to messages and acks sent to the broker, so when there is a rollback of a Spring transaction and a message has been received, what Spring AMQP has to do is not just rollback the transaction, but also manually reject the message (sort of a nack, but that's not what the specification calls it).
@@ -3970,6 +3972,15 @@ For more information about rejecting failed messages, see <<async-listeners>>.
 For more information about RabbitMQ transactions, and their limitations, refer to http://www.rabbitmq.com/semantics.html[RabbitMQ Broker Semantics].
 
 NOTE: Prior to *RabbitMQ 2.7.0*, such messages (and any that are unacked when a channel is closed or aborts) went to the back of the queue on a Rabbit broker, since 2.7.0, rejected messages go to the front of the queue, in a similar manner to JMS rolled back messages.
+
+[NOTE]
+====
+Previously, message requeue on transaction rollback was inconsistent between local transactions and when a `TransactionManager` was provided.
+In the former case, the normal requeue logic (`AmqpRejectAndDontRequeueException` or `defaultRequeueRejected=false`) applied (see <<async-listeners>>); with a transaction manager, the message was unconditionally requeued on rollback.
+Starting with __version 2.0__, the behavior is consistent and the normal requeue logic is applied in both cases.
+To revert to the previous behavior, set the container's `alwaysRequeueWithTxManagerRollback` property to `true`.
+See <<containerAttributes>>.
+====
 
 ===== Using the RabbitTransactionManager
 
@@ -4453,6 +4464,15 @@ MessageId
 | When using a stateful retry advice; if a message with a missing `messageId` property is received, it is considered
 fatal for the consumer (it is stopped) by default.
 Set this to false, to discard (or route to a dead-letter queue) such messages.
+
+a| image::images/tickmark.png[]
+a| image::images/tickmark.png[]
+
+| alwaysRequeueWithTx
+ManagerRollback
+(N/A)
+
+| Set to `true` to always requeue messages on rollback when a transaction manager is configured.
 
 a| image::images/tickmark.png[]
 a| image::images/tickmark.png[]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -48,8 +48,15 @@ See <<message-listener-adapter>> for more information.
 
 ===== Listener Container Changes
 
+====== Message Count
+
 Previously, `MessageProperties.getMessageCount()` returned `0` for messages emitted by the container.
 This property only applies when using `basicGet` (e.g. from `RabbitTemplate.receive()` methods) and is now initialized to `null` for container messages.
+
+====== Transaction Rollback behavior
+
+Message requeue on transaction rollback is now consistent, regardless of whether or not a transaction manager is configured.
+See <<transaction-rollback>> for more information.
 
 ===== Connection Factory Changes
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-711

Previously, messsages were unconditionally requeued when an external
transaction manager is used; this was not consistent with local
transactions, where the normal requeue logic was honored.

__backport to 1.7.x will require rework due to the container changes - I will issue another PR after this is reviewed/merged__