### PR TITLE
AMQP-726: Fix for ChannelProxy; Polishing

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -119,7 +119,9 @@ public abstract class RabbitUtils {
 	}
 
 	public static void closeMessageConsumer(Channel channel, Collection<String> consumerTags, boolean transactional) {
-		if (!channel.isOpen() && !(channel instanceof AutorecoveringChannel)) {
+		if (!channel.isOpen() && !(channel instanceof ChannelProxy
+					&& ((ChannelProxy) channel).getTargetChannel() instanceof AutorecoveringChannel)
+				&& !(channel instanceof AutorecoveringChannel)) {
 			return;
 		}
 		try {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -635,7 +635,7 @@ public class BlockingQueueConsumer {
 			}
 			catch (Exception e) {
 				if (logger.isDebugEnabled()) {
-					logger.debug("Error closing consumer", e);
+					logger.debug("Error closing consumer " + this, e);
 				}
 			}
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -358,6 +359,15 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 					.filter(c -> !c.getChannel().isOpen())
 					.collect(Collectors.toList()) // needed to avoid ConcurrentModificationException in cancelConsumer()
 					.forEach(c -> {
+						try {
+							RabbitUtils.closeMessageConsumer(c.getChannel(),
+									Collections.singletonList(c.getConsumerTag()), isChannelTransacted());
+						}
+						catch (Exception e) {
+							if (logger.isDebugEnabled()) {
+								logger.debug("Error closing consumer " + c, e);
+							}
+						}
 						this.logger.error("Consumer canceled - channel closed " + c);
 						c.cancelConsumer("Consumer " + c + " channel closed");
 					});

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,6 +39,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.logging.log4j.Level;
@@ -48,6 +50,7 @@ import org.mockito.Mockito;
 
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.rabbit.connection.ChannelProxy;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.support.ConsumerCancelledException;
@@ -240,11 +243,14 @@ public class BlockingQueueConsumerTests {
 	public void testAlwaysCancelAutoRecoverConsumer() throws IOException {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		Connection connection = mock(Connection.class);
-		Channel channel = mock(AutorecoveringChannel.class);
+		ChannelProxy channel = mock(ChannelProxy.class);
+		Channel rabbitChannel = mock(AutorecoveringChannel.class);
+		when(channel.getTargetChannel()).thenReturn(rabbitChannel);
 
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		when(connection.createChannel(anyBoolean())).thenReturn(channel);
-		when(channel.isOpen()).thenReturn(true);
+		final AtomicBoolean isOpen = new AtomicBoolean(true);
+		doReturn(isOpen.get()).when(channel).isOpen();
 		when(channel.queueDeclarePassive(Mockito.anyString()))
 				.then(invocation -> mock(AMQP.Queue.DeclareOk.class));
 		when(channel.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
@@ -260,7 +266,7 @@ public class BlockingQueueConsumerTests {
 		blockingQueueConsumer.start();
 
 		verify(channel).basicQos(2);
-		when(channel.isOpen()).thenReturn(false);
+		isOpen.set(false);
 		blockingQueueConsumer.stop();
 		verify(channel).basicCancel("consumerTag");
 	}
@@ -269,11 +275,14 @@ public class BlockingQueueConsumerTests {
 	public void testDrainAndReject() throws IOException {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		Connection connection = mock(Connection.class);
-		Channel channel = mock(AutorecoveringChannel.class);
+		ChannelProxy channel = mock(ChannelProxy.class);
+		Channel rabbitChannel = mock(AutorecoveringChannel.class);
+		when(channel.getTargetChannel()).thenReturn(rabbitChannel);
 
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		when(connection.createChannel(anyBoolean())).thenReturn(channel);
-		when(channel.isOpen()).thenReturn(true);
+		final AtomicBoolean isOpen = new AtomicBoolean(true);
+		doReturn(isOpen.get()).when(channel).isOpen();
 		when(channel.queueDeclarePassive(Mockito.anyString()))
 				.then(invocation -> mock(AMQP.Queue.DeclareOk.class));
 		when(channel.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
@@ -290,7 +299,7 @@ public class BlockingQueueConsumerTests {
 
 		verify(channel).basicQos(2);
 		Consumer consumer = TestUtils.getPropertyValue(blockingQueueConsumer, "consumer", Consumer.class);
-		when(channel.isOpen()).thenReturn(false);
+		isOpen.set(false);
 		blockingQueueConsumer.stop();
 		verify(channel).basicCancel("consumerTag");
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerIntegrationTests.java
@@ -83,7 +83,7 @@ import com.rabbitmq.client.Consumer;
  * @since 2.0
  *
  */
-public class DirectMessageListenerContainerTests {
+public class DirectMessageListenerContainerIntegrationTests {
 
 	private static final String Q1 = "testQ1";
 
@@ -106,7 +106,8 @@ public class DirectMessageListenerContainerTests {
 	@Rule
 	public LogLevelAdjuster adjuster = new LogLevelAdjuster(Level.DEBUG,
 			CachingConnectionFactory.class, DirectReplyToMessageListenerContainer.class,
-			DirectMessageListenerContainer.class, DirectMessageListenerContainerTests.class, BrokerRunning.class);
+			DirectMessageListenerContainer.class, DirectMessageListenerContainerIntegrationTests.class,
+			BrokerRunning.class);
 
 	@Rule
 	public TestName testName = new TestName();
@@ -608,7 +609,7 @@ public class DirectMessageListenerContainerTests {
 
 		@Override
 		public String createConsumerTag(String queue) {
-			return queue + "/" + DirectMessageListenerContainerTests.this.testName.getMethodName() + n++;
+			return queue + "/" + DirectMessageListenerContainerIntegrationTests.this.testName.getMethodName() + n++;
 		}
 
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.springframework.amqp.rabbit.connection.ChannelProxy;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.impl.recovery.AutorecoveringChannel;
+
+/**
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class DirectMessageListenerContainerMockTests {
+
+	@Test
+	public void testAlwaysCancelAutoRecoverConsumer() throws IOException, Exception {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		Connection connection = mock(Connection.class);
+		ChannelProxy channel = mock(ChannelProxy.class);
+		Channel rabbitChannel = mock(AutorecoveringChannel.class);
+		given(channel.getTargetChannel()).willReturn(rabbitChannel);
+
+		given(connectionFactory.createConnection()).willReturn(connection);
+		given(connection.createChannel(anyBoolean())).willReturn(channel);
+		final AtomicBoolean isOpen = new AtomicBoolean(true);
+		willAnswer(i -> isOpen.get()).given(channel).isOpen();
+		given(channel.queueDeclarePassive(Mockito.anyString()))
+				.willAnswer(invocation -> mock(AMQP.Queue.DeclareOk.class));
+		given(channel.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
+						anyMap(), any(Consumer.class))).willReturn("consumerTag");
+
+		final CountDownLatch latch1 = new CountDownLatch(1);
+		final AtomicInteger qos = new AtomicInteger();
+		willAnswer(i -> {
+			qos.set(i.getArgument(0));
+			latch1.countDown();
+			return null;
+		}).given(channel).basicQos(anyInt());
+		final CountDownLatch latch2 = new CountDownLatch(1);
+		willAnswer(i -> {
+			latch2.countDown();
+			return null;
+		}).given(channel).basicCancel("consumerTag");
+
+		DirectMessageListenerContainer container = new DirectMessageListenerContainer(connectionFactory);
+		container.setQueueNames("test");
+		container.setPrefetchCount(2);
+		container.setMonitorInterval(100);
+		container.afterPropertiesSet();
+		container.start();
+
+		assertTrue(latch1.await(10, TimeUnit.SECONDS));
+		assertThat(qos.get(), equalTo(2));
+		isOpen.set(false);
+		assertTrue(latch2.await(10, TimeUnit.SECONDS));
+		container.stop();
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-726

- `instanceof` in RabbitUtils didn't take account of `ChannelProxy`
- fix partial stubbing problem with channel close - use a single stubbing with atomic boolean

__cherry-pick (first commit only) to 1.7.x, 1.6.x; second commit is for master only__