### PR TITLE
Add Object Hash to Connection Id

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 import com.rabbitmq.client.Address;
@@ -96,7 +97,7 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 		@Override
 		public String obtainNewConnectionName(ConnectionFactory connectionFactory) {
 			return (AbstractConnectionFactory.this.beanName != null ? AbstractConnectionFactory.this.beanName
-					: "SpringAMQP") + "#"
+					: "SpringAMQP") + "#" + ObjectUtils.getIdentityHexString(this) + ":"
 					+ AbstractConnectionFactory.this.defaultConnectionNameStrategyCounter.getAndIncrement();
 		}
 
@@ -356,7 +357,7 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 			}
 			Connection connection = new SimpleConnection(rabbitConnection, this.closeTimeout);
 			if (this.logger.isInfoEnabled()) {
-				this.logger.info("Created new connection: " + connection);
+				this.logger.info("Created new connection: " + connectionName + "/" + connection);
 			}
 			if (this.recoveryListener != null && rabbitConnection instanceof AutorecoveringConnection) {
 				((AutorecoveringConnection) rabbitConnection).addRecoveryListener(this.recoveryListener);


### PR DESCRIPTION
- Add the connection factory's object identity hash code to the connection id String
- Add the connection id to the "Created new Connection" log

__cherry-pick to master__