### PR TITLE
Fix tearDown method in testing.adoc code example

### DIFF
--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -279,7 +279,7 @@ Usage:
 public static BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues("foo", "bar");
 
 @AfterClass
-public void tearDown() {
+public static void tearDown() {
     brokerRunning.removeTestQueues("some.other.queue.too") // removes foo, bar as well
 }
 ----


### PR DESCRIPTION
Obvious Fix

`@AfterClass` method has to be static or else Exception is thrown.