### PR TITLE
use AnonymousQueue.Base64UrlNamingStrategy in RabbitListenerAnnotationBeanPostProcessor

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AnonymousQueue.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AnonymousQueue.java
@@ -96,7 +96,7 @@ public class AnonymousQueue extends Queue {
 		/**
 		 * The default instance - using {@code spring.gen-} as the prefix.
 		 */
-		public static Base64UrlNamingStrategy DEFAULT = new Base64UrlNamingStrategy();
+		public static final Base64UrlNamingStrategy DEFAULT = new Base64UrlNamingStrategy();
 
 		private final String prefix;
 
@@ -140,7 +140,7 @@ public class AnonymousQueue extends Queue {
 		/**
 		 * The default instance.
 		 */
-		public static UUIDNamingStrategy DEFAULT = new UUIDNamingStrategy();
+		public static final UUIDNamingStrategy DEFAULT = new UUIDNamingStrategy();
 
 		@Override
 		public String generateName() {

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/QueueBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/QueueBuilder.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public final class QueueBuilder extends AbstractBuilder {
 
-	private static final AnonymousQueue.NamingStrategy namingStrategy = new AnonymousQueue.Base64UrlNamingStrategy();
+	private static final AnonymousQueue.NamingStrategy namingStrategy = AnonymousQueue.Base64UrlNamingStrategy.DEFAULT;
 
 	private final String name;
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -34,6 +34,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.core.AbstractDeclarable;
 import org.springframework.amqp.core.AbstractExchange;
+import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Binding.DestinationType;
 import org.springframework.amqp.core.DirectExchange;
@@ -550,7 +551,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 		boolean exclusive = false;
 		boolean autoDelete = false;
 		if (!StringUtils.hasText(queueName)) {
-			queueName = UUID.randomUUID().toString();
+			queueName = AnonymousQueue.Base64UrlNamingStrategy.DEFAULT.generateName();
 			// default exclusive/autodelete to true when anonymous
 			if (!StringUtils.hasText(bindingQueue.exclusive())
 					|| resolveExpressionAsBoolean(bindingQueue.exclusive())) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;


### PR DESCRIPTION
As suggested by @garyrussell in #575 

It's logically a separate change, so IMHO another PR would make sense.