### PR TITLE
AMQP-725: Suppress WARN Log for Normal Cancel

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -144,6 +144,8 @@ public class BlockingQueueConsumer {
 
 	private volatile long abortStarted;
 
+	private volatile boolean normalCancel;
+
 	/**
 	 * Create a consumer. The consumer must not attempt to use
 	 * the connection factory or communicate with the broker
@@ -326,6 +328,14 @@ public class BlockingQueueConsumer {
 	}
 
 	/**
+	 * Return true if cancellation is expected.
+	 * @return true if expected.
+	 */
+	public boolean isNormalCancel() {
+		return this.normalCancel;
+	}
+
+	/**
 	 * Return the size the queues array.
 	 * @return the count.
 	 */
@@ -334,6 +344,11 @@ public class BlockingQueueConsumer {
 	}
 
 	protected void basicCancel() {
+		basicCancel(false);
+	}
+
+	protected void basicCancel(boolean expected) {
+		this.normalCancel = expected;
 		for (String consumerTag : this.consumerTags.keySet()) {
 			removeConsumer(consumerTag);
 			try {
@@ -789,7 +804,7 @@ public class BlockingQueueConsumer {
 						+ "); " + BlockingQueueConsumer.this);
 			}
 			if (removeConsumer(consumerTag)) {
-				basicCancel();
+				basicCancel(false);
 			}
 		}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerLongTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerLongTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.SingleConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -112,9 +112,9 @@ public class SimpleMessageListenerContainerLongTests {
 
 		RabbitAdmin admin = new RabbitAdmin(connectionFactory);
 		for (int i = 0; i < 20; i++) {
-			AnonymousQueue anonymousQueue = new AnonymousQueue();
-			admin.declareQueue(anonymousQueue);
-			container.addQueueNames(anonymousQueue.getName());
+			Queue queue = new Queue("testAddQueuesAndStartInCycle" + i);
+			admin.declareQueue(queue);
+			container.addQueueNames(queue.getName());
 			if (!container.isRunning()) {
 				container.start();
 			}
@@ -126,6 +126,9 @@ public class SimpleMessageListenerContainerLongTests {
 		}
 		assertEquals(2, container.getActiveConsumerCount());
 		container.stop();
+		for (int i = 0; i < 20; i++) {
+			admin.deleteQueue("testAddQueuesAndStartInCycle" + i);
+		}
 		connectionFactory.destroy();
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-725

Lower the log level to DEBUG when a consumer cancellation is expected, such as during shutdown or changing queues.

__cherry-pick to 1.7.x__.