### PR TITLE
AMQP-733: @Exchange.durable() to true by default

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Exchange.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/Exchange.java
@@ -58,9 +58,9 @@ public @interface Exchange {
 	String type() default ExchangeTypes.DIRECT;
 
 	/**
-	 * @return true if the exchange is to be declared as durable.
+	 * @return false if the exchange is to be declared as non-durable.
 	 */
-	String durable() default "false";
+	String durable() default "true";
 
 	/**
 	 * @return true if the exchange is to be declared as auto-delete.

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -135,6 +135,7 @@ import com.rabbitmq.client.Channel;
  * @author Stephane Nicoll
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 1.4
  */
 @ContextConfiguration(classes = EnableRabbitIntegrationTests.EnableRabbitConfig.class)
@@ -859,7 +860,7 @@ public class EnableRabbitIntegrationTests {
 						@Argument(name = "x-dead-letter-routing-key", value = "amqp656dlq"),
 						@Argument(name = "test-empty", value = ""),
 						@Argument(name = "test-null", value = "") }),
-				exchange = @Exchange(value = "amq.topic", durable = "true", type = "topic"),
+				exchange = @Exchange(value = "amq.topic", type = "topic"),
 				key = "foo"))
 		public String handleWithDeadLetterDefaultExchange(String foo) {
 			throw new AmqpRejectAndDontRequeueException("dlq");
@@ -1240,7 +1241,7 @@ public class EnableRabbitIntegrationTests {
 
 		@Bean
 		public DirectExchange internal() {
-			DirectExchange directExchange = new DirectExchange("auto.internal", false, true);
+			DirectExchange directExchange = new DirectExchange("auto.internal", true, true);
 			directExchange.setInternal(true);
 			return directExchange;
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-733

To be consistent with default `AbstractExchange` ctor,
when by default exchanges must be `durable`, make `@Exchange.durable()`
true by default

**Cherry-pick to 1.7.x**