### PR TITLE
AMQP-728: Make BrokerRunning More Configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -244,7 +244,10 @@ project('spring-rabbit-junit') {
 		compile "org.springframework:spring-core:$springVersion"
 		compile "junit:junit:$junitVersion"
 		compile "com.rabbitmq:amqp-client:$rabbitmqVersion"
-		compile "com.rabbitmq:http-client:$rabbitmqHttpClientVersion"
+		compile ("com.rabbitmq:http-client:$rabbitmqHttpClientVersion") {
+			exclude group: 'org.springframework', module: 'spring-web'
+		}
+		compile "org.springframework:spring-web:$springVersion"
 
 	}
 

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunning.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunning.java
@@ -261,7 +261,7 @@ public final class BrokerRunning extends TestWatcher {
 	}
 
 	/**
-	 * Set the user for the amqp connection default "guest".
+	 * Set the password for the amqp connection default "guest".
 	 * @param password the password.
 	 * @since 1.7.2
 	 */
@@ -288,7 +288,7 @@ public final class BrokerRunning extends TestWatcher {
 	}
 
 	/**
-	 * Set the paswword for the management REST API connection default "guest".
+	 * Set the password for the management REST API connection default "guest".
 	 * @param password the password.
 	 * @since 1.7.2
 	 */
