### PR TITLE
AMQP-726: Always Cancel Auto Recovering Consumers

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -33,6 +33,7 @@ import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Method;
 import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.client.impl.recovery.AutorecoveringChannel;
 
 /**
  * @author Mark Fisher
@@ -118,12 +119,24 @@ public abstract class RabbitUtils {
 	}
 
 	public static void closeMessageConsumer(Channel channel, Collection<String> consumerTags, boolean transactional) {
-		if (!channel.isOpen()) {
+		if (!channel.isOpen() && !(channel instanceof AutorecoveringChannel)) {
 			return;
 		}
 		try {
 			for (String consumerTag : consumerTags) {
-				channel.basicCancel(consumerTag);
+				try {
+					channel.basicCancel(consumerTag);
+				}
+				catch (IOException e) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Error performing 'basicCancel'", e);
+					}
+				}
+				catch (AlreadyClosedException e) {
+					if (logger.isTraceEnabled()) {
+						logger.trace(channel + " is already closed");
+					}
+				}
 			}
 			if (transactional) {
 				/*


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-726

When using auto recovering channels, `RabbitUtils.closeMessageConsumer()` skipped canceling
the consumers if the channel reports as being closed.

This should not cause a problem since the channel is physically closed, which should prevent
the consumers from being recovered.

Change the utility method to unconditionally cancel such consumers (which removes them as
candidates for recovery).

Also add the following defensive code:

1. If stop() is called without first calling `basicCancel()` (so the utility does the canceling),
set the `abortStarted` timer to signal the `handleDelivery` to use `offer()` instead of `put()`.
This happens from `run()` in `SMLC.restart()`.
2. If we time out the `offer()`, unconditionally drain the queue, reject, cancel the consumer and close the channel.

__cherry-pick to 1.7.x, 1.6.x__