### PR TITLE
AMQP-716: ExchangeBuilder and Durable

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeBuilder.java
@@ -31,7 +31,7 @@ public final class ExchangeBuilder extends AbstractBuilder {
 
 	private final String type;
 
-	private boolean durable;
+	private boolean durable = true;
 
 	private boolean autoDelete;
 
@@ -98,10 +98,11 @@ public final class ExchangeBuilder extends AbstractBuilder {
 
 	/**
 	 * Set the durable flag.
+	 * @param durable the durable flag (default true).
 	 * @return the builder.
 	 */
-	public ExchangeBuilder durable() {
-		this.durable = true;
+	public ExchangeBuilder durable(boolean durable) {
+		this.durable = durable;
 		return this;
 	}
 

--- a/spring-amqp/src/test/java/org/springframework/amqp/core/builder/BuilderTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/core/builder/BuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class BuilderTests {
 
 	@Test
 	public void testExchangeBuilder() {
-		Exchange exchange = ExchangeBuilder.directExchange("foo").autoDelete().delayed().durable().internal()
+		Exchange exchange = ExchangeBuilder.directExchange("foo").autoDelete().delayed().internal()
 				.withArgument("foo", "bar").build();
 		assertThat(exchange, instanceOf(DirectExchange.class));
 		assertTrue(exchange.isAutoDelete());
@@ -74,7 +74,7 @@ public class BuilderTests {
 		assertTrue(exchange.isDelayed());
 		assertThat((String) exchange.getArguments().get("foo"), equalTo("bar"));
 
-		exchange = ExchangeBuilder.topicExchange("foo").build();
+		exchange = ExchangeBuilder.topicExchange("foo").durable(false).build();
 		assertThat(exchange, instanceOf(TopicExchange.class));
 		assertFalse(exchange.isAutoDelete());
 		assertFalse(exchange.isDurable());
@@ -84,14 +84,14 @@ public class BuilderTests {
 		exchange = ExchangeBuilder.fanoutExchange("foo").build();
 		assertThat(exchange, instanceOf(FanoutExchange.class));
 		assertFalse(exchange.isAutoDelete());
-		assertFalse(exchange.isDurable());
+		assertTrue(exchange.isDurable());
 		assertFalse(exchange.isInternal());
 		assertFalse(exchange.isDelayed());
 
 		exchange = ExchangeBuilder.headersExchange("foo").build();
 		assertThat(exchange, instanceOf(HeadersExchange.class));
 		assertFalse(exchange.isAutoDelete());
-		assertFalse(exchange.isDurable());
+		assertTrue(exchange.isDurable());
 		assertFalse(exchange.isInternal());
 		assertFalse(exchange.isDelayed());
 	}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3459,6 +3459,10 @@ public Exchange exchange() {
 
 See the javadocs for `org.springframework.amqp.core.QueueBuilder` and `org.springframework.amqp.core.ExchangeBuilder` for more information.
 
+Starting with _version 2.0_, the `ExchangeBuilder` now creates durable exchanges by default, to be consistent with the simple constructors on the individual `AbstractExchange` classes.
+To make a non-durable exchange with the builder, use `.durable(false)` before invoking `.build()`.
+The `durable()` method with no parameter is no longer provided.
+
 [[collection-declaration]]
 ===== Declaring Collections of Exchanges, Queues, Bindings
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -13,6 +13,11 @@ It is recommended to disable `amqp-client` automatic recovery, to avoid getting 
 Starting with _version 1.7.1_, Spring AMQP disables it unless you explicitly create your own RabbitMQ connection factory and provide it to the `CachingConnectionFactory`.
 RabbitMQ `ConnectionFactory` instances created by the `RabbitConnectionFactoryBean` will also have the option disabled by default.
 
+===== General Changes
+
+The `ExchangeBuilder` now builds durable exchanges by default.
+See <<builder-api>> for more information.
+
 ===== New Listener Container
 
 The `DirectMessageListenerContainer` has been added alongside the existing `SimpleMessageListenerContainer`.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-716

The builder was not consistent with the Abstract class regarding
the default for the `durable` flag.

Remove the deprecated `durable()` method and set to `true` by default.