@@ -559,15 +559,15 @@ public final class BrokerRunning extends TestWatcher {
 	 * @since 1.7.2
 	 */
 	public String getAdminUri() {
-		if (StringUtils.hasText(this.adminUri)) {
-			return this.adminUri;
+		if (!StringUtils.hasText(this.adminUri)) {
+			if (!StringUtils.hasText(this.hostName)) {
+				this.adminUri = "http://localhost:15672/api/";
+			}
+			else {
+				this.adminUri = "http://" + this.hostName + ":15672/api/";
+			}
 		}
-		else if (!StringUtils.hasText(this.hostName)) {
-			return "http://localhost:15672/api/";
-		}
-		else {
-			return "http://" + this.hostName + ":15672/api/";
-		}
+		return this.adminUri;
 	}
 
 	private void closeResources(Connection connection, Channel channel) {

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunning.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunning.java
@@ -148,12 +148,22 @@ public final class BrokerRunning extends TestWatcher {
 	}
 
 	/**
-	 * Set environment variables for host, port etc. Will override any real
-	 * environment vars, if present.
+	 * Set environment variable overrides for host, port etc. Will override any real
+	 * environment variables, if present.
+	 * <p><b>The variables will only apply to rule instances that are created after this
+	 * method is called.</b>
+	 * The overrides will remain until
 	 * @param environmentVariables the variables.
 	 */
-	public static void setEnvironmentVariables(Map<String, String> environmentVariables) {
+	public static void setEnvironmentVariableOverrides(Map<String, String> environmentVariables) {
 		environmentOverrides.putAll(environmentVariables);
+	}
+
+	/**
+	 * Clear any environment variable overrides set in {@link #setEnvironmentVariableOverrides(Map)}.
+	 */
+	public static void clearEnvironmentVariableOverrides() {
+		environmentOverrides.clear();
 	}
 
 	/**

--- a/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningTests.java
+++ b/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.junit;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.beans.DirectFieldAccessor;
+
+import com.rabbitmq.client.ConnectionFactory;
+
+/**
+ * @author Gary Russell
+ * @since 5.0
+ *
+ */
+public class BrokerRunningTests {
+
+	@Test
+	public void testVars() {
+		BrokerRunning brokerRunning = BrokerRunning.isBrokerAndManagementRunning();
+		brokerRunning.setAdminPassword("foo");
+		brokerRunning.setAdminUser("bar");
+		brokerRunning.setHostName("baz");
+		brokerRunning.setPassword("qux");
+		brokerRunning.setPort(1234);
+		brokerRunning.setUser("fiz");
+
+		assertEquals("http://baz:15672/api/", brokerRunning.getAdminUri());
+		ConnectionFactory connectionFactory = brokerRunning.getConnectionFactory();
+		assertEquals("baz", connectionFactory.getHost());
+		assertEquals(1234, connectionFactory.getPort());
+		assertEquals("fiz", connectionFactory.getUsername());
+		assertEquals("qux", connectionFactory.getPassword());
+	}
+
+	@Test
+	public void testEnvironmentVars() {
+		Map<String, String> vars = new HashMap<>();
+		vars.put("RABBITMQ_TEST_ADMIN_PASSWORD", "FOO");
+		vars.put("RABBITMQ_TEST_ADMIN_URI", "http://foo/bar");
+		vars.put("RABBITMQ_TEST_ADMIN_USER", "BAR");
+		vars.put("RABBITMQ_TEST_HOSTNAME", "BAZ");
+		vars.put("RABBITMQ_TEST_PASSWORD", "QUX");
+		vars.put("RABBITMQ_TEST_PORT", "2345");
+		vars.put("RABBITMQ_TEST_USER", "FIZ");
+		BrokerRunning.setEnvironmentVariables(vars);
+		BrokerRunning brokerRunning = BrokerRunning.isBrokerAndManagementRunning();
+
+		assertEquals("http://foo/bar", brokerRunning.getAdminUri());
+		ConnectionFactory connectionFactory = brokerRunning.getConnectionFactory();
+		assertEquals("BAZ", connectionFactory.getHost());
+		assertEquals(2345, connectionFactory.getPort());
+		assertEquals("FIZ", connectionFactory.getUsername());
+		assertEquals("QUX", connectionFactory.getPassword());
+		DirectFieldAccessor dfa = new DirectFieldAccessor(brokerRunning);
+		assertEquals("BAR", dfa.getPropertyValue("adminUser"));
+		assertEquals("FOO", dfa.getPropertyValue("adminPassword"));
+	}
+
+}

--- a/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningTests.java
+++ b/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningTests.java
@@ -29,7 +29,7 @@ import com.rabbitmq.client.ConnectionFactory;
 
 /**
  * @author Gary Russell
- * @since 5.0
+ * @since 1.7.2
  *
  */
 public class BrokerRunningTests {
@@ -62,7 +62,7 @@ public class BrokerRunningTests {
 		vars.put("RABBITMQ_TEST_PASSWORD", "QUX");
 		vars.put("RABBITMQ_TEST_PORT", "2345");
 		vars.put("RABBITMQ_TEST_USER", "FIZ");
-		BrokerRunning.setEnvironmentVariables(vars);
+		BrokerRunning.setEnvironmentVariableOverrides(vars);
 		BrokerRunning brokerRunning = BrokerRunning.isBrokerAndManagementRunning();
 
 		assertEquals("http://foo/bar", brokerRunning.getAdminUri());
@@ -74,6 +74,8 @@ public class BrokerRunningTests {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(brokerRunning);
 		assertEquals("BAR", dfa.getPropertyValue("adminUser"));
 		assertEquals("FOO", dfa.getPropertyValue("adminPassword"));
+
+		BrokerRunning.clearEnvironmentVariableOverrides();
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -1165,7 +1165,10 @@ public class EnableRabbitIntegrationTests {
 		@Bean
 		public ConnectionFactory rabbitConnectionFactory() {
 			CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
-			connectionFactory.setHost("localhost");
+			connectionFactory.setHost(brokerRunning.getHostName());
+			connectionFactory.setPort(brokerRunning.getPort());
+			connectionFactory.setUsername(brokerRunning.getUser());
+			connectionFactory.setPassword(brokerRunning.getPassword());
 			ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 			executor.setThreadNamePrefix("rabbitClientThread-");
 			executor.afterPropertiesSet();
@@ -1386,7 +1389,10 @@ public class EnableRabbitIntegrationTests {
 		@Bean
 		public ConnectionFactory rabbitConnectionFactory() {
 			CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
-			connectionFactory.setHost("localhost");
+			connectionFactory.setHost(brokerRunning.getHostName());
+			connectionFactory.setPort(brokerRunning.getPort());
+			connectionFactory.setUsername(brokerRunning.getUser());
+			connectionFactory.setPassword(brokerRunning.getPassword());
 			return connectionFactory;
 		}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import org.apache.commons.logging.Log;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
 import org.mockito.Mockito;
 
 import org.springframework.amqp.utils.test.TestUtils;

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -266,9 +266,11 @@ to suspend the test thread.
 
 Spring AMQP _version 1.7_ provides an additional jar `spring-rabbit-junit`; this jar contains a couple of utility `@Rule` s for use when running JUnit tests.
 
-`BrokerRunning` provides a mechanism to allow tests to succeed when a broker is not running on `localhost`.
+===== BrokerRunning
 
-It also has utility methods to delete queues and exchanges.
+`BrokerRunning` provides a mechanism to allow tests to succeed when a broker is not running (on `localhost`, by default).
+
+It also has utility methods to initialize/empty queues, and delete queues and exchanges.
 
 Usage:
 
@@ -284,10 +286,71 @@ public static void tearDown() {
 }
 ----
 
-Of course, there are times when you want tests to fail if there is no broker, such as a nightly CI build.
+There are several `isRunning...` static methods such as `isBrokerAndManagementRunning()` which verifies the broker has the management plugin enabled.
+
+====== Configuring the Rule
+
+There are times when you want tests to fail if there is no broker, such as a nightly CI build.
 To disable the rule at runtime, set an environment variable `RABBITMQ_SERVER_REQUIRED` to `true`.
 
-There are several `isRunning...` static methods such as `isBrokerAndManagementRunning()` which verifies the broker has the management plugin enabled.
+You can override the broker properties, such as hostname in several ways:
+
+- Setters
+
+[source, java]
+----
+
+@ClassRule
+public static BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues("foo", "bar");
+
+static {
+    brokerRunning.setHostName("10.0.0.1")
+}
+
+@AfterClass
+public static void tearDown() {
+    brokerRunning.removeTestQueues("some.other.queue.too") // removes foo, bar as well
+}
+----
+
+- Environment Variables
+
+The following environment variables are provided:
+
+[source, java]
+----
+public static final String BROKER_ADMIN_URI = "RABBITMQ_TEST_ADMIN_URI";
+public static final String BROKER_HOSTNAME = "RABBITMQ_TEST_HOSTNAME";
+public static final String BROKER_PORT = "RABBITMQ_TEST_PORT";
+public static final String BROKER_USER = "RABBITMQ_TEST_USER";
+public static final String BROKER_PW = "RABBITMQ_TEST_PASSWORD";
+public static final String BROKER_ADMIN_USER = "RABBITMQ_TEST_ADMIN_USER";
+public static final String BROKER_ADMIN_PW = "RABBITMQ_TEST_ADMIN_PASSWORD";
+----
+
+These will override the default settings (`localhost:5672` for amqp and `http://localhost:15672/api/` for the management REST API).
+
+Changing the host name affects both the amqp and management REST API connection (unless the admin uri is explicitly set).
+
+`BrokerRunning` also provides a `static` method: `setEnvironmentVariables` where you can pass in a map containing these variables; they override system environment variables.
+This might be useful if you wish to use different configuration for tests in multiple test suites.
+
+In your test cases, you can use those properties when creating the connection factory:
+
+[source, java]
+----
+@Bean
+public ConnectionFactory rabbitConnectionFactory() {
+    CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+    connectionFactory.setHost(brokerRunning.getHostName());
+    connectionFactory.setPort(brokerRunning.getPort());
+    connectionFactory.setUsername(brokerRunning.getUser());
+    connectionFactory.setPassword(brokerRunning.getPassword());
+    return connectionFactory;
+}
+----
+
+===== LongRunningIntegrationTest
 
 `LongRunningIntegrationTest` is a rule that disables long running tests; you might want to use this on a developer system but ensure that the rule is disabled on, for example, nightly CI builds.
 

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -332,8 +332,11 @@ These will override the default settings (`localhost:5672` for amqp and `http://
 
 Changing the host name affects both the amqp and management REST API connection (unless the admin uri is explicitly set).
 
-`BrokerRunning` also provides a `static` method: `setEnvironmentVariables` where you can pass in a map containing these variables; they override system environment variables.
+`BrokerRunning` also provides a `static` method: `setEnvironmentVariableOverrides` where you can pass in a map containing these variables; they override system environment variables.
 This might be useful if you wish to use different configuration for tests in multiple test suites.
+IMPORTANT: The method must be called before invoking any of the `isRunning()` static methods that create the rule instance.
+Variable values will be applied to all instances created after this.
+Invoke `clearEnvironmentVariableOverrides()` to reset the rule to use defaults (including any actual environment variables).
 
 In your test cases, you can use those properties when creating the connection factory:
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-728
Resolves: #592

Add more options to configure the `BrokerRunning` JUnit `@Rule`.

Fix missing exclude from build.gradle for the junit subproject.

__cherry-pick to 1.7.x - needs diamond operator fixups__.