### PR TITLE
AMQP-711: Make Transaction Rollback Consistent [1.7.x Backport]

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,11 +167,11 @@ public final class ConnectionFactoryUtils {
 		RabbitUtils.closeConnection(resourceHolder.getConnection());
 	}
 
-	public static void bindResourceToTransaction(RabbitResourceHolder resourceHolder,
+	public static RabbitResourceHolder bindResourceToTransaction(RabbitResourceHolder resourceHolder,
 			ConnectionFactory connectionFactory, boolean synched) {
 		if (TransactionSynchronizationManager.hasResource(connectionFactory)
 				|| !TransactionSynchronizationManager.isActualTransactionActive() || !synched) {
-			return;
+			return (RabbitResourceHolder) TransactionSynchronizationManager.getResource(connectionFactory);
 		}
 		TransactionSynchronizationManager.bindResource(connectionFactory, resourceHolder);
 		resourceHolder.setSynchronizedWithTransaction(true);
@@ -179,6 +179,7 @@ public final class ConnectionFactoryUtils {
 			TransactionSynchronizationManager.registerSynchronization(new RabbitResourceSynchronization(resourceHolder,
 					connectionFactory));
 		}
+		return resourceHolder;
 	}
 
 	public static void registerDeliveryTag(ConnectionFactory connectionFactory, Channel channel, Long tag) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -23,6 +23,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.AmqpIOException;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.rabbit.listener.MessageRejectedWhileStoppingException;
 import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
 import org.springframework.util.Assert;
 
@@ -293,6 +295,32 @@ public abstract class RabbitUtils {
 					&& ((AMQP.Connection.Close) shutdownReason).getClassId() == 40 // exchange
 					&& ((AMQP.Connection.Close) shutdownReason).getMethodId() == 10; // declare
 		}
+	}
+
+	/**
+	 * Determine whether a message should be requeued; returns true if the throwable is a
+	 * {@link MessageRejectedWhileStoppingException} or defaultRequeueRejected is true and
+	 * there is not an {@link AmqpRejectAndDontRequeueException} in the cause chain.
+	 * @param defaultRequeueRejected the default requeue rejected.
+	 * @param throwable the throwable.
+	 * @param logger the logger to use for debug.
+	 * @return true to requeue.
+	 * @since 1.7.1
+	 */
+	public static boolean shouldRequeue(boolean defaultRequeueRejected, Throwable throwable, Log logger) {
+		boolean shouldRequeue = defaultRequeueRejected ||
+				throwable instanceof MessageRejectedWhileStoppingException;
+		Throwable t = throwable;
+		while (shouldRequeue && t != null) {
+			if (t instanceof AmqpRejectAndDontRequeueException) {
+				shouldRequeue = false;
+			}
+			t = t.getCause();
+		}
+		if (logger.isDebugEnabled()) {
+			logger.debug("Rejecting messages (requeue=" + shouldRequeue + ")");
+		}
+		return shouldRequeue;
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtilsTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtilsTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * @author Gary Russell
+ * @since 1.7.1
+ *
+ */
+public class ConnectionFactoryUtilsTests {
+
+	@Test
+	public void testResourceHolder() {
+		RabbitResourceHolder h1 = new RabbitResourceHolder();
+		RabbitResourceHolder h2 = new RabbitResourceHolder();
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		TransactionSynchronizationManager.initSynchronization();
+		ConnectionFactoryUtils.bindResourceToTransaction(h1, connectionFactory, true);
+		assertSame(h1, ConnectionFactoryUtils.bindResourceToTransaction(h2, connectionFactory, true));
+		TransactionSynchronizationManager.clear();
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -26,6 +26,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
@@ -55,6 +57,7 @@ import org.springframework.amqp.rabbit.transaction.RabbitTransactionManager;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 import org.springframework.transaction.interceptor.NoRollbackRuleAttribute;
 import org.springframework.transaction.interceptor.RollbackRuleAttribute;
 import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute;
@@ -94,20 +97,7 @@ public class ExternalTxManagerTests {
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		willAnswer(new Answer<Channel>() {
-			boolean done;
-			@Override
-			public Channel answer(InvocationOnMock invocation) throws Throwable {
-				if (!done) {
-					done = true;
-					return onlyChannel;
-				}
-				tooManyChannels.set(new Exception("More than one channel requested"));
-				Channel channel = mock(Channel.class);
-				given(channel.isOpen()).willReturn(true);
-				return channel;
-			}
-		}).given(mockConnection).createChannel();
+		willAnswer(ensureOneChannelAnswer(onlyChannel, tooManyChannels)).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 		final CountDownLatch consumerLatch = new CountDownLatch(1);
@@ -242,6 +232,201 @@ public class ExternalTxManagerTests {
 		container.stop();
 	}
 
+	@Test
+	public void testMessageListenerRollback() throws Exception {
+		testMessageListenerRollbackGuts(true, TransactionDefinition.PROPAGATION_REQUIRED);
+	}
+
+	@Test
+	public void testMessageListenerRollbackDontRequeue() throws Exception {
+		testMessageListenerRollbackGuts(false, TransactionDefinition.PROPAGATION_REQUIRED);
+	}
+
+	@Test
+	public void testMessageListenerRollbackNoBoundTransaction() throws Exception {
+		testMessageListenerRollbackGuts(true, TransactionDefinition.PROPAGATION_NEVER);
+	}
+
+	@Test
+	public void testMessageListenerRollbackDontRequeueNoBoundTransaction() throws Exception {
+		testMessageListenerRollbackGuts(false, TransactionDefinition.PROPAGATION_NEVER);
+	}
+
+	/**
+	 * Verifies that the channel is rolled back after an exception.
+	 */
+	@SuppressWarnings("unchecked")
+	private void testMessageListenerRollbackGuts(boolean expectRequeue, int propagation) throws Exception {
+		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
+		Connection mockConnection = mock(Connection.class);
+		final Channel channel = mock(Channel.class);
+		given(channel.isOpen()).willReturn(true);
+
+		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
+		cachingConnectionFactory.setExecutor(mock(ExecutorService.class));
+
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
+
+		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
+		willAnswer(ensureOneChannelAnswer(channel, tooManyChannels)).given(mockConnection).createChannel();
+
+		willAnswer(invocation -> channel).given(mockConnection).createChannel();
+
+		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
+		final CountDownLatch consumerLatch = new CountDownLatch(1);
+
+		willAnswer(invocation -> {
+			consumer.set(invocation.getArgumentAt(6, Consumer.class));
+			consumerLatch.countDown();
+			return "consumerTag";
+		}).given(channel)
+				.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(),
+						any(Consumer.class));
+
+		final CountDownLatch rollbackLatch = new CountDownLatch(1);
+		willAnswer(invocation -> {
+			rollbackLatch.countDown();
+			return null;
+		}).given(channel).txRollback();
+
+		final CountDownLatch rejectLatch = new CountDownLatch(1);
+		willAnswer(invocation -> {
+			rejectLatch.countDown();
+			return null;
+		}).given(channel).basicReject(anyLong(), anyBoolean());
+		willAnswer(invocation -> {
+			rejectLatch.countDown();
+			return null;
+		}).given(channel).basicNack(anyLong(), anyBoolean(), anyBoolean());
+
+
+		final CountDownLatch latch = new CountDownLatch(1);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(cachingConnectionFactory);
+		container.setTransactionAttribute(new DefaultTransactionAttribute(propagation));
+		container.setMessageListener((MessageListener) message -> {
+			latch.countDown();
+			throw expectRequeue
+					? new RuntimeException("force rollback")
+					: new AmqpRejectAndDontRequeueException("force rollback");
+		});
+		container.setQueueNames("queue");
+		container.setChannelTransacted(true);
+		container.setAlwaysRequeueWithTxManagerRollback(false);
+		container.setShutdownTimeout(100);
+		container.setTransactionManager(new DummyTxManager());
+		container.afterPropertiesSet();
+		container.start();
+		assertTrue(consumerLatch.await(10, TimeUnit.SECONDS));
+
+		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
+				new byte[] { 0 });
+
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+		Exception e = tooManyChannels.get();
+		if (e != null) {
+			throw e;
+		}
+
+		verify(mockConnection, times(1)).createChannel();
+		assertTrue(rejectLatch.await(10, TimeUnit.SECONDS));
+
+		assertTrue(rollbackLatch.await(10, TimeUnit.SECONDS));
+		if (propagation != TransactionDefinition.PROPAGATION_NEVER) {
+			verify(channel).basicReject(anyLong(), eq(expectRequeue));
+		}
+		else {
+			verify(channel).basicReject(anyLong(), eq(expectRequeue));
+		}
+		container.stop();
+	}
+
+	@Test
+	public void testMessageListenerCommit() throws Exception {
+		testMessageListenerCommitGuts(TransactionDefinition.PROPAGATION_REQUIRED);
+	}
+
+	@Test
+	public void testMessageListenerCommitNoBoundTransaction() throws Exception {
+		testMessageListenerCommitGuts(TransactionDefinition.PROPAGATION_NEVER);
+	}
+
+	/**
+	 * Verifies that the channel is committed.
+	 */
+	@SuppressWarnings("unchecked")
+	private void testMessageListenerCommitGuts(int propagation) throws Exception {
+		ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
+		Connection mockConnection = mock(Connection.class);
+		final Channel channel = mock(Channel.class);
+		given(channel.isOpen()).willReturn(true);
+
+		final CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(mockConnectionFactory);
+		cachingConnectionFactory.setExecutor(mock(ExecutorService.class));
+
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
+
+		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
+		willAnswer(ensureOneChannelAnswer(channel, tooManyChannels)).given(mockConnection).createChannel();
+
+		willAnswer(invocation -> channel).given(mockConnection).createChannel();
+
+		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
+		final CountDownLatch consumerLatch = new CountDownLatch(1);
+
+		willAnswer(invocation -> {
+			consumer.set(invocation.getArgumentAt(6, Consumer.class));
+			consumerLatch.countDown();
+			return "consumerTag";
+		}).given(channel)
+				.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), anyMap(),
+						any(Consumer.class));
+
+		final CountDownLatch commitLatch = new CountDownLatch(1);
+		willAnswer(invocation -> {
+			commitLatch.countDown();
+			return null;
+		}).given(channel).txCommit();
+		final CountDownLatch ackLatch = new CountDownLatch(1);
+		willAnswer(invocation -> {
+			ackLatch.countDown();
+			return null;
+		}).given(channel).basicAck(anyLong(), anyBoolean());
+
+		final CountDownLatch latch = new CountDownLatch(1);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(cachingConnectionFactory);
+		container.setTransactionAttribute(new DefaultTransactionAttribute(propagation));
+		container.setMessageListener((MessageListener) message -> {
+			latch.countDown();
+		});
+		container.setQueueNames("queue");
+		container.setChannelTransacted(true);
+		container.setShutdownTimeout(100);
+		container.setTransactionManager(new DummyTxManager());
+		container.afterPropertiesSet();
+		container.start();
+		assertTrue(consumerLatch.await(10, TimeUnit.SECONDS));
+
+		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
+				new byte[] { 0 });
+
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+		Exception e = tooManyChannels.get();
+		if (e != null) {
+			throw e;
+		}
+
+		verify(mockConnection, times(1)).createChannel();
+
+		assertTrue(ackLatch.await(10, TimeUnit.SECONDS));
+		assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
+		verify(channel).basicAck(anyLong(), anyBoolean());
+		container.stop();
+	}
+
 	/**
 	 * Verifies that an up-stack RabbitTemplate does not use the listener's
 	 * channel when it has its own connection factory.
@@ -269,20 +454,7 @@ public class ExternalTxManagerTests {
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		willAnswer(new Answer<Channel>() {
-			boolean done;
-			@Override
-			public Channel answer(InvocationOnMock invocation) throws Throwable {
-				if (!done) {
-					done = true;
-					return listenerChannel;
-				}
-				tooManyChannels.set(new Exception("More than one channel requested"));
-				Channel channel = mock(Channel.class);
-				given(channel.isOpen()).willReturn(true);
-				return channel;
-			}
-		}).given(listenerConnection).createChannel();
+		willAnswer(ensureOneChannelAnswer(listenerChannel, tooManyChannels)).given(listenerConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 
@@ -378,20 +550,7 @@ public class ExternalTxManagerTests {
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		willAnswer(new Answer<Channel>() {
-			boolean done;
-			@Override
-			public Channel answer(InvocationOnMock invocation) throws Throwable {
-				if (!done) {
-					done = true;
-					return onlyChannel;
-				}
-				tooManyChannels.set(new Exception("More than one channel requested"));
-				Channel channel = mock(Channel.class);
-				given(channel.isOpen()).willReturn(true);
-				return channel;
-			}
-		}).given(mockConnection).createChannel();
+		willAnswer(ensureOneChannelAnswer(onlyChannel, tooManyChannels)).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 
@@ -480,20 +639,7 @@ public class ExternalTxManagerTests {
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		willAnswer(new Answer<Channel>() {
-			boolean done;
-			@Override
-			public Channel answer(InvocationOnMock invocation) throws Throwable {
-				if (!done) {
-					done = true;
-					return onlyChannel;
-				}
-				tooManyChannels.set(new Exception("More than one channel requested"));
-				Channel channel = mock(Channel.class);
-				given(channel.isOpen()).willReturn(true);
-				return channel;
-			}
-		}).given(mockConnection).createChannel();
+		willAnswer(ensureOneChannelAnswer(onlyChannel, tooManyChannels)).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 
@@ -583,20 +729,7 @@ public class ExternalTxManagerTests {
 
 		final AtomicReference<Exception> tooManyChannels = new AtomicReference<Exception>();
 
-		willAnswer(new Answer<Channel>() {
-			boolean done;
-			@Override
-			public Channel answer(InvocationOnMock invocation) throws Throwable {
-				if (!done) {
-					done = true;
-					return onlyChannel;
-				}
-				tooManyChannels.set(new Exception("More than one channel requested"));
-				Channel channel = mock(Channel.class);
-				given(channel.isOpen()).willReturn(true);
-				return channel;
-			}
-		}).given(mockConnection).createChannel();
+		willAnswer(ensureOneChannelAnswer(onlyChannel, tooManyChannels)).given(mockConnection).createChannel();
 
 		final AtomicReference<Consumer> consumer = new AtomicReference<Consumer>();
 
@@ -660,6 +793,21 @@ public class ExternalTxManagerTests {
 		assertEquals(0, channels.size());
 
 		container.stop();
+	}
+
+	private Answer<Channel> ensureOneChannelAnswer(final Channel onlyChannel,
+			final AtomicReference<Exception> tooManyChannels) {
+		final AtomicBoolean done = new AtomicBoolean();
+		return invocation -> {
+			if (!done.get()) {
+				done.set(true);
+				return onlyChannel;
+			}
+			tooManyChannels.set(new Exception("More than one channel requested"));
+			Channel channel = mock(Channel.class);
+			given(channel.isOpen()).willReturn(true);
+			return channel;
+		};
 	}
 
 	@SuppressWarnings("serial")

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3584,6 +3584,7 @@ The default `FatalExceptionStrategy` logs a warning message when an exception is
 
 Since _version 1.6.3_ a convenient way to add user exceptions to the fatal list is to subclass `ConditionalRejectingErrorHandler.DefaultExceptionStrategy` and override the method `isUserCauseFatal(Throwable cause)` to return true for fatal exceptions.
 
+[[transactions]]
 ==== Transactions
 
 ===== Introduction
@@ -3675,6 +3676,7 @@ public AbstractMessageListenerContainer container() {
 }
 ----
 
+[[transaction-rollback]]
 ===== A note on Rollback of Received Messages
 
 AMQP transactions only apply to messages and acks sent to the broker, so when there is a rollback of a Spring transaction and a message has been received, what Spring AMQP has to do is not just rollback the transaction, but also manually reject the message (sort of a nack, but that's not what the specification calls it).
@@ -3684,6 +3686,14 @@ For more information about rejecting failed messages, see <<async-listeners>>.
 For more information about RabbitMQ transactions, and their limitations, refer to http://www.rabbitmq.com/semantics.html[RabbitMQ Broker Semantics].
 
 NOTE: Prior to *RabbitMQ 2.7.0*, such messages (and any that are unacked when a channel is closed or aborts) went to the back of the queue on a Rabbit broker, since 2.7.0, rejected messages go to the front of the queue, in a similar manner to JMS rolled back messages.
+
+[NOTE]
+====
+Message requeue on transaction rollback is inconsistent between local transactions and when a `TransactionManager` is provided.
+In the former case, the normal requeue logic (`AmqpRejectAndDontRequeueException` or `defaultRequeueRejected=false`) applies (see <<async-listeners>>); with a transaction manager, the message is unconditionally requeued on rollback.
+Starting with __version 1.7.1__, you can enable the consistent behavior by setting the container's `alwaysRequeueWithTxManagerRollback` property to `false`; it will be `false` by default in 2.0.
+See <<containerAttributes>>.
+====
 
 ===== Using the RabbitTransactionManager
 
@@ -4030,6 +4040,13 @@ an implementation of <<consumerTags, ConsumerTagStrategy>>, enabling the creatio
 
 | Starting with _version 1.6_, `SimpleMessageListenerContainer` has this new property.
 See <<idle-containers>>.
+
+| alwaysRequeueWithTx
+ManagerRollback
+(N/A)
+
+| Set to `true` to always requeue messages on rollback when a transaction manager is configured (default).
+Set to `false` to configure the container to use consistent message rejection behavior regardless of whether a transaction manager is configured.
 
 |===
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -44,6 +44,13 @@ It is also now more flexible when using a transaction advice.
 A new `ConnectionNameStrategy` is now provided to populate the application-specific identification of the target RabbitMQ connection from the `AbstractConnectionFactory`.
 See <<connections>> for more information.
 
+===== Listener Container Changes
+
+====== Transaction Rollback behavior
+
+Message requeue on transaction rollback can now be configured to be consistent, regardless of whether or not a transaction manager is configured.
+See <<transaction-rollback>> for more information.
+
 ==== Earlier Releases
 
 See <<previous-whats-new>> for changes in previous versions.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-711

Previously, messsages were unconditionally requeued when an external
transaction manager is used; this was not consistent with local
transactions, where the normal requeue logic was honored.

Fix the case when the transaction manager is a RabbitTransactionManager

When the transaction manager is a `RabbitTransactionManager`, the resource is already bound and
the resource bound within the transaction template execute() method is ignored.

The `requeueOnRollback` field needs to be set in the correct resource holder.

Change the `ConnectionFactoryUtils.bindResourceToTransaction` method to return the actual
resource holder that is bound to the transaction and set the boolean therein.

Polishing - clear the transaction thread locals.

Handle corner case where we have a transaction manager, but no global transaction.

This can only happen if the transaction attribute causes a transaction to be not started.

In this case, act like a local transaction, wrt committing and rolling back.

Test Polishing

The verify on commit/rollback should not be conditional.

Conflicts:
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
	spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
	src/reference/asciidoc/whats-new.adoc
Resolved.