### PR TITLE
AMQP-727: RoutingConnectionFactory Fixes

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -197,6 +197,8 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	private boolean alwaysRequeueWithTxManagerRollback;
 
+	private String lookupKeyQualifier = "";
+
 	/**
 	 * {@inheritDoc}
 	 * @since 1.5
@@ -529,12 +531,49 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 		ConnectionFactory connectionFactory = super.getConnectionFactory();
 		if (connectionFactory instanceof RoutingConnectionFactory) {
 			ConnectionFactory targetConnectionFactory = ((RoutingConnectionFactory) connectionFactory)
-					.getTargetConnectionFactory(this.queueNames.toString().replaceAll(" ", ""));
+					.getTargetConnectionFactory(getRoutingLookupKey());
 			if (targetConnectionFactory != null) {
 				return targetConnectionFactory;
 			}
 		}
 		return connectionFactory;
+	}
+
+	/**
+	 * Set a qualifier that will prefix the connection factory lookup key; default none.
+	 * @param lookupKeyQualifier the qualifier
+	 * @since 1.6.9
+	 * @see #getRoutingLookupKey()
+	 */
+	public void setLookupKeyQualifier(String lookupKeyQualifier) {
+		this.lookupKeyQualifier = lookupKeyQualifier;
+	}
+
+	/**
+	 * Return the lookup key if the connection factory is a
+	 * {@link RoutingConnectionFactory}; null otherwise. The routing key is the
+	 * comma-delimited list of queue names will all spaces removed and bracketed by [...],
+	 * optionally prefixed by a qualifier, e.g. "foo[...]".
+	 * @return the key or null.
+	 * @since 1.6.9
+	 * @see AbstractMessageListenerContainer#setLookupKeyQualifier(String)
+	 */
+	protected String getRoutingLookupKey() {
+		return super.getConnectionFactory() instanceof RoutingConnectionFactory
+				? (this.lookupKeyQualifier + this.queueNames.toString().replaceAll(" ", ""))
+				: null;
+	}
+
+	/**
+	 * Return the (@link RoutingConnectionFactory} if the connection factory is a
+	 * {@link RoutingConnectionFactory}; null otherwise.
+	 * @return the key or null.
+	 * @since 1.6.9
+	 */
+	protected RoutingConnectionFactory getRoutingConnectionFactory() {
+		return super.getConnectionFactory() instanceof RoutingConnectionFactory
+				? (RoutingConnectionFactory) super.getConnectionFactory()
+				: null;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -41,6 +41,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactoryUtils;
 import org.springframework.amqp.rabbit.connection.ConsumerChannelRegistry;
 import org.springframework.amqp.rabbit.connection.RabbitResourceHolder;
 import org.springframework.amqp.rabbit.connection.RabbitUtils;
+import org.springframework.amqp.rabbit.connection.SimpleResourceHolder;
 import org.springframework.amqp.rabbit.listener.exception.FatalListenerExecutionException;
 import org.springframework.amqp.rabbit.listener.exception.FatalListenerStartupException;
 import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
@@ -862,6 +863,11 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 			this.consumer.setLocallyTransacted(isChannelLocallyTransacted());
 
+			String routingLookupKey = getRoutingLookupKey();
+			if (routingLookupKey != null) {
+				SimpleResourceHolder.bind(getRoutingConnectionFactory(), routingLookupKey);
+			}
+
 			if (this.consumer.getQueueCount() < 1) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("Consumer stopping; no queues for " + this.consumer);
@@ -1056,6 +1062,9 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				restart(this.consumer);
 			}
 
+			if (routingLookupKey != null) {
+				SimpleResourceHolder.unbind(getRoutingConnectionFactory());
+			}
 		}
 
 		private void logConsumerException(Throwable t) {

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -466,9 +466,14 @@ But, if `lenientFallback = false`, an `IllegalStateException` is thrown.
 
 The Namespace support also provides the `send-connection-factory-selector-expression` and `receive-connection-factory-selector-expression` attributes on the `<rabbit:template>` component.
 
-Also starting with _version 1.4_, you can configure a routing connection factory in a `SimpleMessageListenerContainer`.
+Also starting with _version 1.4_, you can configure a routing connection factory in a listener container.
 In that case, the list of queue names is used as the lookup key.
 For example, if you configure the container with `setQueueNames("foo", "bar")`, the lookup key will be `"[foo,bar]"` (no spaces).
+
+Starting with _version 1.6.9_ you can add a qualifier to the lookup key using `setLookupKeyQualifier` on the listener container.
+This would enable, for example, listening to queues with the same name, but in different virtual host (where you would have a connection factory for each).
+
+For example, with lookup key qualifier `foo` and a container listening to queue `bar`, the lookup key you would register the target connection factory with would be `foo[bar]`.
 
 [[queue-affinity]]
 ===== Queue Affinity and the LocalizedQueueConnectionFactory


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-727

- Bind the lookup key to any thread in the container that might open a connection
  so that the same connection factory will be used if a connection listener is invoked.
- Add a lookup key qualifier to the container so that the same queue name(s) can be used in
  different virtual hosts.

__cherry-pick to 1.7.x, 1.6.x (minus the DMLC bits)__