### PR TITLE
AMQP-716: ExchangeBuilder and Durable

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeBuilder.java
@@ -97,11 +97,24 @@ public final class ExchangeBuilder extends AbstractBuilder {
 	}
 
 	/**
-	 * Set the durable flag.
+	 * Set the durable flag to true.
 	 * @return the builder.
+	 * @deprecated - in 2.0, durable will be true by default
+	 * @see #durable(boolean)
 	 */
+	@Deprecated
 	public ExchangeBuilder durable() {
 		this.durable = true;
+		return this;
+	}
+
+	/**
+	 * Set the durable flag.
+	 * @return the builder.
+	 * @see #durable
+	 */
+	public ExchangeBuilder durable(boolean durable) {
+		this.durable = durable;
 		return this;
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-716

The builder was not consistent with the Abstract class regarding
the default for the `durable` flag.

__cherry-pick to 1.6.x__

I will issue a separate PR for master after merge - it will need `what's new`, and code changes including tests.