### PR TITLE
AMQP-722 Support multiple routing keys in @QueueBinding

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/QueueBinding.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/QueueBinding.java
@@ -45,7 +45,7 @@ public @interface QueueBinding {
 	/**
 	 * @return the routing key or pattern for the binding.
 	 */
-	String key() default "";
+	String[] key() default {};
 
 	/**
 	 * @return true if the declaration exceptions should be ignored.


### PR DESCRIPTION
I described the idea in https://jira.spring.io/browse/AMQP-722

If we are going forward I could add javadocs to the affected privates methods and probably change Collection to Predicate, etc.

WDYT?