### PR TITLE
CheckStyle: JavaDoc

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,8 +127,8 @@ public abstract class AbstractExchange extends AbstractDeclarable implements Exc
 	/**
 	 * Set the delayed flag.
 	 * @param delayed the delayed.
-	 * @see Exchange#isDelayed()
 	 * @since 1.6
+	 * @see Exchange#isDelayed()
 	 */
 	public void setDelayed(boolean delayed) {
 		this.delayed = delayed;
@@ -142,8 +142,8 @@ public abstract class AbstractExchange extends AbstractDeclarable implements Exc
 	/**
 	 * Set the internal flag.
 	 * @param internal the internal.
-	 * @see Exchange#isInternal()
 	 * @since 1.6
+	 * @see Exchange#isInternal()
 	 */
 	public void setInternal(boolean internal) {
 		this.internal = internal;

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,12 +55,12 @@ public class Address {
 	private final String routingKey;
 
 	/**
-	 * Create an Address instance from a structured String in the form
+	 * Create an Address instance from a structured String with the form
 	 *
 	 * <pre class="code">
 	 * (exchange)/(routingKey)
 	 * </pre>
-	 *
+	 * .
 	 * @param address a structured string.
 	 */
 	public Address(String address) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpAdmin.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.Properties;
 
 
 /**
- * Specifies a basic set of portable AMQP administrative operations for AMQP &gt; 0.8
+ * Specifies a basic set of portable AMQP administrative operations for AMQP &gt; 0.9.
  *
  * @author Mark Pollack
  * @author Dave Syer
@@ -29,7 +29,7 @@ import java.util.Properties;
 public interface AmqpAdmin {
 
 	/**
-	 * Declare an exchange
+	 * Declare an exchange.
 	 * @param exchange the exchange to declare.
 	 */
 	void declareExchange(Exchange exchange);
@@ -53,33 +53,33 @@ public interface AmqpAdmin {
 	Queue declareQueue();
 
 	/**
-	 * Declare the given queue
-	 * @param queue the queue to declare
+	 * Declare the given queue.
+	 * @param queue the queue to declare.
 	 * @return the name of the queue.
 	 */
 	String declareQueue(Queue queue);
 
 	/**
-	 * Delete a queue, without regard for whether it is in use or has messages on it
-	 * @param queueName the name of the queue
-	 * @return true if the queue existed and was deleted
+	 * Delete a queue, without regard for whether it is in use or has messages on it.
+	 * @param queueName the name of the queue.
+	 * @return true if the queue existed and was deleted.
 	 */
 	boolean deleteQueue(String queueName);
 
 	// Note that nowait option is not readily exposed in Rabbit Java API but is for Rabbit .NET API.
 
 	/**
-	 * Delete a queue
-	 * @param queueName the name of the queue
-	 * @param unused true if the queue should be deleted only if not in use
-	 * @param empty true if the queue should be deleted only if empty
+	 * Delete a queue.
+	 * @param queueName the name of the queue.
+	 * @param unused true if the queue should be deleted only if not in use.
+	 * @param empty true if the queue should be deleted only if empty.
 	 */
 	void deleteQueue(String queueName, boolean unused, boolean empty);
 
 	/**
 	 * Purges the contents of the given queue.
-	 * @param queueName the name of the queue
-	 * @param noWait true to not await completion of the purge
+	 * @param queueName the name of the queue.
+	 * @param noWait true to not await completion of the purge.
 	 */
 	void purgeQueue(String queueName, boolean noWait);
 
@@ -101,7 +101,7 @@ public interface AmqpAdmin {
 	/**
 	 * Returns an implementation-specific Map of properties if the queue exists.
 	 * @param queueName the name of the queue.
-	 * @return the properties or null if the queue doesn't exist
+	 * @return the properties or null if the queue doesn't exist.
 	 */
 	Properties getQueueProperties(String queueName);
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpTemplate.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpTemplate.java
@@ -537,7 +537,7 @@ public interface AmqpTemplate {
 	 * @throws AmqpException if there is a problem.
 	 * @since 2.0
 	 */
-	<T> T convertSendAndReceiveAsType(final Object message, ParameterizedTypeReference<T> responseType)
+	<T> T convertSendAndReceiveAsType(Object message, ParameterizedTypeReference<T> responseType)
 			throws AmqpException;
 
 	/**
@@ -554,7 +554,7 @@ public interface AmqpTemplate {
 	 * @throws AmqpException if there is a problem
 	 * @since 2.0
 	 */
-	<T> T convertSendAndReceiveAsType(final String routingKey, final Object message,
+	<T> T convertSendAndReceiveAsType(String routingKey, Object message,
 			ParameterizedTypeReference<T> responseType) throws AmqpException;
 
 	/**
@@ -572,7 +572,7 @@ public interface AmqpTemplate {
 	 * @throws AmqpException if there is a problem
 	 * @since 2.0
 	 */
-	<T> T convertSendAndReceiveAsType(final String exchange, final String routingKey, final Object message,
+	<T> T convertSendAndReceiveAsType(String exchange, String routingKey, Object message,
 			ParameterizedTypeReference<T> responseType) throws AmqpException;
 
 	/**
@@ -589,7 +589,7 @@ public interface AmqpTemplate {
 	 * @throws AmqpException if there is a problem
 	 * @since 2.0
 	 */
-	<T> T convertSendAndReceiveAsType(final Object message, final MessagePostProcessor messagePostProcessor,
+	<T> T convertSendAndReceiveAsType(Object message, MessagePostProcessor messagePostProcessor,
 			ParameterizedTypeReference<T> responseType) throws AmqpException;
 
 	/**
@@ -607,8 +607,8 @@ public interface AmqpTemplate {
 	 * @throws AmqpException if there is a problem
 	 * @since 2.0
 	 */
-	<T> T convertSendAndReceiveAsType(final String routingKey, final Object message,
-			final MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<T> responseType)
+	<T> T convertSendAndReceiveAsType(String routingKey, Object message,
+			MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<T> responseType)
 			throws AmqpException;
 
 	/**
@@ -627,8 +627,8 @@ public interface AmqpTemplate {
 	 * @throws AmqpException if there is a problem
 	 * @since 2.0
 	 */
-	<T> T convertSendAndReceiveAsType(final String exchange, final String routingKey, final Object message,
-			final MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<T> responseType)
+	<T> T convertSendAndReceiveAsType(String exchange, String routingKey, Object message,
+			MessagePostProcessor messagePostProcessor, ParameterizedTypeReference<T> responseType)
 			throws AmqpException;
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AnonymousQueue.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AnonymousQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class AnonymousQueue extends Queue {
 	}
 
 	/**
-	 * A strategy to name anonymous queues
+	 * A strategy to name anonymous queues.
 	 * @since 1.5.3
 	 *
 	 */

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Binding.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,20 @@ import java.util.Map;
  */
 public class Binding extends AbstractDeclarable {
 
+	/**
+	 * The binding destination.
+	 */
 	public enum DestinationType {
-		QUEUE, EXCHANGE;
+
+		/**
+		 * Queue destination.
+		 */
+		QUEUE,
+
+		/**
+		 * Exchange destination.
+		 */
+		EXCHANGE;
 	}
 
 	private final String destination;

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/BindingBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/BindingBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,9 @@ public final class BindingBuilder {
 		return map;
 	}
 
+	/**
+	 * General destination configurer.
+	 */
 	public static final class DestinationConfigurer {
 
 		protected final String name;
@@ -84,6 +87,9 @@ public final class BindingBuilder {
 		}
 	}
 
+	/**
+	 * Headers exchange configurer.
+	 */
 	public static final class HeadersExchangeMapConfigurer {
 
 		protected final DestinationConfigurer destination;
@@ -115,6 +121,9 @@ public final class BindingBuilder {
 			return new HeadersExchangeMapBindingCreator(headerValues, true);
 		}
 
+		/**
+		 * Headers exchange single value binding creator.
+		 */
 		public final class HeadersExchangeSingleValueBindingCreator {
 
 			private final String key;
@@ -139,6 +148,9 @@ public final class BindingBuilder {
 			}
 		}
 
+		/**
+		 * Headers exchange keys binding creator.
+		 */
 		public final class HeadersExchangeKeysBindingCreator {
 
 			private final Map<String, Object> headerMap;
@@ -156,6 +168,9 @@ public final class BindingBuilder {
 			}
 		}
 
+		/**
+		 * Headers exchange map binding creator.
+		 */
 		public final class HeadersExchangeMapBindingCreator {
 
 			private final Map<String, Object> headerMap;
@@ -186,6 +201,9 @@ public final class BindingBuilder {
 		}
 	}
 
+	/**
+	 * Topic exchange routing key configurer.
+	 */
 	public static final class TopicExchangeRoutingKeyConfigurer extends AbstractRoutingKeyConfigurer<TopicExchange> {
 
 		TopicExchangeRoutingKeyConfigurer(DestinationConfigurer destination, TopicExchange exchange) {
@@ -203,6 +221,9 @@ public final class BindingBuilder {
 		}
 	}
 
+	/**
+	 * Generic exchange routing key configurer.
+	 */
 	public static final class GenericExchangeRoutingKeyConfigurer extends AbstractRoutingKeyConfigurer<TopicExchange> {
 
 		GenericExchangeRoutingKeyConfigurer(DestinationConfigurer destination, Exchange exchange) {
@@ -219,6 +240,9 @@ public final class BindingBuilder {
 
 	}
 
+	/**
+	 * Generic argument configurer.
+	 */
 	public static class GenericArgumentsConfigurer {
 
 		private final GenericExchangeRoutingKeyConfigurer configurer;
@@ -241,6 +265,9 @@ public final class BindingBuilder {
 
 	}
 
+	/**
+	 * Direct exchange routing key configurer.
+	 */
 	public static final class DirectExchangeRoutingKeyConfigurer extends AbstractRoutingKeyConfigurer<DirectExchange> {
 
 		DirectExchangeRoutingKeyConfigurer(DestinationConfigurer destination, DirectExchange exchange) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/CustomExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/CustomExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,8 @@ import java.util.Map;
  * Simple container collecting information to describe a custom exchange. Custom exchange types are allowed by the AMQP
  * specification, and their names should start with "x-" (but this is not enforced here). Used in conjunction with
  * administrative operations.
- *
- * @see AmqpAdmin
- *
  * @author Dave Syer
+ * @see AmqpAdmin
  */
 public class CustomExchange extends AbstractExchange {
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/DirectExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/DirectExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,15 @@ import java.util.Map;
 /**
  * Simple container collecting information to describe a direct exchange.
  * Used in conjunction with administrative operations.
- *
- * @see AmqpAdmin
- *
  * @author Mark Pollack
  * @author Dave Syer
+ * @see AmqpAdmin
  */
 public class DirectExchange extends AbstractExchange {
 
+	/**
+	 * The default exchange.
+	 */
 	public static final DirectExchange DEFAULT = new DirectExchange("");
 
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Exchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Exchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.amqp.core;
 import java.util.Map;
 
 /**
+ * Interface for all exchanges.
+ *
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
@@ -28,28 +30,28 @@ public interface Exchange extends Declarable {
 	/**
 	 * The name of the exchange.
 	 *
-	 * @return the name of the exchange
+	 * @return the name of the exchange.
 	 */
 	String getName();
 
 	/**
 	 * The type of the exchange. See {@link ExchangeTypes} for some well-known examples.
 	 *
-	 * @return the type of the exchange
+	 * @return the type of the exchange.
 	 */
 	String getType();
 
 	/**
-	 * A durable exchange will survive a server restart
+	 * A durable exchange will survive a server restart.
 	 *
-	 * @return true if durable
+	 * @return true if durable.
 	 */
 	boolean isDurable();
 
 	/**
 	 * True if the server should delete the exchange when it is no longer in use (if all bindings are deleted).
 	 *
-	 * @return true if auto-delete
+	 * @return true if auto-delete.
 	 */
 	boolean isAutoDelete();
 
@@ -57,7 +59,7 @@ public interface Exchange extends Declarable {
 	 * A map of arguments used to declare the exchange. These are stored by the broker, but do not necessarily have any
 	 * meaning to the broker (depending on the exchange type).
 	 *
-	 * @return the arguments
+	 * @return the arguments.
 	 */
 	Map<String, Object> getArguments();
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeBuilder.java
@@ -43,8 +43,8 @@ public final class ExchangeBuilder extends AbstractBuilder {
 	 * Construct an instance of the appropriate type.
 	 * @param name the exchange name
 	 * @param type the type name
-	 * @see ExchangeTypes
 	 * @since 1.6.7
+	 * @see ExchangeTypes
 	 */
 	public ExchangeBuilder(String name, String type) {
 		this.name = name;

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeTypes.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/ExchangeTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,14 +24,29 @@ package org.springframework.amqp.core;
  */
 public abstract class ExchangeTypes {
 
+	/**
+	 * Direct exchange.
+	 */
 	public static final String DIRECT = "direct";
 
+	/**
+	 * Topic exchange.
+	 */
 	public static final String TOPIC = "topic";
 
+	/**
+	 * Fanout exchange.
+	 */
 	public static final String FANOUT = "fanout";
 
+	/**
+	 * Headers exchange.
+	 */
 	public static final String HEADERS = "headers";
 
+	/**
+	 * System exchange.
+	 */
 	public static final String SYSTEM = "system";
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/FanoutExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/FanoutExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,9 @@ import java.util.Map;
 /**
  * Simple container collecting information to describe a fanout exchange.
  * Used in conjunction with administrative operations.
- * @see AmqpAdmin
- *
  * @author Mark Pollack
  * @author Dave Syer
+ * @see AmqpAdmin
  */
 public class FanoutExchange extends AbstractExchange {
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/HeadersExchange.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/HeadersExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.amqp.core;
 import java.util.Map;
 
 /**
+ * Headers exchange.
+ *
  * @author Mark Fisher
  * @author Dave Syer
  */

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageBuilderSupport.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageBuilderSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.springframework.beans.BeanUtils;
 /**
  * Support class for building {@link Message} and {@link MessageProperties}
  * fluent API.
- *
+ * @param <T> The message builder type.
  * @author Gary Russell
  * @since 1.3
  *

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageDeliveryMode.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageDeliveryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,15 @@ package org.springframework.amqp.core;
  */
 public enum MessageDeliveryMode {
 
-	NON_PERSISTENT, PERSISTENT;
+	/**
+	 * Non persistent.
+	 */
+	NON_PERSISTENT,
+
+	/**
+	 * Persistent.
+	 */
+	PERSISTENT;
 
 	public static int toInt(MessageDeliveryMode mode) {
 		switch (mode) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -472,7 +472,7 @@ public class MessageProperties implements Serializable {
 
 	/**
 	 * Set the inferred target argument type when using a method-level
-	 * {@code @RabbitListener}
+	 * {@code @RabbitListener}.
 	 * @param inferredArgumentType the type.
 	 * @since 1.6
 	 */
@@ -499,7 +499,7 @@ public class MessageProperties implements Serializable {
 	}
 
 	/**
-	 * The target bean when using {@code @RabbitListener}
+	 * The target bean when using {@code @RabbitListener}.
 	 * @return the bean.
 	 * @since 1.6
 	 */
@@ -508,7 +508,7 @@ public class MessageProperties implements Serializable {
 	}
 
 	/**
-	 * Set the target bean when using {@code @RabbitListener}
+	 * Set the target bean when using {@code @RabbitListener}.
 	 * @param targetBean the bean.
 	 * @since 1.6
 	 */

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Queue.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Queue.java
@@ -93,9 +93,9 @@ public class Queue extends AbstractDeclarable {
 	}
 
 	/**
-	 * A durable queue will survive a server restart
+	 * A durable queue will survive a server restart.
 	 *
-	 * @return true if durable
+	 * @return true if durable.
 	 */
 	public boolean isDurable() {
 		return this.durable;
@@ -104,7 +104,7 @@ public class Queue extends AbstractDeclarable {
 	/**
 	 * True if the server should only send messages to the declarer's connection.
 	 *
-	 * @return true if auto-delete
+	 * @return true if exclusive.
 	 */
 	public boolean isExclusive() {
 		return this.exclusive;
@@ -114,7 +114,7 @@ public class Queue extends AbstractDeclarable {
 	 * True if the server should delete the queue when it is no longer in use (the last consumer is cancelled). A queue
 	 * that never has any consumers will not be deleted automatically.
 	 *
-	 * @return true if auto-delete
+	 * @return true if auto-delete.
 	 */
 	public boolean isAutoDelete() {
 		return this.autoDelete;

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/ReplyToAddressCallback.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/ReplyToAddressCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,11 @@ package org.springframework.amqp.core;
  *
  * <p>This often as an anonymous class within a method implementation.
  *
-* @author Artem Bilan
-* @author Gary Russell
-* @since 1.3
-*/
+ * @param <T> the reply type.
+ * @author Artem Bilan
+ * @author Gary Russell
+ * @since 1.3
+ */
 @FunctionalInterface
 public interface ReplyToAddressCallback<T> {
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/SimpleAmqpHeaderMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/SimpleAmqpHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,6 +268,8 @@ public class SimpleAmqpHeaderMapper extends AbstractHeaderMapper<MessageProperti
 	 * Will extract Content-Type from MessageHeaders and convert it to String if possible
 	 * Required since Content-Type can be represented as org.springframework.http.MediaType
 	 * or org.springframework.util.MimeType.
+	 * @param headers the headers.
+	 * @return the content type.
 	 */
 	private String extractContentTypeAsString(Map<String, Object> headers) {
 		String contentTypeStringValue = null;

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
 /**
+ * Abstract type mapper.
+ *
  * @author Mark Pollack
  * @author Sam Nelson
  * @author Andreas Asplund

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJsonMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.util.ClassUtils;
 
 /**
- *
+ * Abstract JSON message converter.
  * @author Mark Pollack
  * @author James Carr
  * @author Dave Syer

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/ContentTypeDelegatingMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/ContentTypeDelegatingMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ public class ContentTypeDelegatingMessageConverter implements MessageConverter {
 
 
 	/**
+	 * Add a delegate converter for the content type.
 	 * @param contentType the content type to check.
 	 * @param messageConverter the {@link MessageConverter} for the content type.
 	 * @since 1.6
@@ -78,6 +79,7 @@ public class ContentTypeDelegatingMessageConverter implements MessageConverter {
 	}
 
 	/**
+	 * Remove the delegate for the content type.
 	 * @param contentType the content type key to remove {@link MessageConverter} from delegates.
 	 * @return the remove {@link MessageConverter}.
 	 */

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultClassMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultClassMapper.java
@@ -81,8 +81,8 @@ public class DefaultClassMapper implements ClassMapper, InitializingBean {
 	 * if the {@value #DEFAULT_CLASSID_FIELD_NAME} header is {@code HashTable} convert to this
 	 * class.
 	 * @param defaultMapClass the map class.
-	 * @see #DEFAULT_CLASSID_FIELD_NAME
 	 * @since 2.0
+	 * @see #DEFAULT_CLASSID_FIELD_NAME
 	 */
 	public void setDefaultMapClass(Class<?> defaultMapClass) {
 		this.defaultMapClass = defaultMapClass;

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
 /**
+ * Jackson 2 type mapper.
  * @author Mark Pollack
  * @author Sam Nelson
  * @author Andreas Asplund

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ import com.fasterxml.jackson.databind.JavaType;
  */
 public interface Jackson2JavaTypeMapper extends ClassMapper {
 
+	/**
+	 * The precedence for type conversion - inferred from the method parameter or message
+	 * headers. Only applies if both exist.
+	 */
 	enum TypePrecedence {
 		INFERRED, TYPE_ID
 	}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,9 +75,10 @@ public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter i
 	}
 
 	/**
+	 * Return the type precedence.
 	 * @return the precedence.
-	 * @see #setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence)
 	 * @since 1.6.
+	 * @see #setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence)
 	 */
 	public Jackson2JavaTypeMapper.TypePrecedence getTypePrecedence() {
 		return this.javaTypeMapper.getTypePrecedence();
@@ -133,6 +134,7 @@ public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter i
 	}
 
 	/**
+	 * {@inheritDoc}
 	 * @param conversionHint The conversionHint must be a {@link ParameterizedTypeReference}.
 	 */
 	@Override

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 
 /**
+ * Message converter interface.
  * @author Mark Fisher
  * @author Mark Pollack
  */

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SmartMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SmartMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,8 @@ public interface SmartMessageConverter extends MessageConverter {
 	 * @param conversionHint an extra object passed to the {@link MessageConverter}.
 	 * @return the result of the conversion, or {@code null} if the converter cannot
 	 * perform the conversion.
-	 * @see #fromMessage(Message)
 	 * @throws MessageConversionException if the conversion fails.
+	 * @see #fromMessage(Message)
 	 */
 	Object fromMessage(Message message, Object conversionHint) throws MessageConversionException;
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/AbstractCompressingPostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/AbstractCompressingPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,7 @@ public abstract class AbstractCompressingPostProcessor implements MessagePostPro
 	}
 
 	/**
+	 * Set the order.
 	 * @param order the order, default 0.
 	 * @see Ordered
 	 */
@@ -106,6 +107,7 @@ public abstract class AbstractCompressingPostProcessor implements MessagePostPro
 	}
 
 	/**
+	 * Get the stream.
 	 * @param stream The output stream to write the compressed data to.
 	 * @return the compressor output stream.
 	 * @throws IOException IOException
@@ -113,6 +115,7 @@ public abstract class AbstractCompressingPostProcessor implements MessagePostPro
 	protected abstract OutputStream getCompressorStream(OutputStream stream) throws IOException;
 
 	/**
+	 * Get the encoding.
 	 * @return the content-encoding header.
 	 */
 	protected abstract String getEncoding();

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/AbstractDecompressingPostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/AbstractDecompressingPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ public abstract class AbstractDecompressingPostProcessor implements MessagePostP
 	}
 
 	/**
+	 * Set the order.
 	 * @param order the order, default 0.
 	 * @see Ordered
 	 */
@@ -115,6 +116,7 @@ public abstract class AbstractDecompressingPostProcessor implements MessagePostP
 	}
 
 	/**
+	 * Get the stream.
 	 * @param stream The output stream to write the compressed data to.
 	 * @return the decompressor input stream.
 	 * @throws IOException IOException
@@ -122,6 +124,7 @@ public abstract class AbstractDecompressingPostProcessor implements MessagePostP
 	protected abstract InputStream getDecompressorStream(InputStream stream) throws IOException;
 
 	/**
+	 * Get the encoding.
 	 * @return the content-encoding header.
 	 */
 	protected abstract String getEncoding();

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/AbstractDeflaterPostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/AbstractDeflaterPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.springframework.amqp.support.postprocessor;
 import java.util.zip.Deflater;
 
 /**
- * Base class for post processors based on {@link Deflater}
+ * Base class for post processors based on {@link Deflater}.
  * @author Gary Russell
  *
  * @since 1.4.2

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/DelegatingDecompressingPostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/DelegatingDecompressingPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ public class DelegatingDecompressingPostProcessor implements MessagePostProcesso
 	}
 
 	/**
+	 * Set the order.
 	 * @param order the order.
 	 * @see Ordered
 	 */

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/MessagePostProcessorUtils.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/MessagePostProcessorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import org.springframework.core.Ordered;
 import org.springframework.core.PriorityOrdered;
 
 /**
+ * Utilities for message post processors.
+ *
  * @author Gary Russell
  * @since 1.4.2
  *

--- a/spring-amqp/src/main/java/org/springframework/amqp/utils/MapBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/utils/MapBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.util.Map;
 
 /**
  * A {@code Builder} pattern implementation for a {@link Map}.
- *
+ * @param <B> the builder type.
+ * @param <K> the key type.
+ * @param <V> the value type.
  * @author Artem Bilan
  * @author Gary Russell
  * @since 2.0

--- a/spring-amqp/src/main/java/org/springframework/amqp/utils/SerializationUtils.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/utils/SerializationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ public final class SerializationUtils {
 	}
 
 	/**
+	 * Deserialize the bytes.
 	 * @param bytes a serialized object created
 	 * @return the result of deserializing the bytes
 	 */
@@ -71,6 +72,7 @@ public final class SerializationUtils {
 	}
 
 	/**
+	 * Deserialize the stream.
 	 * @param stream an object stream created from a serialized object
 	 * @return the result of deserializing the bytes
 	 */

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunning.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunning.java
@@ -70,14 +70,12 @@ import com.rabbitmq.http.client.Client;
  * set the environment variable {@value #BROKER_REQUIRED} to {@code true} and the
  * tests will fail fast.
  *
- * @see Assume
- * @see AssumptionViolatedException
- *
  * @author Dave Syer
  * @author Gary Russell
  *
  * @since 1.7
- *
+ * @see Assume
+ * @see AssumptionViolatedException
  */
 public final class BrokerRunning extends TestWatcher {
 
@@ -142,6 +140,7 @@ public final class BrokerRunning extends TestWatcher {
 	}
 
 	/**
+	 * @param queues the queues.
 	 * @return a new rule that assumes an existing broker with the management plugin with
 	 * the provided queues declared (and emptied if needed)..
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -656,6 +656,7 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 
 	/**
 	 * Base class for {@link ListenableFuture}s returned by {@link AsyncRabbitTemplate}.
+	 * @param <T> the type.
 	 * @since 1.6
 	 */
 	public abstract class RabbitFuture<T> extends SettableListenableFuture<T> {
@@ -767,6 +768,7 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 	/**
 	 * A {@link RabbitFuture} with a return type of the template's
 	 * generic parameter.
+	 * @param <C> the type.
 	 * @since 1.6
 	 */
 	public class RabbitConverterFuture<C> extends RabbitFuture<C> implements ListenableFuture<C> {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Argument.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Argument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import java.lang.annotation.Target;
 public @interface Argument {
 
 	/**
+	 * Return the argument name.
 	 * @return the argument name.
 	 */
 	String name();
@@ -45,6 +46,7 @@ public @interface Argument {
 	String value() default "";
 
 	/**
+	 * Return the argument value.
 	 * @return the type of the argument value.
 	 */
 	String type() default "java.lang.String";

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -755,7 +755,8 @@ public class RabbitListenerAnnotationBeanPostProcessor
 
 	/**
 	 * Resolve the specified value if possible.
-	 *
+	 * @param value the value to resolve.
+	 * @return the resolved value.
 	 * @see ConfigurableBeanFactory#resolveEmbeddedValue
 	 */
 	private String resolve(String value) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import org.springframework.util.backoff.FixedBackOff;
 
 /**
  * Base {@link RabbitListenerContainerFactory} for Spring's base container implementation.
- *
+ * @param <C> the container type.
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author Artem Bilan

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AdminParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AdminParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.StringUtils;
 
 /**
- * @author tomas.lukosius@opencredo.com
+ * Parser for &lt;rabbit:admin/&gt;.
+ * @author Tomas Lukosius
  * @since 1.0
  */
 class AdminParser extends AbstractSingleBeanDefinitionParser {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/NamespaceUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/NamespaceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,13 +82,11 @@ public abstract class NamespaceUtils {
 	 * The property name will be the camel-case equivalent of the lower case hyphen separated attribute (e.g. the
 	 * "foo-bar" attribute would match the "fooBar" property).
 	 *
-	 * @see Conventions#attributeNameToPropertyName(String)
-	 *
 	 * @param builder the bean definition builder to be configured
 	 * @param element the XML element where the attribute should be defined
 	 * @param attributeName the name of the attribute whose value will be set on the property
-	 *
 	 * @return true if defined.
+	 * @see Conventions#attributeNameToPropertyName(String)
 	 */
 	public static boolean setValueIfAttributeDefined(BeanDefinitionBuilder builder, Element element,
 			String attributeName) {
@@ -101,7 +99,6 @@ public abstract class NamespaceUtils {
 	 *
 	 * @param element the XML element where the attribute should be defined
 	 * @param attributeName the name of the attribute whose value will be used as a constructor argument
-	 *
 	 * @return true if defined.
 	 */
 	public static boolean isAttributeDefined(Element element, String attributeName) {
@@ -116,7 +113,6 @@ public abstract class NamespaceUtils {
 	 * @param builder the bean definition builder to be configured
 	 * @param element the XML element where the attribute should be defined
 	 * @param attributeName the name of the attribute whose value will be used as a constructor argument
-	 *
 	 * @return true if defined.
 	 */
 	public static boolean addConstructorArgValueIfAttributeDefined(BeanDefinitionBuilder builder, Element element,
@@ -220,15 +216,11 @@ public abstract class NamespaceUtils {
 	 * The property name will be the camel-case equivalent of the lower case hyphen separated attribute (e.g. the
 	 * "foo-bar" attribute would match the "fooBar" property).
 	 *
-	 * @see Conventions#attributeNameToPropertyName(String)
-	 *
 	 * @param builder the bean definition builder to be configured
 	 * @param element the XML element where the attribute should be defined
 	 * @param attributeName the name of the attribute whose value will be used as a bean reference to populate the
 	 * property
-	 *
 	 * @return true if defined.
-	 *
 	 * @see Conventions#attributeNameToPropertyName(String)
 	 */
 	public static boolean setReferenceIfAttributeDefined(BeanDefinitionBuilder builder, Element element,

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/QueueParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/QueueParser.java
@@ -39,7 +39,7 @@ public class QueueParser extends AbstractSingleBeanDefinitionParser {
 
 	private static final ThreadLocal<Element> CURRENT_ELEMENT = new ThreadLocal<>();
 
-	/**  Element OR attribute */
+	/**  Element OR attribute. */
 	private static final String ARGUMENTS = "queue-arguments";
 
 	private static final String DURABLE_ATTRIBUTE = "durable";

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilder.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,11 +59,12 @@ import org.springframework.util.Assert;
  *				.build();
  * </pre>
  *
+ * @param <T> The type of {@link MethodInterceptor} returned by the builder's {@link #build()} method.
+ *
  * @author James Carr
  * @author Gary Russell
  * @since 1.3
  *
- * @param <T> The type of {@link MethodInterceptor} returned by the builder's {@link #build()} method.
  */
 public abstract class RetryInterceptorBuilder<T extends MethodInterceptor> {
 
@@ -200,6 +201,9 @@ public abstract class RetryInterceptorBuilder<T extends MethodInterceptor> {
 	public abstract T build();
 
 
+	/**
+	 * Builder for a stateful interceptor.
+	 */
 	public static final class StatefulRetryInterceptorBuilder extends RetryInterceptorBuilder<StatefulRetryOperationsInterceptor> {
 
 		private final StatefulRetryOperationsInterceptorFactoryBean factoryBean =
@@ -287,6 +291,9 @@ public abstract class RetryInterceptorBuilder<T extends MethodInterceptor> {
 	}
 
 
+	/**
+	 * Builder for a stateless interceptor.
+	 */
 	public static final class StatelessRetryInterceptorBuilder
 			extends RetryInterceptorBuilder<RetryOperationsInterceptor> {
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatefulRetryOperationsInterceptorFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatefulRetryOperationsInterceptorFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,11 +39,11 @@ import org.springframework.retry.support.RetryTemplate;
  * processed using a {@link MessageRecoverer} if one is provided, in a new transaction. If a recoverer is not provided
  * the message will be logged and dropped.
  *
- * @see RetryOperations#execute(org.springframework.retry.RetryCallback, org.springframework.retry.RecoveryCallback,
- * org.springframework.retry.RetryState)
- *
  * @author Dave Syer
  * @author Gary Russell
+ *
+ * @see RetryOperations#execute(org.springframework.retry.RetryCallback, org.springframework.retry.RecoveryCallback,
+ * org.springframework.retry.RetryState)
  *
  */
 public class StatefulRetryOperationsInterceptorFactoryBean extends AbstractRetryOperationsInterceptorFactoryBean {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptorFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptorFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,10 @@ import org.springframework.retry.support.RetryTemplate;
  * transaction (in which case no exception is propagated). If a recoverer is not provided the exception will be
  * propagated and the message may be redelivered if the channel is transactional.
  *
- * @see RetryOperations#execute(org.springframework.retry.RetryCallback, org.springframework.retry.RecoveryCallback)
- *
  * @author Dave Syer
  * @author Gary Russell
  *
+ * @see RetryOperations#execute(org.springframework.retry.RetryCallback, org.springframework.retry.RecoveryCallback)
  */
 public class StatelessRetryOperationsInterceptorFactoryBean extends AbstractRetryOperationsInterceptorFactoryBean {
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -148,8 +148,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	/**
 	 * @param uri the URI
-	 * @see com.rabbitmq.client.ConnectionFactory#setUri(URI)
 	 * @since 1.5
+	 * @see com.rabbitmq.client.ConnectionFactory#setUri(URI)
 	 */
 	public void setUri(URI uri) {
 		try {
@@ -162,8 +162,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	/**
 	 * @param uri the URI
-	 * @see com.rabbitmq.client.ConnectionFactory#setUri(String)
 	 * @since 1.5
+	 * @see com.rabbitmq.client.ConnectionFactory#setUri(String)
 	 */
 	public void setUri(String uri) {
 		try {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,9 +192,9 @@ public abstract class AbstractRoutingConnectionFactory implements ConnectionFact
 	}
 
 	/**
-	 * Adds the given {@link ConnectionFactory} and associates it with the given lookup key
-	 * @param key the lookup key
-	 * @param connectionFactory the {@link ConnectionFactory}
+	 * Adds the given {@link ConnectionFactory} and associates it with the given lookup key.
+	 * @param key the lookup key.
+	 * @param connectionFactory the {@link ConnectionFactory}.
 	 */
 	protected void addTargetConnectionFactory(Object key, ConnectionFactory connectionFactory) {
 		this.targetConnectionFactories.put(key, connectionFactory);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -109,13 +109,16 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	private final ChannelCachingConnectionProxy connection = new ChannelCachingConnectionProxy(null);
 
+	/**
+	 * The cache mode.
+	 */
 	public enum CacheMode {
 		/**
-		 * Cache channels - single connection
+		 * Cache channels - single connection.
 		 */
 		CHANNEL,
 		/**
-		 * Cache connections and channels within each connection
+		 * Cache connections and channels within each connection.
 		 */
 		CONNECTION
 	}
@@ -172,7 +175,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	private volatile ConditionalExceptionLogger closeExceptionLogger = new DefaultChannelCloseLogger();
 
-	/** Synchronization monitor for the shared Connection */
+	/** Synchronization monitor for the shared Connection. */
 	private final Object connectionMonitor = new Object();
 
 	/** Executor used for deferred close if no explicit executor set. */
@@ -324,8 +327,8 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	 * <p>
 	 * Since 1.5.5, also applies to getting a connection when the cache mode is CONNECTION.
 	 * @param channelCheckoutTimeout the timeout in milliseconds; default 0 (channel limiting not enabled).
-	 * @see #setConnectionLimit(int)
 	 * @since 1.4.2
+	 * @see #setConnectionLimit(int)
 	 */
 	public void setChannelCheckoutTimeout(long channelCheckoutTimeout) {
 		this.channelCheckoutTimeout = channelCheckoutTimeout;
@@ -727,9 +730,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	 * Defaults to phase {@link Integer#MIN_VALUE - 1000} so the factory is
 	 * stopped in a very late phase, allowing other beans to use the connection
 	 * to clean up.
-	 * @see #getPhase()
 	 * @param phase the phase.
 	 * @since 1.5.3
+	 * @see #getPhase()
 	 */
 	public void setPhase(int phase) {
 		this.phase = phase;
@@ -1015,8 +1018,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		}
 
 		/**
-		 * GUARDED by channelList
-		 * @param proxy the channel to close
+		 * GUARDED by channelList.
+		 * @param proxy the channel to close.
+		 * @throws Exception an exception.
 		 */
 		private void logicalClose(ChannelProxy proxy) throws Exception {
 			if (this.target == null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitAccessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import com.rabbitmq.client.Channel;
  */
 public abstract class RabbitAccessor implements InitializingBean {
 
-	/** Logger available to subclasses */
+	/** Logger available to subclasses. */
 	protected final Log logger = LogFactory.getLog(getClass()); // NOSONAR
 
 	private volatile ConnectionFactory connectionFactory;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -316,7 +316,7 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	/**
 	 * Get the key store type - this defaults to PKCS12 if not overridden by
-	 * {@link #setSslPropertiesLocation(Resource)} or {@link #setKeyStoreType}
+	 * {@link #setSslPropertiesLocation(Resource)} or {@link #setKeyStoreType}.
 	 * @return the key store type.
 	 * @since 1.6.2
 	 */
@@ -336,8 +336,8 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	 * Set the key store type - overrides
 	 * the property in {@link #setSslPropertiesLocation(Resource)}.
 	 * @param keyStoreType the key store type.
-	 * @see java.security.KeyStore#getInstance(String)
 	 * @since 1.6.2
+	 * @see java.security.KeyStore#getInstance(String)
 	 */
 	public void setKeyStoreType(String keyStoreType) {
 		this.keyStoreType = keyStoreType;
@@ -345,7 +345,7 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	/**
 	 * Get the trust store type - this defaults to JKS if not overridden by
-	 * {@link #setSslPropertiesLocation(Resource)} or {@link #setTrustStoreType}
+	 * {@link #setSslPropertiesLocation(Resource)} or {@link #setTrustStoreType}.
 	 * @return the trust store type.
 	 * @since 1.6.2
 	 */
@@ -365,8 +365,8 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	 * Set the trust store type - overrides
 	 * the property in {@link #setSslPropertiesLocation(Resource)}.
 	 * @param trustStoreType the trust store type.
-	 * @see java.security.KeyStore#getInstance(String)
 	 * @since 1.6.2
+	 * @see java.security.KeyStore#getInstance(String)
 	 */
 	public void setTrustStoreType(String trustStoreType) {
 		this.trustStoreType = trustStoreType;
@@ -380,8 +380,8 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	 * Set the secure random to use when initializing the {@link SSLContext}.
 	 * Defaults to null, in which case the default implementation is used.
 	 * @param secureRandom the secure random.
-	 * @see SSLContext#init(KeyManager[], TrustManager[], SecureRandom)
 	 * @since 1.6.4
+	 * @see SSLContext#init(KeyManager[], TrustManager[], SecureRandom)
 	 */
 	public void setSecureRandom(SecureRandom secureRandom) {
 		this.secureRandom = secureRandom;
@@ -591,8 +591,8 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	/**
 	 * @param channelRpcTimeout continuation timeout for RPC calls in channels
-	 * @see com.rabbitmq.client.ConnectionFactory#setChannelRpcTimeout(int)
 	 * @since 2.0
+	 * @see com.rabbitmq.client.ConnectionFactory#setChannelRpcTimeout(int)
 	 */
 	public void setChannelRpcTimeout(int channelRpcTimeout) {
 		this.connectionFactory.setChannelRpcTimeout(channelRpcTimeout);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ package org.springframework.amqp.rabbit.connection;
 public interface RoutingConnectionFactory {
 
 	/**
-	 * Returns the {@link ConnectionFactory} bound to given lookup key, or null if one does not exist
+	 * Returns the {@link ConnectionFactory} bound to given lookup key, or null if one does not exist.
 	 * @param key The lookup key to which the {@link ConnectionFactory} is bound
 	 * @return the {@link ConnectionFactory} bound to the given lookup key, or null if one does not exist
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/SimpleResourceHolder.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/SimpleResourceHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,8 @@ public final class SimpleResourceHolder {
 
 	/**
 	 * Actually check the value of the resource that is bound for the given key.
+	 * @param actualKey the key.
+	 * @return the resource object.
 	 */
 	private static Object doGet(Object actualKey) {
 		Map<Object, Object> map = resources.get();

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/ChannelCallback.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/ChannelCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package org.springframework.amqp.rabbit.core;
 import com.rabbitmq.client.Channel;
 
 /**
- * Basic callback for use in RabbitTemplate
+ * Basic callback for use in RabbitTemplate.
+ * @param <T> the return type.
  * @author Mark Fisher
  * @author Gary Russell
  */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -53,7 +53,7 @@ import com.rabbitmq.client.AMQP.Queue.DeclareOk;
 import com.rabbitmq.client.Channel;
 
 /**
- * RabbitMQ implementation of portable AMQP administrative operations for AMQP &gt;= 0.9.1
+ * RabbitMQ implementation of portable AMQP administrative operations for AMQP &gt;= 0.9.1.
  *
  * @author Mark Pollack
  * @author Mark Fisher
@@ -90,7 +90,7 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 
 	private static final String DELAYED_MESSAGE_EXCHANGE = "x-delayed-message";
 
-	/** Logger available to subclasses */
+	/** Logger available to subclasses. */
 	protected final Log logger = LogFactory.getLog(getClass());
 
 	private final RabbitTemplate rabbitTemplate;
@@ -469,6 +469,7 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 	/**
 	 * Remove any instances that should not be declared by this admin.
 	 * @param declarables the collection of {@link Declarable}s.
+	 * @param <T> the declarable type.
 	 * @return a new collection containing {@link Declarable}s that should be declared by this
 	 * admin.
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitGatewaySupport.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitGatewaySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import org.springframework.beans.factory.InitializingBean;
  */
 public class RabbitGatewaySupport implements InitializingBean {
 
-	/** Logger available to subclasses */
+	/** Logger available to subclasses. */
 	protected final Log logger = LogFactory.getLog(getClass());
 
 	private RabbitOperations rabbitOperations;
@@ -49,10 +49,9 @@ public class RabbitGatewaySupport implements InitializingBean {
 	/**
 	 * Set the Rabbit connection factory to be used by the gateway.
 	 * Will automatically create a RabbitTemplate for the given ConnectionFactory.
+	 * @param connectionFactory The connection factory.
 	 * @see #createRabbitTemplate
 	 * @see #setConnectionFactory(org.springframework.amqp.rabbit.connection.ConnectionFactory)
-	 *
-	 * @param connectionFactory The connection factory.
 	 */
 	public final void setConnectionFactory(ConnectionFactory connectionFactory) {
 		this.rabbitOperations = createRabbitTemplate(connectionFactory);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitMessageOperations.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitMessageOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ public interface RabbitMessageOperations extends MessageSendingOperations<String
 	 * @param exchange the name of the exchange
 	 * @param routingKey the routing key
 	 * @param message the message to send
+	 * @throws MessagingException a messaging exception.
 	 */
 	void send(String exchange, String routingKey, Message<?> message) throws MessagingException;
 
@@ -53,6 +54,7 @@ public interface RabbitMessageOperations extends MessageSendingOperations<String
 	 * @param exchange the name of the exchange
 	 * @param routingKey the routing key
 	 * @param payload the Object to use as payload
+	 * @throws MessagingException a messaging exception.
 	 */
 	void convertAndSend(String exchange, String routingKey, Object payload) throws MessagingException;
 
@@ -65,6 +67,7 @@ public interface RabbitMessageOperations extends MessageSendingOperations<String
 	 * @param routingKey the routing key
 	 * @param payload the Object to use as payload
 	 * @param headers headers for the message to send
+	 * @throws MessagingException a messaging exception.
 	 */
 	void convertAndSend(String exchange, String routingKey, Object payload, Map<String, Object> headers)
 			throws MessagingException;
@@ -79,6 +82,7 @@ public interface RabbitMessageOperations extends MessageSendingOperations<String
 	 * @param routingKey the routing key
 	 * @param payload the Object to use as payload
 	 * @param postProcessor the post processor to apply to the message
+	 * @throws MessagingException a messaging exception.
 	 */
 	void convertAndSend(String exchange, String routingKey, Object payload, MessagePostProcessor postProcessor)
 			throws MessagingException;
@@ -94,18 +98,20 @@ public interface RabbitMessageOperations extends MessageSendingOperations<String
 	 * @param payload the Object to use as payload
 	 * @param headers headers for the message to send
 	 * @param postProcessor the post processor to apply to the message
+	 * @throws MessagingException a messaging exception.
 	 */
 	void convertAndSend(String exchange, String routingKey, Object payload, Map<String,
 			Object> headers, MessagePostProcessor postProcessor) throws MessagingException;
 
 	/**
 	 * Send a request message to a specific exchange with a specific routing key and
-	 * wait for the reply
+	 * wait for the reply.
 	 * @param exchange the name of the exchange
 	 * @param routingKey the routing key
 	 * @param requestMessage the message to send
 	 * @return the reply, possibly {@code null} if the message could not be received,
 	 * for example due to a timeout
+	 * @throws MessagingException a messaging exception.
 	 */
 	Message<?> sendAndReceive(String exchange, String routingKey, Message<?> requestMessage) throws MessagingException;
 
@@ -121,6 +127,7 @@ public interface RabbitMessageOperations extends MessageSendingOperations<String
 	 * @param <T> return type
 	 * @return the payload of the reply message, possibly {@code null} if the message
 	 * could not be received, for example due to a timeout
+	 * @throws MessagingException a messaging exception.
 	 */
 	<T> T convertSendAndReceive(String exchange, String routingKey, Object request, Class<T> targetClass)
 			throws MessagingException;
@@ -139,6 +146,7 @@ public interface RabbitMessageOperations extends MessageSendingOperations<String
 	 * @param <T> return type
 	 * @return the payload of the reply message, possibly {@code null} if the message
 	 * could not be received, for example due to a timeout
+	 * @throws MessagingException a messaging exception.
 	 */
 	<T> T convertSendAndReceive(String exchange, String routingKey, Object request, Map<String, Object> headers,
 			Class<T> targetClass) throws MessagingException;
@@ -157,6 +165,7 @@ public interface RabbitMessageOperations extends MessageSendingOperations<String
 	 * @param <T> return type
 	 * @return the payload of the reply message, possibly {@code null} if the message
 	 * could not be received, for example due to a timeout
+	 * @throws MessagingException a messaging exception.
 	 */
 	<T> T convertSendAndReceive(String exchange, String routingKey, Object request, Class<T> targetClass,
 			MessagePostProcessor requestPostProcessor) throws MessagingException;
@@ -177,6 +186,7 @@ public interface RabbitMessageOperations extends MessageSendingOperations<String
 	 * @param <T> return type
 	 * @return the payload of the reply message, possibly {@code null} if the message
 	 * could not be received, for example due to a timeout
+	 * @throws MessagingException a messaging exception.
 	 */
 	<T> T convertSendAndReceive(String exchange, String routingKey, Object request, Map<String, Object> headers,
 			Class<T> targetClass, MessagePostProcessor requestPostProcessor) throws MessagingException;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -142,7 +142,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 
 	private static final String RETURN_CORRELATION_KEY = "spring_request_return_correlation";
 
-	/** Alias for amq.direct default exchange */
+	/** Alias for amq.direct default exchange. */
 	private static final String DEFAULT_EXCHANGE = "";
 
 	private static final String DEFAULT_ROUTING_KEY = "";
@@ -564,8 +564,8 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	 * Set a {@link CorrelationDataPostProcessor} to be invoked before publishing a message.
 	 * Correlation data is used to correlate publisher confirms.
 	 * @param correlationDataPostProcessor the post processor.
-	 * @see #setConfirmCallback(ConfirmCallback)
 	 * @since 1.6.7
+	 * @see #setConfirmCallback(ConfirmCallback)
 	 */
 	public void setCorrelationDataPostProcessor(CorrelationDataPostProcessor correlationDataPostProcessor) {
 		this.correlationDataPostProcessor = correlationDataPostProcessor;
@@ -1780,7 +1780,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	 * @param message The Message to send.
 	 * @param mandatory The mandatory flag.
 	 * @param correlationData The correlation data.
-	 * @throws IOException If thrown by RabbitMQ API methods
+	 * @throws Exception If thrown by RabbitMQ API methods
 	 */
 	public void doSend(Channel channel, String exchange, String routingKey, Message message,
 			boolean mandatory, CorrelationData correlationData) throws Exception {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -629,8 +629,8 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	/**
 	 * Return the default requeue rejected.
 	 * @return the boolean.
-	 * @see #setDefaultRequeueRejected(boolean)
 	 * @since 2.0
+	 * @see #setDefaultRequeueRejected(boolean)
 	 */
 	protected boolean isDefaultRequeueRejected() {
 		return this.defaultRequeueRejected;
@@ -1579,6 +1579,9 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 		}
 	}
 
+	/**
+	 * A runtime exception to wrap a {@link Throwable}.
+	 */
 	@SuppressWarnings("serial")
 	protected static final class WrappedTransactionException extends RuntimeException {
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.springframework.expression.BeanResolver;
 import org.springframework.util.Assert;
 
 /**
- * Base model for a Rabbit listener endpoint
+ * Base model for a Rabbit listener endpoint.
  *
  * @author Stephane Nicoll
  * @author Gary Russell

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ActiveObjectCounter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ActiveObjectCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 /**
+ * A mechanism to keep track of active objects.
+ * @param <T> the object type.
  * @author Dave Syer
  *
  */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -258,8 +258,8 @@ public class BlockingQueueConsumer {
 	/**
 	 * Set the number of retries after passive queue declaration fails.
 	 * @param declarationRetries The number of retries, default 3.
-	 * @see #setFailedDeclarationRetryInterval(long)
 	 * @since 1.3.9
+	 * @see #setFailedDeclarationRetryInterval(long)
 	 */
 	public void setDeclarationRetries(int declarationRetries) {
 		this.declarationRetries = declarationRetries;
@@ -268,8 +268,8 @@ public class BlockingQueueConsumer {
 	/**
 	 * Set the interval between passive queue declaration attempts in milliseconds.
 	 * @param failedDeclarationRetryInterval the interval, default 5000.
-	 * @see #setDeclarationRetries(int)
 	 * @since 1.3.9
+	 * @see #setDeclarationRetries(int)
 	 */
 	public void setFailedDeclarationRetryInterval(long failedDeclarationRetryInterval) {
 		this.failedDeclarationRetryInterval = failedDeclarationRetryInterval;
@@ -375,6 +375,9 @@ public class BlockingQueueConsumer {
 	 * If this is a non-POISON non-null delivery simply return it.
 	 * If this is POISON we are in shutdown mode, throw
 	 * shutdown. If delivery is null, we may be in shutdown mode. Check and see.
+	 * @param delivery the delivered message contents.
+	 * @return A message built from the contents.
+	 * @throws InterruptedException if the thread is interrupted.
 	 */
 	private Message handle(Delivery delivery) throws InterruptedException {
 		if ((delivery == null && this.shutdown != null)) {
@@ -698,8 +701,8 @@ public class BlockingQueueConsumer {
 	/**
 	 * Perform a commit or message acknowledgement, as appropriate.
 	 * @param locallyTransacted Whether the channel is locally transacted.
-	 * @throws IOException Any IOException.
 	 * @return true if at least one delivery tag exists.
+	 * @throws IOException Any IOException.
 	 */
 	public boolean commitIfNecessary(boolean locallyTransacted) throws IOException {
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,7 @@ public class ConditionalRejectingErrorHandler implements ErrorHandler {
 	}
 
 	/**
+	 * @param t a {@link Throwable}.
 	 * @return true if the cause chain already contains an
 	 * {@link AmqpRejectAndDontRequeueException}.
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -579,7 +579,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
-	 * Must hold this.consumersMonitor
+	 * Must hold this.consumersMonitor.
 	 */
 	private void actualShutDown() {
 		Assert.state(getTaskExecutor() != null, "Cannot shut down if not initialized");
@@ -619,6 +619,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		// default empty
 	}
 
+	/**
+	 * The consumer object.
+	 */
 	final class SimpleConsumer extends DefaultConsumer {
 
 		private final Log logger = DirectMessageListenerContainer.this.logger;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -219,11 +219,11 @@ public class DirectReplyToMessageListenerContainer extends DirectMessageListener
 	 */
 	public static class ChannelHolder {
 
-		public final Channel channel;
+		private final Channel channel;
 
-		public final int consumerEpoch;
+		private final int consumerEpoch;
 
-		public ChannelHolder(Channel channel, int consumerEpoch) {
+		ChannelHolder(Channel channel, int consumerEpoch) {
 			this.channel = channel;
 			this.consumerEpoch = consumerEpoch;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ package org.springframework.amqp.rabbit.listener;
 /**
  * Factory of {@link MessageListenerContainer} based on a
  * {@link RabbitListenerEndpoint} definition.
- *
+ * @param <C> the container type.
  * @author Stephane Nicoll
  * @author Gary Russell
  * @since 1.4

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
@@ -101,8 +101,8 @@ public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLife
 	/**
 	 * Return the ids of the managed {@link MessageListenerContainer} instance(s).
 	 * @return the ids.
-	 * @see #getListenerContainer(String)
 	 * @since 1.5.2
+	 * @see #getListenerContainer(String)
 	 */
 	public Set<String> getListenerContainerIds() {
 		return Collections.unmodifiableSet(this.listenerContainers.keySet());
@@ -272,6 +272,7 @@ public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLife
 	/**
 	 * Start the specified {@link MessageListenerContainer} if it should be started
 	 * on startup or when start is called explicitly after startup.
+	 * @param listenerContainer the container.
 	 * @see MessageListenerContainer#isAutoStartup()
 	 */
 	private void startIfNecessary(MessageListenerContainer listenerContainer) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -371,8 +371,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	/**
 	 * Set the number of retries after passive queue declaration fails.
 	 * @param declarationRetries The number of retries, default 3.
-	 * @see #setFailedDeclarationRetryInterval(long)
 	 * @since 1.3.9
+	 * @see #setFailedDeclarationRetryInterval(long)
 	 */
 	public void setDeclarationRetries(int declarationRetries) {
 		this.declarationRetries = declarationRetries;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ import com.rabbitmq.client.Channel;
 
 /**
  * An abstract {@link MessageListener} adapter providing the necessary infrastructure
- * to extract the payload of a {@link Message}
+ * to extract the payload of a {@link Message}.
  *
  * @author Stephane Nicoll
  * @author Gary Russell
@@ -67,7 +67,7 @@ public abstract class AbstractAdaptableMessageListener implements MessageListene
 
 	private static final ParserContext PARSER_CONTEXT = new TemplateParserContext("!{", "}");
 
-	/** Logger available to subclasses */
+	/** Logger available to subclasses. */
 	protected final Log logger = LogFactory.getLog(getClass());
 
 	private final StandardEvaluationContext evalContext = new StandardEvaluationContext();
@@ -437,6 +437,9 @@ public abstract class AbstractAdaptableMessageListener implements MessageListene
 	protected void postProcessChannel(Channel channel, Message response) throws Exception {
 	}
 
+	/**
+	 * Result holder.
+	 */
 	public static final class ResultHolder {
 
 		private final Object result;
@@ -455,6 +458,9 @@ public abstract class AbstractAdaptableMessageListener implements MessageListene
 
 	}
 
+	/**
+	 * Root object for reply expression evaluation.
+	 */
 	public static final class ReplyExpressionRoot {
 
 		private final Message request;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
@@ -98,9 +98,9 @@ public class DelegatingInvocableHandler {
 	 * Invoke the method with the given message.
 	 * @param message the message.
 	 * @param providedArgs additional arguments.
+	 * @return the result of the invocation.
 	 * @throws Exception raised if no suitable argument resolver can be found,
 	 * or the method raised an exception.
-	 * @return the result of the invocation.
 	 */
 	public Object invoke(Message<?> message, Object... providedArgs) throws Exception {
 		Class<? extends Object> payloadClass = message.getPayload().getClass();

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -171,6 +171,10 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	/**
 	 * Invoke the handler, wrapping any exception to a {@link ListenerExecutionFailedException}
 	 * with a dedicated error message.
+	 * @param amqpMessage the raw message.
+	 * @param channel the channel.
+	 * @param message the messaging message.
+	 * @return the result of invoking the handler.
 	 */
 	private Object invokeHandler(org.springframework.amqp.core.Message amqpMessage, Channel channel,
 			Message<?> message) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/ReplyingMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/ReplyingMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.amqp.rabbit.listener.adapter;
 /**
  * A Message Listener that returns a reply - intended for lambda use in a
  * {@link MessageListenerAdapter}.
+ * @param <T> the request type.
+ * @param <R> the reply type.
  *
  * @author Gary Russell
  * @since 2.0

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,12 +86,12 @@ public class AmqpAppender extends AbstractAppender {
 	public static final String APPLICATION_ID = "applicationId";
 
 	/**
-	 * Key name for the logger category name in the message properties
+	 * Key name for the logger category name in the message properties.
 	 */
 	public static final String CATEGORY_NAME = "categoryName";
 
 	/**
-	 * Key name for the logger level name in the message properties
+	 * Key name for the logger level name in the message properties.
 	 */
 	public static final String CATEGORY_LEVEL = "level";
 
@@ -366,6 +366,9 @@ public class AmqpAppender extends AbstractAppender {
 
 	}
 
+	/**
+	 * Manager class for the appender.
+	 */
 	protected static class AmqpManager extends AbstractManager {
 
 		/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,8 +89,8 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 	}
 
 	/**
-	 * @see #errorRoutingKeyPrefix(String)
 	 * @param errorRoutingKeyPrefix The prefix (default "error.").
+	 * @see #errorRoutingKeyPrefix(String)
 	 */
 	public void setErrorRoutingKeyPrefix(String errorRoutingKeyPrefix) {
 		Assert.notNull(errorRoutingKeyPrefix, "'errorRoutingKeyPrefix' cannot be null");

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
 		this.convertLongLongStrings = convertLongLongStrings;
 	}
 
+	@Override
 	public MessageProperties toMessageProperties(final BasicProperties source, final Envelope envelope,
 			final String charset) {
 		MessageProperties target = new MessageProperties();
@@ -132,6 +133,7 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
 		return target;
 	}
 
+	@Override
 	public BasicProperties fromMessageProperties(final MessageProperties source, final String charset) {
 		BasicProperties.Builder target = new BasicProperties.Builder();
 		target.headers(this.convertHeadersIfNecessary(source.getHeaders()))
@@ -175,6 +177,8 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
 	 * Converts a header value to a String if the value type is unsupported by AMQP, also handling values
 	 * nested inside Lists or Maps.
 	 * <p> {@code null} values are passed through, although Rabbit client will throw an IllegalArgumentException.
+	 * @param value the value.
+	 * @return the converted value.
 	 */
 	private Object convertHeaderValueIfNecessary(Object value) {
 		boolean valid = (value instanceof String) || (value instanceof byte[]) || (value instanceof Boolean)
@@ -209,6 +213,9 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
 	 * length-driven threshold. If the length is {@link #longStringLimit} bytes or less, a
 	 * String will be returned, otherwise a DataInputStream is returned or the {@link LongString}
 	 * is returned unconverted if {@link #convertLongLongStrings} is true.
+	 * @param longString the long string.
+	 * @param charset the charset.
+	 * @return the converted string.
 	 */
 	private Object convertLongString(LongString longString, String charset) {
 		try {
@@ -227,6 +234,9 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
 	/**
 	 * Converts a LongString value using {@link #convertLongString(LongString, String)}, also handling values
 	 * nested in Lists or Maps.
+	 * @param value the value.
+	 * @param charset the charset.
+	 * @return the converted string.
 	 */
 	private Object convertLongStringIfNecessary(Object value, String charset) {
 		if (value instanceof LongString) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannel.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public interface PublisherCallbackChannel extends Channel {
 	String RETURN_CORRELATION_KEY = "spring_listener_return_correlation";
 
 	/**
-	 * Adds a {@link Listener}
+	 * Adds a {@link Listener}.
 	 * @param listener The Listener.
 	 */
 	void addListener(Listener listener);
@@ -50,7 +50,7 @@ public interface PublisherCallbackChannel extends Channel {
 	Collection<PendingConfirm> expire(Listener listener, long cutoffTime);
 
     /**
-     * Get the {@link PendingConfirm}s count
+     * Get the {@link PendingConfirm}s count.
      * @param listener the listener.
      * @return Count of the pending confirms.
      */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,7 @@ public class PublisherCallbackChannelImpl
 	}
 
 	/**
-	 * Added to the 3.3.x client
+	 * Added to the 3.3.x client.
 	 * @since 1.3.3
 	 * @deprecated in the 3.5.3 client
 	 */
@@ -189,7 +189,7 @@ public class PublisherCallbackChannelImpl
 	}
 
 	/**
-	 * Added to the 3.3.x client
+	 * Added to the 3.3.x client.
 	 * @since 1.3.3
 	 */
 	@Override
@@ -421,7 +421,7 @@ public class PublisherCallbackChannelImpl
 	}
 
 	/**
-	 * Added to the 3.3.x client
+	 * Added to the 3.3.x client.
 	 * @since 1.3.3
 	 */
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/ValueExpression.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/ValueExpression.java
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  */
 public class ValueExpression<V> implements Expression {
 
-	/** Fixed value of this expression */
+	/** Fixed value of this expression. */
 	private final V value;
 
 	private final Class<V> aClass;

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -5,6 +5,9 @@
 <suppressions>
 	<suppress files="package-info\.java" checks=".*" />
 	<suppress files="[\\/]test[\\/]" checks="RequireThis" />
-	<suppress files="[\\/]test[\\/]" checks="Javadoc*" />
+	<suppress files="[\\/]test[\\/]" checks="Javadoc.*" />
+	<suppress files="[\\/]test[\\/]" checks="NonEmptyAtclauseDescription" />
+	<suppress files="EnableRabbit" checks="JavadocStyle" />
+	<suppress files="logback[\\/]AmqpAppender" checks="JavadocStyle" />
 	<suppress files="CachingConnectionFactory" checks="FinalClass" /> <!-- Tests spy -->
 </suppressions>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -91,31 +91,31 @@
 		</module>
 
 		<!-- Javadoc Comments -->
-<!-- 		<module name="JavadocType"> -->
-<!-- 			<property name="scope" value="package"/> -->
-<!-- 			<property name="authorFormat" value=".+\s.+"/> -->
-<!-- 		</module> -->
-<!-- 		<module name="JavadocMethod"> -->
-<!-- 			<property name="allowMissingJavadoc" value="true" /> -->
-<!-- 		</module> -->
-<!-- 		<module name="JavadocVariable"> -->
-<!-- 			<property name="scope" value="public"/> -->
-<!-- 		</module> -->
-<!-- 		<module name="JavadocStyle"> -->
-<!-- 			<property name="checkEmptyJavadoc" value="true"/> -->
-<!-- 		</module> -->
-<!-- 		<module name="NonEmptyAtclauseDescription" /> -->
-<!-- 		<module name="JavadocTagContinuationIndentation"> -->
-<!-- 			<property name="offset" value="0"/> -->
-<!-- 		</module> -->
-<!-- 		<module name="AtclauseOrder"> -->
-<!-- 			<property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF"/> -->
-<!--     		<property name="tagOrder" value="@param, @author, @since, @see, @version, @serial, @deprecated"/> -->
-<!-- 		</module> -->
-<!--  		<module name="AtclauseOrder"> -->
-<!-- 			<property name="target" value="METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/> -->
-<!--     		<property name="tagOrder" value="@param, @return, @throws, @since, @deprecated, @see"/> -->
-<!-- 		</module> -->
+		<module name="JavadocType">
+			<property name="scope" value="package"/>
+		</module>
+		<module name="JavadocMethod">
+			<property name="allowMissingJavadoc" value="true" />
+		</module>
+		<module name="JavadocVariable">
+			<property name="scope" value="public"/>
+			<property name="ignoreNamePattern" value="[A-Z_0-9]*"/>
+		</module>
+		<module name="JavadocStyle">
+			<property name="checkEmptyJavadoc" value="false"/>
+		</module>
+		<module name="NonEmptyAtclauseDescription" />
+		<module name="JavadocTagContinuationIndentation">
+			<property name="offset" value="0"/>
+		</module>
+		<module name="AtclauseOrder">
+			<property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF"/>
+    		<property name="tagOrder" value="@param, @author, @since, @see, @version, @serial, @deprecated"/>
+		</module>
+ 		<module name="AtclauseOrder">
+			<property name="target" value="METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+    		<property name="tagOrder" value="@param, @return, @throws, @since, @deprecated, @see"/>
+		</module>
 
 		<!-- Miscellaneous -->
 		<module name="CommentsIndentation">


### PR DESCRIPTION
@artembilan - you might not want to bother looking at all the changes but you should look at the checkstyle config file changes.

I had to suppress `JavaDocStyle` for two classes because `<bean/>` tags within `<pre/>` confused checkstyle.