### PR TITLE
support anonymous queues in @RabbitListener queuesToDeclare

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -495,8 +495,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 						"@RabbitListener can have only one of 'queues', 'queuesToDeclare', or 'bindings'");
 			}
 			for (int i = 0; i < queuesToDeclare.length; i++) {
-				declareQueue(queuesToDeclare[i]);
-				resolveAsString(resolveExpression(queuesToDeclare[i].value()), result);
+				result.add(declareQueue(queuesToDeclare[i]));
 			}
 		}
 		if (bindings.length > 0) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.amqp.rabbit.annotation;
 
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -215,6 +216,14 @@ public class EnableRabbitIntegrationTests {
 	@Test
 	public void autoSimpleDeclare() {
 		assertEquals("FOOX", rabbitTemplate.convertSendAndReceive("test.simple.declare", "foo"));
+	}
+
+	@Test
+	public void autoSimpleDeclareAnonymousQueue() {
+		final SimpleMessageListenerContainer container = (SimpleMessageListenerContainer) registry
+				.getListenerContainer("anonymousQueue575");
+		assertThat(container.getQueueNames(), arrayWithSize(1));
+		assertEquals("viaAnonymous:foo", rabbitTemplate.convertSendAndReceive(container.getQueueNames()[0], "foo"));
 	}
 
 	@Test
@@ -674,6 +683,11 @@ public class EnableRabbitIntegrationTests {
 		@RabbitListener(queuesToDeclare = @Queue(name = "${jjjj:test.simple.declare}", durable = "true"))
 		public String handleWithSimpleDeclare(String foo) {
 			return foo.toUpperCase() + "X";
+		}
+
+		@RabbitListener(queuesToDeclare = @Queue, id = "anonymousQueue575")
+		public String handleWithAnonymousQueueToDeclare(String data) throws Exception {
+			return "viaAnonymous:" + data;
 		}
 
 		@RabbitListener(bindings = @QueueBinding(


### PR DESCRIPTION
This code seems to be inconsistent:
* declareQueue() already calls resolveExpression(), no need to resolve it another time
* if queue name is empty a random name is generated and returned - which is ignored

That's why I suggest this change, it allows doing code like this (without this change it fails as listener container is trying to use an empty queue name).

```java
@RabbitListener(queuesToDeclare = @Queue)
public void onMessage(@Payload String message) {}
```

WDYT?

Btw, a good question for this setup would be obtaining this queue name, the following works, but is not that convenient:
```java
@RabbitListener(... group = "foo")
...
final List<?> foo = applicationContext.getBean("foo", List.class);
final String fooQueue = ((AbstractMessageListenerContainer) foo.get(0)).getQueueNames()[0];
```

