### PR TITLE
Remove overridden DMLC methods accepting Queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 services:
   - rabbitmq
 env:
+  global:
+  - GRADLE_OPTS="-Xmx512m"
   - TERM=dumb
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -251,7 +251,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * Set the name of the queue(s) to receive messages from.
 	 * @param queues the desired queue(s) (can not be <code>null</code>)
 	 */
-	public void setQueues(Queue... queues) {
+	public final void setQueues(Queue... queues) {
 		setQueueNames(collectQueueNames(queues));
 	}
 
@@ -295,7 +295,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * Add queue(s) to this container's list of queues.
 	 * @param queues The queue(s) to add.
 	 */
-	public void addQueues(Queue... queues) {
+	public final void addQueues(Queue... queues) {
 		this.addQueueNames(collectQueueNames(queues));
 	}
 
@@ -315,7 +315,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @param queues The queue(s) to remove.
 	 * @return the boolean result of removal on the target {@code queueNames} List.
 	 */
-	public boolean removeQueues(Queue... queues) {
+	public final boolean removeQueues(Queue... queues) {
 		return this.removeQueueNames(collectQueueNames(queues));
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -296,7 +296,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @param queues The queue(s) to add.
 	 */
 	public final void addQueues(Queue... queues) {
-		this.addQueueNames(collectQueueNames(queues));
+		addQueueNames(collectQueueNames(queues));
 	}
 
 	/**
@@ -316,7 +316,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @return the boolean result of removal on the target {@code queueNames} List.
 	 */
 	public final boolean removeQueues(Queue... queues) {
-		return this.removeQueueNames(collectQueueNames(queues));
+		return removeQueueNames(collectQueueNames(queues));
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -252,12 +252,17 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @param queues the desired queue(s) (can not be <code>null</code>)
 	 */
 	public void setQueues(Queue... queues) {
-		final String[] queueNames = new String[queues.length];
+		setQueueNames(collectQueueNames(queues));
+	}
+
+	private static String[] collectQueueNames(Queue... queues) {
+		Assert.notNull(queues, "'queues' cannot be null");
+		Assert.noNullElements(queues, "'queues' cannot contain null elements");
+		String[] queueNames = new String[queues.length];
 		for (int i = 0; i < queues.length; i++) {
-			Assert.notNull(queues[i], "Queue (" + i + ") must not be null.");
 			queueNames[i] = queues[i].getName();
 		}
-		setQueueNames(queueNames);
+		return queueNames;
 	}
 
 	/**
@@ -291,13 +296,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @param queues The queue(s) to add.
 	 */
 	public void addQueues(Queue... queues) {
-		Assert.notNull(queues, "'queues' cannot be null");
-		Assert.noNullElements(queues, "'queues' cannot contain null elements");
-		String[] queueNames = new String[queues.length];
-		for (int i = 0; i < queues.length; i++) {
-			queueNames[i] = queues[i].getName();
-		}
-		this.addQueueNames(queueNames);
+		this.addQueueNames(collectQueueNames(queues));
 	}
 
 	/**
@@ -317,13 +316,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @return the boolean result of removal on the target {@code queueNames} List.
 	 */
 	public boolean removeQueues(Queue... queues) {
-		Assert.notNull(queues, "'queues' cannot be null");
-		Assert.noNullElements(queues, "'queues' cannot contain null elements");
-		String[] queueNames = new String[queues.length];
-		for (int i = 0; i < queues.length; i++) {
-			queueNames[i] = queues[i].getName();
-		}
-		return this.removeQueueNames(queueNames);
+		return this.removeQueueNames(collectQueueNames(queues));
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -17,7 +17,6 @@
 package org.springframework.amqp.rabbit.listener;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -245,7 +244,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 */
 	public void setQueueNames(String... queueName) {
 		Assert.noNullElements(queueName, "Queue name(s) cannot be null");
-		this.queueNames = new CopyOnWriteArrayList<>(Arrays.asList(queueName));
+		this.queueNames = new CopyOnWriteArrayList<>(queueName);
 	}
 
 	/**
@@ -253,13 +252,12 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @param queues the desired queue(s) (can not be <code>null</code>)
 	 */
 	public void setQueues(Queue... queues) {
-		List<String> queueNames = new ArrayList<String>(queues.length);
+		final String[] queueNames = new String[queues.length];
 		for (int i = 0; i < queues.length; i++) {
 			Assert.notNull(queues[i], "Queue (" + i + ") must not be null.");
-			queueNames.add(queues[i].getName());
+			queueNames[i] = queues[i].getName();
 		}
-		queueNames = new CopyOnWriteArrayList<>(queueNames);
-		this.queueNames = queueNames;
+		setQueueNames(queueNames);
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentMap;
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Address;
 import org.springframework.amqp.core.MessageListener;
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.ChannelAwareMessageListener;
 import org.springframework.util.Assert;
@@ -73,27 +72,12 @@ public class DirectReplyToMessageListenerContainer extends DirectMessageListener
 	}
 
 	@Override
-	public final void setQueues(Queue... queues) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public final void addQueueNames(String... queueNames) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public final void addQueues(Queue... queues) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public final boolean removeQueueNames(String... queueNames) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public final boolean removeQueues(Queue... queues) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -36,7 +36,6 @@ import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.ImmediateAcknowledgeAmqpException;
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactoryUtils;
 import org.springframework.amqp.rabbit.connection.ConsumerChannelRegistry;
@@ -302,12 +301,6 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		this.queuesChanged();
 	}
 
-	@Override
-	public void setQueues(Queue... queues) {
-		super.setQueues(queues);
-		this.queuesChanged();
-	}
-
 	/**
 	 * Add queue(s) to this container's list of queues. The existing consumers
 	 * will be cancelled after they have processed any pre-fetched messages and
@@ -322,19 +315,6 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
-	 * Add queue(s) to this container's list of queues. The existing consumers
-	 * will be cancelled after they have processed any pre-fetched messages and
-	 * new consumers will be created. The queue must exist to avoid problems when
-	 * restarting the consumers.
-	 * @param queue The queue to add.
-	 */
-	@Override
-	public void addQueues(Queue... queue) {
-		super.addQueues(queue);
-		this.queuesChanged();
-	}
-
-	/**
 	 * Remove queues from this container's list of queues. The existing consumers
 	 * will be cancelled after they have processed any pre-fetched messages and
 	 * new consumers will be created. At least one queue must remain.
@@ -343,23 +323,6 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	@Override
 	public boolean removeQueueNames(String... queueName) {
 		if (super.removeQueueNames(queueName)) {
-			this.queuesChanged();
-			return true;
-		}
-		else {
-			return false;
-		}
-	}
-
-	/**
-	 * Remove queue(s) from this container's list of queues. The existing consumers
-	 * will be cancelled after they have processed any pre-fetched messages and
-	 * new consumers will be created. At least one queue must remain.
-	 * @param queue The queue to remove.
-	 */
-	@Override
-	public boolean removeQueues(Queue... queue) {
-		if (super.removeQueues(queue)) {
 			this.queuesChanged();
 			return true;
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerIntegrationTests.java
@@ -18,6 +18,7 @@ package org.springframework.amqp.rabbit.listener;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -211,6 +212,48 @@ public class DirectMessageListenerContainerIntegrationTests {
 		assertEquals("FOO", template.convertSendAndReceive(Q1, "foo"));
 		assertEquals("BAR", template.convertSendAndReceive(Q2, "bar"));
 		container.removeQueueNames(Q1, Q2, "junk");
+		assertTrue(consumersOnQueue(Q1, 0));
+		assertTrue(consumersOnQueue(Q2, 0));
+		assertTrue(activeConsumerCount(container, 0));
+		container.stop();
+		assertTrue(consumersOnQueue(Q1, 0));
+		assertTrue(consumersOnQueue(Q2, 0));
+		assertTrue(activeConsumerCount(container, 0));
+		assertEquals(0, TestUtils.getPropertyValue(container, "consumersByQueue", MultiValueMap.class).size());
+		template.stop();
+		cf.destroy();
+	}
+
+	@Test
+	public void testQueueManagementQueueInstances() throws Exception {
+		CachingConnectionFactory cf = new CachingConnectionFactory("localhost");
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setThreadNamePrefix("client-");
+		executor.afterPropertiesSet();
+		cf.setExecutor(executor);
+		DirectMessageListenerContainer container = new DirectMessageListenerContainer(cf);
+		container.setConsumersPerQueue(2);
+		container.setMessageListener(new MessageListenerAdapter((ReplyingMessageListener<String, String>) in -> {
+			if ("foo".equals(in) || "bar".equals(in)) {
+				return in.toUpperCase();
+			}
+			else {
+				return null;
+			}
+		}));
+		container.setBeanName("qManage");
+		container.setConsumerTagStrategy(new Tag());
+		container.afterPropertiesSet();
+		container.setQueues(new Queue(Q1));
+		assertArrayEquals(new String[] { Q1 }, container.getQueueNames());
+		container.start();
+		container.addQueues(new Queue(Q2));
+		assertTrue(consumersOnQueue(Q1, 2));
+		assertTrue(consumersOnQueue(Q2, 2));
+		RabbitTemplate template = new RabbitTemplate(cf);
+		assertEquals("FOO", template.convertSendAndReceive(Q1, "foo"));
+		assertEquals("BAR", template.convertSendAndReceive(Q2, "bar"));
+		container.removeQueues(new Queue(Q1), new Queue(Q2), new Queue("junk"));
 		assertTrue(consumersOnQueue(Q1, 0));
 		assertTrue(consumersOnQueue(Q2, 0));
 		assertTrue(activeConsumerCount(container, 0));


### PR DESCRIPTION
As the implementations of those in AbstractMessageListenerContainer
delegate to ones accepting Strings.