### PR TITLE
AMQP-736: @RabbitListener.concurrency

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,68 +23,75 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.amqp.core.MessageListener;
-import org.springframework.amqp.rabbit.listener.RabbitListenerErrorHandler;
-import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 
 /**
- * Annotation that marks a method to be the target of a Rabbit message
- * listener on the specified {@link #queues()} (or {@link #bindings()}).
- * The {@link #containerFactory()}
- * identifies the {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory
+ * Annotation that marks a method to be the target of a Rabbit message listener on the
+ * specified {@link #queues()} (or {@link #bindings()}). The {@link #containerFactory()}
+ * identifies the
+ * {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory
  * RabbitListenerContainerFactory} to use to build the rabbit listener container. If not
- * set, a <em>default</em> container factory is assumed to be available with a bean
- * name of {@code rabbitListenerContainerFactory} unless an explicit default has been
- * provided through configuration.
+ * set, a <em>default</em> container factory is assumed to be available with a bean name
+ * of {@code rabbitListenerContainerFactory} unless an explicit default has been provided
+ * through configuration.
  *
- * <p>Processing of {@code @RabbitListener} annotations is performed by
- * registering a {@link RabbitListenerAnnotationBeanPostProcessor}. This can be
- * done manually or, more conveniently, through the {@code <rabbit:annotation-driven/>}
- * element or {@link EnableRabbit} annotation.
+ * <p>
+ * Processing of {@code @RabbitListener} annotations is performed by registering a
+ * {@link RabbitListenerAnnotationBeanPostProcessor}. This can be done manually or, more
+ * conveniently, through the {@code <rabbit:annotation-driven/>} element or
+ * {@link EnableRabbit} annotation.
  *
- * <p>Annotated methods are allowed to have flexible signatures similar to what
+ * <p>
+ * Annotated methods are allowed to have flexible signatures similar to what
  * {@link MessageMapping} provides, that is
  * <ul>
  * <li>{@link com.rabbitmq.client.Channel} to get access to the Channel</li>
- * <li>{@link org.springframework.amqp.core.Message} or one if subclass to get
- * access to the raw AMQP message</li>
- * <li>{@link org.springframework.messaging.Message} to use the messaging abstraction counterpart</li>
- * <li>{@link org.springframework.messaging.handler.annotation.Payload @Payload}-annotated method
- * arguments including the support of validation</li>
- * <li>{@link org.springframework.messaging.handler.annotation.Header @Header}-annotated method
- * arguments to extract a specific header value, including standard AMQP headers defined by
- * {@link org.springframework.amqp.support.AmqpHeaders AmqpHeaders}</li>
+ * <li>{@link org.springframework.amqp.core.Message} or one if subclass to get access to
+ * the raw AMQP message</li>
+ * <li>{@link org.springframework.messaging.Message} to use the messaging abstraction
+ * counterpart</li>
+ * <li>{@link org.springframework.messaging.handler.annotation.Payload @Payload}-annotated
+ * method arguments including the support of validation</li>
+ * <li>{@link org.springframework.messaging.handler.annotation.Header @Header}-annotated
+ * method arguments to extract a specific header value, including standard AMQP headers
+ * defined by {@link org.springframework.amqp.support.AmqpHeaders AmqpHeaders}</li>
  * <li>{@link org.springframework.messaging.handler.annotation.Headers @Headers}-annotated
- * argument that must also be assignable to {@link java.util.Map} for getting access to all
- * headers.</li>
+ * argument that must also be assignable to {@link java.util.Map} for getting access to
+ * all headers.</li>
  * <li>{@link org.springframework.messaging.MessageHeaders MessageHeaders} arguments for
  * getting access to all headers.</li>
- * <li>{@link org.springframework.messaging.support.MessageHeaderAccessor MessageHeaderAccessor}
- * or {@link org.springframework.amqp.support.AmqpMessageHeaderAccessor AmqpMessageHeaderAccessor}
- * for convenient access to all method arguments.</li>
+ * <li>{@link org.springframework.messaging.support.MessageHeaderAccessor
+ * MessageHeaderAccessor} or
+ * {@link org.springframework.amqp.support.AmqpMessageHeaderAccessor
+ * AmqpMessageHeaderAccessor} for convenient access to all method arguments.</li>
  * </ul>
  *
- * <p>Annotated methods may have a non {@code void} return type. When they do, the result of the
- * method invocation is sent as a reply to the queue defined by the
- * {@link org.springframework.amqp.core.MessageProperties#getReplyTo() ReplyTo}  header of the
- * incoming message. When this value is not set, a default queue can be provided by
- * adding @{@link org.springframework.messaging.handler.annotation.SendTo SendTo} to the method
- * declaration.
+ * <p>
+ * Annotated methods may have a non {@code void} return type. When they do, the result of
+ * the method invocation is sent as a reply to the queue defined by the
+ * {@link org.springframework.amqp.core.MessageProperties#getReplyTo() ReplyTo} header of
+ * the incoming message. When this value is not set, a default queue can be provided by
+ * adding @{@link org.springframework.messaging.handler.annotation.SendTo SendTo} to the
+ * method declaration.
  *
- * <p>When {@link #bindings()} are provided, and the application context contains a
- * {@link org.springframework.amqp.rabbit.core.RabbitAdmin},
- * the queue, exchange and binding will be automatically declared.
+ * <p>
+ * When {@link #bindings()} are provided, and the application context contains a
+ * {@link org.springframework.amqp.rabbit.core.RabbitAdmin}, the queue, exchange and
+ * binding will be automatically declared.
  *
- * <p>When defined at the method level, a listener container is created for each method. The
- * {@link MessageListener} is a {@link MessagingMessageListenerAdapter}, configured with a
+ * <p>When defined at the method level, a listener container is created for each method.
+ * The {@link org.springframework.amqp.core.MessageListener} is a
+ * {@link org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter},
+ * configured with a
  * {@link org.springframework.amqp.rabbit.listener.MethodRabbitListenerEndpoint}.
  *
- * <p>When defined at the class level, a single message listener container is used to service
- * all methods annotated with {@code @RabbitHandler}. Method signatures of such annotated
- * methods must not cause any ambiguity such that a single method can be resolved for a
- * particular inbound message. The {@link MessagingMessageListenerAdapter} is configured with
- * a {@link org.springframework.amqp.rabbit.listener.MultiMethodRabbitListenerEndpoint}.
+ * <p>When defined at the class level, a single message listener container is used to
+ * service all methods annotated with {@code @RabbitHandler}. Method signatures of such
+ * annotated methods must not cause any ambiguity such that a single method can be
+ * resolved for a particular inbound message. The
+ * {@link org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter}
+ * is configured with a
+ * {@link org.springframework.amqp.rabbit.listener.MultiMethodRabbitListenerEndpoint}.
  *
  * @author Stephane Nicoll
  * @author Gary Russell
@@ -201,11 +208,29 @@ public @interface RabbitListener {
 	String returnExceptions() default "";
 
 	/**
-	 * Set an {@link RabbitListenerErrorHandler} to invoke if the listener method throws
-	 * an exception.
+	 * Set an {@link org.springframework.amqp.rabbit.listener.RabbitListenerErrorHandler}
+	 * to invoke if the listener method throws an exception.
 	 * @return the error handler.
 	 * @since 2.0
 	 */
 	String errorHandler() default "";
