### PR TITLE
minor optimization Message.toString()

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Message.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Message.java
@@ -60,9 +60,9 @@ public class Message implements Serializable {
 
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("(");
-		buffer.append("Body:'" + this.getBodyContentAsString() + "'");
+		buffer.append("Body:'").append(this.getBodyContentAsString()).append("'");
 		if (this.messageProperties != null) {
 			buffer.append(" ").append(this.messageProperties.toString());
 		}

--- a/spring-amqp/src/test/java/org/springframework/amqp/core/builder/MessageBuilderTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/core/builder/MessageBuilderTests.java
@@ -318,7 +318,7 @@ public class MessageBuilderTests {
 		assertEquals("contentEncoding", properties.getContentEncoding());
 		assertEquals(MessageProperties.CONTENT_TYPE_TEXT_PLAIN, properties.getContentType());
 		assertEquals(1, properties.getContentLength());
-		assertEquals("correlationId", new String(properties.getCorrelationId()));
+		assertEquals("correlationId", properties.getCorrelationId());
 		assertEquals(MessageDeliveryMode.NON_PERSISTENT, properties.getDeliveryMode());
 		assertEquals(2, properties.getDeliveryTag());
 		assertEquals("expiration", properties.getExpiration());
@@ -342,7 +342,7 @@ public class MessageBuilderTests {
 		assertEquals("CONTENTENCODING", properties.getContentEncoding());
 		assertEquals(MessageProperties.CONTENT_TYPE_BYTES, properties.getContentType());
 		assertEquals(10, properties.getContentLength());
-		assertEquals("CORRELATIONID", new String(properties.getCorrelationId()));
+		assertEquals("CORRELATIONID", properties.getCorrelationId());
 		assertEquals(MessageDeliveryMode.PERSISTENT, properties.getDeliveryMode());
 		assertEquals(20, properties.getDeliveryTag());
 		assertEquals("EXPIRATION", properties.getExpiration());


### PR DESCRIPTION
* StringBuffer -> StringBuilder in Message.toString()
* in tests: correlationId is a string, `new String(String)` can be avoided

Just to have less warnings in IDE :-)