### PR TITLE
AMQP-739: SimpleMessageConverter + Not Convertible

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SimpleMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/SimpleMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,8 +155,10 @@ public class SimpleMessageConverter extends WhiteListDeserializingMessageConvert
 		}
 		if (bytes != null) {
 			messageProperties.setContentLength(bytes.length);
+			return new Message(bytes, messageProperties);
 		}
-		return new Message(bytes, messageProperties);
+		throw new IllegalArgumentException(getClass().getSimpleName()
+				+ " only supports String, byte[] and Serializable payloads, received: " + object.getClass().getName());
 	}
 
 	/**

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/SimpleMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/SimpleMessageConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package org.springframework.amqp.support.converter;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -157,6 +160,21 @@ public class SimpleMessageConverterTests extends WhiteListDeserializingMessageCo
 		this.exception.expect(MessageConversionException.class);
 		this.exception.expectCause(instanceOf(IllegalStateException.class));
 		converter.fromMessage(message);
+	}
+
+	@Test
+	public void notConvertible() {
+		class Foo {
+
+		}
+		try {
+			new SimpleMessageConverter().toMessage(new Foo(), new MessageProperties());
+			fail("Expected exception");
+		}
+		catch (IllegalArgumentException e) {
+			assertThat(e.getMessage(), containsString(
+					"SimpleMessageConverter only supports String, byte[] and Serializable payloads, received:"));
+		}
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-739

Reject non-convertible source objects rather than sending a `null` body.