+
+	/**
+	 * Set the concurrency of the listener container for this listener. Overrides the
+	 * default set by the listener container factory. Maps to the concurrency setting of
+	 * the container type.
+	 * <p>For a
+	 * {@link org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer
+	 * SimpleMessageListenerContainer} if this value is a simple integer, it sets a fixed
+	 * number of consumers in the {@code concurrentConsumers} property. If it is a string
+	 * with the form {@code "m-n"}, the {@code concurrentConsumers} is set to {@code m}
+	 * and the {@code maxConcurrentConsumers} is set to {@code n}.
+	 * <p>For a
+	 * {@link org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer
+	 * DirectMessageListenerContainer} it sets the {@code consumersPerQueue} property.
+	 * @return the concurrency.
+	 * @since 2.0
+	 */
+	String concurrency() default "";
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -402,6 +402,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 		endpoint.setMessageHandlerMethodFactory(this.messageHandlerMethodFactory);
 		endpoint.setId(getEndpointId(rabbitListener));
 		endpoint.setQueueNames(resolveQueues(rabbitListener));
+		endpoint.setConcurrency(resolveExpressionAsStringOrInteger(rabbitListener.concurrency(), "concurrency"));
 		String group = rabbitListener.group();
 		if (StringUtils.hasText(group)) {
 			Object resolvedGroup = resolveExpression(group);
@@ -694,6 +695,23 @@ public class RabbitListenerAnnotationBeanPostProcessor
 		Object resolved = resolveExpression(value);
 		if (resolved instanceof String) {
 			return (String) resolved;
+		}
+		else {
+			throw new IllegalStateException("The [" + attribute + "] must resolve to a String. "
+					+ "Resolved to [" + resolved.getClass() + "] for [" + value + "]");
+		}
+	}
+
+	private String resolveExpressionAsStringOrInteger(String value, String attribute) {
+		if (!StringUtils.hasLength(value)) {
+			return null;
+		}
+		Object resolved = resolveExpression(value);
+		if (resolved instanceof String) {
+			return (String) resolved;
+		}
+		else if (resolved instanceof Integer) {
+			return resolved.toString();
 		}
 		else {
 			throw new IllegalStateException("The [" + attribute + "] must resolve to a String. "

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
@@ -328,7 +328,7 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 		instance.setListenerId(endpoint.getId());
 
 		endpoint.setupListenerContainer(instance);
-		initializeContainer(instance);
+		initializeContainer(instance, endpoint);
 
 		return instance;
 	}
@@ -343,9 +343,10 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 	 * Further initialize the specified container.
 	 * <p>Subclasses can inherit from this method to apply extra
 	 * configuration if necessary.
-	 * @param instance the containe instance to configure.
+	 * @param instance the container instance to configure.
+	 * @param endpoint the endpoint.
 	 */
-	protected void initializeContainer(C instance) {
+	protected void initializeContainer(C instance, RabbitListenerEndpoint endpoint) {
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/DirectRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/DirectRabbitListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.amqp.rabbit.config;
 
 import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpoint;
 import org.springframework.scheduling.TaskScheduler;
 
 /**
@@ -73,8 +74,8 @@ public class DirectRabbitListenerContainerFactory
 	}
 
 	@Override
-	protected void initializeContainer(DirectMessageListenerContainer instance) {
-		super.initializeContainer(instance);
+	protected void initializeContainer(DirectMessageListenerContainer instance, RabbitListenerEndpoint endpoint) {
+		super.initializeContainer(instance, endpoint);
 
 		if (this.taskScheduler != null) {
 			instance.setTaskScheduler(this.taskScheduler);
@@ -82,7 +83,15 @@ public class DirectRabbitListenerContainerFactory
 		if (this.monitorInterval != null) {
 			instance.setMonitorInterval(this.monitorInterval);
 		}
-		if (this.consumersPerQueue != null) {
+		if (endpoint.getConcurrency() != null) {
+			try {
+				instance.setConsumersPerQueue(Integer.parseInt(endpoint.getConcurrency()));
+			}
+			catch (NumberFormatException e) {
+				throw new IllegalStateException("Failed to parse concurrency: " + e.getMessage());
+			}
+		}
+		else if (this.consumersPerQueue != null) {
 			instance.setConsumersPerQueue(this.consumersPerQueue);
 		}
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.config;
 
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 
 /**
@@ -120,16 +121,20 @@ public class SimpleRabbitListenerContainerFactory
 	}
 
 	@Override
-	protected void initializeContainer(SimpleMessageListenerContainer instance) {
-		super.initializeContainer(instance);
+	protected void initializeContainer(SimpleMessageListenerContainer instance, RabbitListenerEndpoint endpoint) {
+		super.initializeContainer(instance, endpoint);
 
 		if (this.txSize != null) {
 			instance.setTxSize(this.txSize);
 		}
-		if (this.concurrentConsumers != null) {
+		String concurrency = endpoint.getConcurrency();
+		if (concurrency != null) {
+			instance.setConcurrency(concurrency);
+		}
+		else if (this.concurrentConsumers != null) {
 			instance.setConcurrentConsumers(this.concurrentConsumers);
 		}
-		if (this.maxConcurrentConsumers != null) {
+		if ((concurrency == null || !(concurrency.contains("-"))) && this.maxConcurrentConsumers != null) {
 			instance.setMaxConcurrentConsumers(this.maxConcurrentConsumers);
 		}
 		if (this.startConsumerMinInterval != null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
@@ -57,6 +57,8 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 
 	private Integer priority;
 
+	private String concurrency;
+
 	private RabbitAdmin admin;
 
 	private BeanFactory beanFactory;
@@ -173,6 +175,27 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 	 */
 	public Integer getPriority() {
 		return this.priority;
+	}
+
+	/**
+	 * Set the concurrency of this endpoint; usually overrides any concurrency
+	 * settings on the container factory. Contents depend on container implementation.
+	 * @param concurrency the concurrency.
+	 * @since 2.0
+	 */
+	public void setConcurrency(String concurrency) {
+		this.concurrency = concurrency;
+	}
+
+	/**
+	 * The concurrency of this endpoint; Not used by this abstract class;
+	 * used by subclasses to set the concurrency appropriate for the container type.
+	 * @return the concurrency.
+	 * @since 2.0
+	 */
+	@Override
+	public String getConcurrency() {
+		return this.concurrency;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,12 @@ public interface RabbitListenerEndpoint {
 	 * @since 1.5
 	 */
 	String getGroup();
+
+	/**
+	 * @return the concurrency of this endpoint.
+	 * @since 2.0
+	 */
+	String getConcurrency();
 
 	/**
 	 * Setup the specified message listener container with the model

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -189,6 +189,33 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
+	 * Specify concurrency limits via a "lower-upper" String, e.g. "5-10", or a simple
+	 * upper limit String, e.g. "10" (a fixed number of consumers).
+	 * <p>This listener container will always hold on to the minimum number of consumers
+	 * ({@link #setConcurrentConsumers}) and will slowly scale up to the maximum number
+	 * of consumers {@link #setMaxConcurrentConsumers} in case of increasing load.
+	 * @param concurrency the concurrency.
+	 * @since 2.0
+	 */
+	public void setConcurrency(String concurrency) {
+		try {
+			int separatorIndex = concurrency.indexOf('-');
+			if (separatorIndex != -1) {
+				setConcurrentConsumers(Integer.parseInt(concurrency.substring(0, separatorIndex)));
+				setMaxConcurrentConsumers(
+						Integer.parseInt(concurrency.substring(separatorIndex + 1, concurrency.length())));
+			}
+			else {
+				setConcurrentConsumers(Integer.parseInt(concurrency));
+			}
+		}
+		catch (NumberFormatException ex) {
+			throw new IllegalArgumentException("Invalid concurrency value [" + concurrency + "]: only " +
+					"single fixed integer (e.g. \"5\") and minimum-maximum combo (e.g. \"3-5\") supported.");
+		}
+	}
+
+	/**
 	 * Set to true for an exclusive consumer - if true, the concurrency must be 1.
 	 * @param exclusive true for an exclusive consumer.
 	 */

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1766,6 +1766,8 @@ public class AppConfig {
 }
 ----
 
+Since _version 2.0_, a `DirectMessageListenerContainerFactory` is also available, which creates `DirectMessageListenerContainer` s.
+
 NOTE: To choose between the `SimpleRabbitListenerContainerFactory` and `DirectRabbitListenerContainerFactory` see <<choose-container>>.
 
 By default, the infrastructure looks for a bean named `rabbitListenerContainerFactory` as the source for the factory to use to create message listener containers.
@@ -1775,11 +1777,12 @@ It is possible to customize the listener container factory to use per annotation
 The default is only required if at least one endpoint is registered without a specific container factory.
 See the javadoc for full details and examples.
 
-If you prefer XML configuration, use the `<rabbit:annotation-driven>` element.
+If you prefer XML configuration, use the `<rabbit:annotation-driven>` element; any beans annotated with `@RabbitListener` will be detected.
+
+For `SimpleRabbitListenerContainer` s:
 
 [source,xml]
 ----
-
 <rabbit:annotation-driven/>
 
 <bean id="rabbitListenerContainerFactory"
@@ -1788,8 +1791,29 @@ If you prefer XML configuration, use the `<rabbit:annotation-driven>` element.
     <property name="concurrentConsumers" value="3"/>
     <property name="maxConcurrentConsumers" value="10"/>
 </bean>
-
 ----
+
+and for `DirectMessageListenerContainer` s:
+
+[source,xml]
+----
+<rabbit:annotation-driven/>
+
+<bean id="rabbitListenerContainerFactory"
+      class="org.springframework.amqp.rabbit.config.DirectRabbitListenerContainerFactory">
+    <property name="connectionFactory" ref="connectionFactory"/>
+    <property name="consumersPerQueue" value="3"/>
+</bean>
+----
+
+Starting with _version 2.0_, the `@RabbitListener` annotation has a `concurrency` property; it supports SpEL expressions (`#{...}`) and property placeholders (`${...}`).
+Its meaning, and allowed values, depend on the container type.
+
+- For the `DirectMessageListenerContainer`, the value must be a single integer value, which sets the `consumersPerQueue` property on the container.
+- For the `SimpleRabbitListenerContainer`, the value can be a single integer value, which sets the `concurrentConsumers` property on the container, or it can have the form `m-n` where `m` is the `concurrentConsumers` property, and `n` is the `maxConcurrentConsumers` property.
+
+In either case, this setting overrides the setting(s) on the factory.
+Previously you had to define different container factories if you had listeners that required different concurrency.
 
 [[async-annotation-conversion]]
 ====== Message Conversion for Annotated Methods
@@ -4260,6 +4284,16 @@ See <<listener-concurrency>>.
 a| image::images/tickmark.png[]
 a|
 
+| concurrency
+(N/A)
+
+| `m-n` The range of concurrent consumers for each listener (min, max).
+If only `n` is provided, `n` is a fixed number of consumers.
+See <<listener-concurrency>>.
+
+a| image::images/tickmark.png[]
+a|
+
 | startConsumerMin
 Interval
 (min-start-interval)
@@ -4577,6 +4611,8 @@ NOTE: Practically, consumers will only be stopped if the whole container is idle
 This is because the broker will share its work across all the active consumers.
 
 A single channel is used by each consumer, regardless of the number of configured queues.
+
+Starting with version _2.0_ the `concurrentConsumers` and `maxConcurrentConsumers` properties can be set with the single property `concurrency`; e.g. `"2-4"`.
 
 ===== DirectMessageListenerContainer
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -107,6 +107,7 @@ See <<annotation-error-handling>> for more information.
 You can now bind a queue with multiple routing keys when using the `@QueueBinding` annotation.
 Also `@QueueBinding.exchange()` now supports custom exchange types and declares durable exchanges by default.
 
+You can now set the `concurrency` of the listener container at the annotation level rather than having to configure a different container factory for different concurrency settings.
 
 See <<async-annotation-driven>> for more information.
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-736

Support concurrency on the annotation to avoid having to configure a different factory for each listener.