### PR TITLE
AMQP-738: DMLC: Add messagesPerAck

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -212,9 +212,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	/**
-	 * An approximate timeout; when messagesPerAck is > 1 and this time elapses since the
-	 * last ack, without messages arriving, the pending acks will be sent. The actual time
-	 * depends on the {@link #setMonitorInterval(long) monitorInterval}.
+	 * An approximate timeout; when messagesPerAck is greater than 1 and this time elapses
+	 * since the last ack, without messages arriving, the pending acks will be sent. The
+	 * actual time depends on the {@link #setMonitorInterval(long) monitorInterval}.
 	 * @param ackTimeout the timeout in milliseconds (default 20000);
 	 */
 	public void setAckTimeout(long ackTimeout) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -206,16 +206,20 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 	 * Set the number of messages to receive before acknowledging (success).
 	 * A failed message will short-circuit this counter.
 	 * @param messagesPerAck the number of messages.
+	 * @see DirectMessageListenerContainer#setAckTimeout(long)
 	 */
 	public void setMessagesPerAck(int messagesPerAck) {
 		this.messagesPerAck = messagesPerAck;
 	}
 
 	/**
-	 * An approximate timeout; when messagesPerAck is greater than 1 and this time elapses
-	 * since the last ack, without messages arriving, the pending acks will be sent. The
-	 * actual time depends on the {@link #setMonitorInterval(long) monitorInterval}.
+	 * An approximate timeout; when {@link #setMessagesPerAck(int) messagesPerAck} is
+	 * greater than 1, and this time elapses since the last ack, the pending acks will be
+	 * sent either when the next message arrives, or a short time later if no additional
+	 * messages arrive. In that case, the actual time depends on the
+	 * {@link #setMonitorInterval(long) monitorInterval}.
 	 * @param ackTimeout the timeout in milliseconds (default 20000);
+	 * @see #setMessagesPerAck(int)
 	 */
 	public void setAckTimeout(long ackTimeout) {
 		this.ackTimeout = ackTimeout;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -206,7 +206,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 	 * Set the number of messages to receive before acknowledging (success).
 	 * A failed message will short-circuit this counter.
 	 * @param messagesPerAck the number of messages.
-	 * @see DirectMessageListenerContainer#setAckTimeout(long)
+	 * @see #setAckTimeout(long)
 	 */
 	public void setMessagesPerAck(int messagesPerAck) {
 		this.messagesPerAck = messagesPerAck;
@@ -876,7 +876,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 							&& TransactionSynchronizationManager.getResource(this.connectionFactory) == null);
 			try {
 				if (this.ackRequired) {
-					if (this.messagesPerAck > 0) {
+					if (this.messagesPerAck > 1) {
 						synchronized (this) {
 							this.deliveryTag = deliveryTag;
 							this.pendingAcks++;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
@@ -192,7 +192,7 @@ public class DirectMessageListenerContainerMockTests {
 			latch5.countDown();
 			return null;
 		}).given(channel).basicCancel("consumerTag");
-		Executors.newSingleThreadExecutor().execute(() -> container.stop());
+		Executors.newSingleThreadExecutor().execute(container::stop);
 		assertTrue(latch5.await(10, TimeUnit.SECONDS));
 		// pending acks on stop
 		verify(channel).basicAck(20L, true);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
@@ -22,16 +22,20 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -41,8 +45,10 @@ import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 
 import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.impl.recovery.AutorecoveringChannel;
 
 /**
@@ -94,6 +100,106 @@ public class DirectMessageListenerContainerMockTests {
 		isOpen.set(false);
 		assertTrue(latch2.await(10, TimeUnit.SECONDS));
 		container.stop();
+	}
+
+	@Test
+	public void testDeferredAcks() throws Exception {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		Connection connection = mock(Connection.class);
+		ChannelProxy channel = mock(ChannelProxy.class);
+		Channel rabbitChannel = mock(AutorecoveringChannel.class);
+		given(channel.getTargetChannel()).willReturn(rabbitChannel);
+
+		given(connectionFactory.createConnection()).willReturn(connection);
+		given(connection.createChannel(anyBoolean())).willReturn(channel);
+		given(channel.isOpen()).willReturn(true);
+		given(channel.queueDeclarePassive(Mockito.anyString()))
+				.willAnswer(invocation -> mock(AMQP.Queue.DeclareOk.class));
+		final AtomicReference<Consumer> consumer = new AtomicReference<>();
+		final CountDownLatch latch1 = new CountDownLatch(1);
+		willAnswer(i -> {
+			consumer.set(i.getArgument(6));
+			consumer.get().handleConsumeOk("consumerTag");
+			latch1.countDown();
+			return "consumerTag";
+		})
+		.given(channel).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
+						anyMap(), any(Consumer.class));
+
+		final AtomicInteger qos = new AtomicInteger();
+		willAnswer(i -> {
+			qos.set(i.getArgument(0));
+			return null;
+		}).given(channel).basicQos(anyInt());
+		final CountDownLatch latch2 = new CountDownLatch(2);
+		final CountDownLatch latch3 = new CountDownLatch(1);
+		willAnswer(i -> {
+			if (i.getArgument(0).equals(10L) || i.getArgument(0).equals(16L)) {
+				latch2.countDown();
+			}
+			else if (i.getArgument(0).equals(17L)) {
+				latch3.countDown();
+			}
+			return null;
+		}).given(channel).basicAck(anyLong(), anyBoolean());
+		final CountDownLatch latch4 = new CountDownLatch(1);
+		willAnswer(i -> {
+			latch4.countDown();
+			return null;
+		}).given(channel).basicNack(19L, true, true);
+
+		DirectMessageListenerContainer container = new DirectMessageListenerContainer(connectionFactory);
+		container.setQueueNames("test");
+		container.setPrefetchCount(2);
+		container.setMonitorInterval(100);
+		container.setMessagesPerAck(10);
+		container.setAckTimeout(100);
+		container.setMessageListener(m -> {
+			if (m.getMessageProperties().getDeliveryTag() == 19L) {
+				throw new RuntimeException("TestNackAndPendingAcks");
+			}
+		});
+		container.afterPropertiesSet();
+		container.start();
+
+		assertTrue(latch1.await(10, TimeUnit.SECONDS));
+		assertThat(qos.get(), equalTo(2));
+		BasicProperties props = new BasicProperties();
+		byte[] body = new byte[1];
+		for (long i = 1; i < 16; i++) {
+			consumer.get().handleDelivery("consumerTag", envelope(i), props, body);
+		}
+		Thread.sleep(200);
+		consumer.get().handleDelivery("consumerTag", envelope(16), props, body);
+		// should get 2 acks #10 and #6 (timeout)
+		assertTrue(latch2.await(10, TimeUnit.SECONDS));
+		consumer.get().handleDelivery("consumerTag", envelope(17), props, body);
+		verify(channel).basicAck(10L, true);
+		verify(channel).basicAck(16L, true);
+		assertTrue(latch3.await(10, TimeUnit.SECONDS));
+		// monitor task timeout
+		verify(channel).basicAck(17L, true);
+		consumer.get().handleDelivery("consumerTag", envelope(18), props, body);
+		consumer.get().handleDelivery("consumerTag", envelope(19), props, body);
+		assertTrue(latch4.await(10, TimeUnit.SECONDS));
+		// pending acks before nack
+		verify(channel).basicAck(18L, true);
+		verify(channel).basicNack(19L, true, true);
+		consumer.get().handleDelivery("consumerTag", envelope(20), props, body);
+		final CountDownLatch latch5 = new CountDownLatch(1);
+		willAnswer(i -> {
+			consumer.get().handleCancelOk("consumerTag");
+			latch5.countDown();
+			return null;
+		}).given(channel).basicCancel("consumerTag");
+		Executors.newSingleThreadExecutor().execute(() -> container.stop());
+		assertTrue(latch5.await(10, TimeUnit.SECONDS));
+		// pending acks on stop
+		verify(channel).basicAck(20L, true);
+	}
+
+	private Envelope envelope(long tag) {
+		return new Envelope(tag,  false, "", "");
 	}
 
 }

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4198,6 +4198,31 @@ If the `prefetchCount` is less than the `txSize`, it will be increased to match 
 a| image::images/tickmark.png[]
 a|
 
+| messagesPerAck
+(N/A)
+
+| The number of messages to receive between acks.
+Use this to reduce the number of acks sent to the broker (at the cost of increasing the possibility of redelivered messages).
+Generally, you should only set this property on high-volume listener containers.
+If this is set, and a message is rejected (exception thrown), pending acks will be acknowledged and the failed message rejected.
+Not allowed with transacted channels.
+Default: ack every message.
+See also `ackTimeout`.
+
+a|
+a| image::images/tickmark.png[]
+
+| ackTimout
+(N/A)
+
+| When `messagesPerAck` is set, this timeout is used an an alternative to send an ack.
+When a new message arrives, the count of unacked messages is compared to `messagesPerAck`, and the time since the last ack is compared to this value; if either condition is true, the message is acknowledged.
+When no new messages arrive, and there are unacked messages, this timeout is approximate since the condition is only checked each `monitorInterval`.
+See also `messagesPerAck`, `monitorInterval`.
+
+a|
+a| image::images/tickmark.png[]
+
 | receiveTimeout
 (receive-timeout)
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4212,10 +4212,10 @@ See also `ackTimeout`.
 a|
 a| image::images/tickmark.png[]
 
-| ackTimout
+| ackTimeout
 (N/A)
 
-| When `messagesPerAck` is set, this timeout is used an an alternative to send an ack.
+| When `messagesPerAck` is set, this timeout is used as an alternative to send an ack.
 When a new message arrives, the count of unacked messages is compared to `messagesPerAck`, and the time since the last ack is compared to this value; if either condition is true, the message is acknowledged.
 When no new messages arrive, and there are unacked messages, this timeout is approximate since the condition is only checked each `monitorInterval`.
 See also `messagesPerAck`, `monitorInterval`.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-738

Using a `DirectMessageListenerContainer`, support sending acks in batches to reduce network traffic in high volume environments.