### PR TITLE
AMQP-737: SMLC: Fix Consumer Cancel Stack Trace

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -359,9 +359,16 @@ public class BlockingQueueConsumer {
 		for (String consumerTag : this.consumerTags.keySet()) {
 			removeConsumer(consumerTag);
 			try {
-				this.channel.basicCancel(consumerTag);
+				if (this.channel.isOpen()) {
+					this.channel.basicCancel(consumerTag);
+				}
 			}
 			catch (IOException e) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Error performing 'basicCancel'", e);
+				}
+			}
+			catch (IllegalStateException e) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("Error performing 'basicCancel'", e);
 				}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-737

Don't attempt to `basicCancel()` a consumer if the channel is already closed.

Also, catch `IllegalStateException` which can occur if the application context is already closed.

__cherry-pick to 1.6.x, master (change to multi-catch on master)__