### PR TITLE
AMQP-741: Fix Headers Containing Arrays

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
@@ -185,9 +185,16 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
 				|| (value instanceof LongString) || (value instanceof Integer) || (value instanceof Long)
 				|| (value instanceof Float) || (value instanceof Double) || (value instanceof BigDecimal)
 				|| (value instanceof Short) || (value instanceof Byte) || (value instanceof Date)
-				|| (value instanceof List) || (value instanceof Map);
+				|| (value instanceof List) || (value instanceof Map) || (value instanceof Object[]);
 		if (!valid && value != null) {
 			value = value.toString();
+		}
+		else if (value instanceof Object[]) {
+			Object[] writableArray = new Object[((Object[]) value).length];
+			for (int i = 0; i < writableArray.length; i++) {
+				writableArray[i] = convertHeaderValueIfNecessary(((Object[]) value)[i]);
+			}
+			value = writableArray;
 		}
 		else if (value instanceof List<?>) {
 			List<Object> writableList = new ArrayList<Object>(((List<?>) value).size());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -409,9 +410,21 @@ public class RabbitTemplateIntegrationTests {
 
 	@Test
 	public void testSendAndReceiveWithPostProcessor() throws Exception {
+		final String[] strings = new String[] { "1", "2" };
 		template.convertAndSend(ROUTE, (Object) "message", message -> {
 			message.getMessageProperties().setContentType("text/other");
 			// message.getMessageProperties().setUserId("foo");
+			MessageProperties props = message.getMessageProperties();
+			props.getHeaders().put("strings", strings);
+			props.getHeaders().put("objects", new Object[] { new Foo(), new Foo() });
+			props.getHeaders().put("bytes", "abc".getBytes());
+			return message;
+		});
+		template.setAfterReceivePostProcessors(message -> {
+			assertEquals(Arrays.asList(strings), message.getMessageProperties().getHeaders().get("strings"));
+			assertEquals(Arrays.asList(new String[] { "FooAsAString", "FooAsAString" }),
+					message.getMessageProperties().getHeaders().get("objects"));
+			assertArrayEquals("abc".getBytes(), (byte[]) message.getMessageProperties().getHeaders().get("bytes"));
 			return message;
 		});
 		String result = (String) template.receiveAndConvert(ROUTE);
@@ -1555,6 +1568,19 @@ public class RabbitTemplateIntegrationTests {
 		@Bean
 		public ConnectionFactory defaultCF() {
 			return mock(ConnectionFactory.class);
+		}
+
+	}
+
+	private static class Foo {
+
+		Foo() {
+			super();
+		}
+
+		@Override
+		public String toString() {
+			return "FooAsAString";
 		}
 
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverterTests.java
@@ -201,8 +201,8 @@ public class DefaultMessagePropertiesConverterTests {
 		assertEquals(MessageDeliveryMode.toInt(MessageDeliveryMode.NON_PERSISTENT), bProps.getDeliveryMode().intValue());
 		props = converter.toMessageProperties(bProps, null, "UTF-8");
 		assertEquals(MessageDeliveryMode.NON_PERSISTENT, props.getReceivedDeliveryMode());
-		assertArrayEquals(strings, (String[]) props.getHeaders().get("strings"));
-		assertEquals("[FooAsAString]", props.getHeaders().get("objects").toString());
+		assertArrayEquals(strings, (Object[]) props.getHeaders().get("strings"));
+		assertEquals("[FooAsAString]", Arrays.asList((Object[]) props.getHeaders().get("objects")).toString());
 		assertNull(props.getDeliveryMode());
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.support;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -192,12 +193,30 @@ public class DefaultMessagePropertiesConverterTests {
 	public void testInboundDeliveryMode() {
 		DefaultMessagePropertiesConverter converter = new DefaultMessagePropertiesConverter();
 		MessageProperties props = new MessageProperties();
+		String[] strings = new String[] { "1", "2" };
+		props.getHeaders().put("strings", strings);
+		props.getHeaders().put("objects", new Object[] { new Foo() });
 		props.setDeliveryMode(MessageDeliveryMode.NON_PERSISTENT);
 		BasicProperties bProps = converter.fromMessageProperties(props, "UTF-8");
 		assertEquals(MessageDeliveryMode.toInt(MessageDeliveryMode.NON_PERSISTENT), bProps.getDeliveryMode().intValue());
 		props = converter.toMessageProperties(bProps, null, "UTF-8");
 		assertEquals(MessageDeliveryMode.NON_PERSISTENT, props.getReceivedDeliveryMode());
+		assertArrayEquals(strings, (String[]) props.getHeaders().get("strings"));
+		assertEquals("[FooAsAString]", props.getHeaders().get("objects").toString());
 		assertNull(props.getDeliveryMode());
+	}
+
+	private static class Foo {
+
+		Foo() {
+			super();
+		}
+
+		@Override
+		public String toString() {
+			return "FooAsAString";
+		}
+
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-741

The `DefaultMessagePropertiesConverter` incorrectly converts headers containing arrays (e.g. String[]) toString().

The java client handles arrays in headers.

Change the converter to allow arrays to pass down to the client (after converting the element values if necessary).

__cherry-pick to 1.7.x, 1.6.x__