### PR TITLE
AMQP-738: Fix prefetchCount with messagesPerAck

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -338,6 +338,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 	protected void actualStart() throws Exception {
 		this.aborted = false;
 		this.hasStopped = false;
+		if (getPrefetchCount() < this.messagesPerAck) {
+			setPrefetchCount(this.messagesPerAck);
+		}
 		super.doStart();
 		final String[] queueNames = getQueueNames();
 		checkMissingQueues(queueNames);
@@ -905,7 +908,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		 */
 		private synchronized void ackIfNecessary(long now) throws IOException {
 			if (this.pendingAcks >= this.messagesPerAck || (
-					this.pendingAcks > 0 && now - this.lastAck > this.ackTimeout) || this.canceled) {
+					this.pendingAcks > 0 && (now - this.lastAck > this.ackTimeout || this.canceled))) {
 				sendAck(now);
 			}
 		}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4172,7 +4172,7 @@ a| image::images/tickmark.png[]
 | The number of messages to accept from the broker in one socket frame.
 The higher this is the faster the messages can be delivered, but the higher the risk of non-sequential processing.
 Ignored if the `acknowledgeMode` is NONE.
-This will be increased, if necessary, to match the `txSize`.
+This will be increased, if necessary, to match the `txSize` or `messagePerAck`.
 
 a| image::images/tickmark.png[]
 a| image::images/tickmark.png[]
@@ -4206,6 +4206,7 @@ Use this to reduce the number of acks sent to the broker (at the cost of increas
 Generally, you should only set this property on high-volume listener containers.
 If this is set, and a message is rejected (exception thrown), pending acks will be acknowledged and the failed message rejected.
 Not allowed with transacted channels.
+If the `prefetchCount` is less than the `messagesPerAck`, it will be increased to match the `messagesPerAck`.
 Default: ack every message.
 See also `ackTimeout`.
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-738

The `prefetchCount` must be at least `messagesPerAck` otherwise the broker
won't send enough messages.

Adjust up the `prefetchCount` if necessary, as does the `SMLC` for `txSize`.

Also fix the condition for sending acks after the consumer is canceled - the current logic caused an extra ack attempt when stopping the container - the `canceled` flag applied unconditionally, even if no acks were pending.