### PR TITLE
Make Mismatched Queue Tests More Robust

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root=true
+
+[*.java]
+indent_style = tab
+indent_size = 4
+continuation_indent_size = 8
+
+[*.xml]
+indent_style = tab
+indent_size = 4
+continuation_indent_size = 8

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ShutDownChannelListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ShutDownChannelListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.ShutdownSignalException;
+
+/**
+ * Functional sub interface enabling a lambda for the onShutDown method.
+ *
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+@FunctionalInterface
+public interface ShutDownChannelListener extends ChannelListener {
+
+	@Override
+	default void onCreate(Channel channel, boolean transactional) {
+	}
+
+	@Override
+	void onShutDown(ShutdownSignalException signal);
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerInitializationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerInitializationTests.java
@@ -20,7 +20,11 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -30,10 +34,13 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.RabbitUtils;
+import org.springframework.amqp.rabbit.connection.ShutDownChannelListener;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.listener.exception.FatalListenerStartupException;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -87,12 +94,15 @@ public class ContainerInitializationTests {
 	@Test
 	public void testMismatchedQueueDuringRestart() throws Exception {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config2.class);
+		CountDownLatch[] latches = setUpChannelLatches(context);
 		RabbitAdmin admin = context.getBean(RabbitAdmin.class);
 		admin.deleteQueue(TEST_MISMATCH);
+		assertTrue(latches[0].await(20, TimeUnit.SECONDS));
 		admin.declareQueue(new Queue(TEST_MISMATCH, false, false, true));
+		assertTrue(latches[1].await(20, TimeUnit.SECONDS));
 		SimpleMessageListenerContainer container = context.getBean(SimpleMessageListenerContainer.class);
 		int n = 0;
-		while (n++ < 100 && container.isRunning()) {
+		while (n++ < 200 && container.isRunning()) {
 			Thread.sleep(100);
 		}
 		assertFalse(container.isRunning());
@@ -102,9 +112,12 @@ public class ContainerInitializationTests {
 	@Test
 	public void testMismatchedQueueDuringRestartMultiQueue() throws Exception {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config3.class);
+		CountDownLatch[] latches = setUpChannelLatches(context);
 		RabbitAdmin admin = context.getBean(RabbitAdmin.class);
 		admin.deleteQueue(TEST_MISMATCH);
+		assertTrue(latches[0].await(20, TimeUnit.SECONDS));
 		admin.declareQueue(new Queue(TEST_MISMATCH, false, false, true));
+		assertTrue(latches[1].await(20, TimeUnit.SECONDS));
 		SimpleMessageListenerContainer container = context.getBean(SimpleMessageListenerContainer.class);
 		int n = 0;
 		while (n++ < 100 && container.isRunning()) {
@@ -112,6 +125,21 @@ public class ContainerInitializationTests {
 		}
 		assertFalse(container.isRunning());
 		context.close();
+	}
+
+	private CountDownLatch[] setUpChannelLatches(ApplicationContext context) {
+		CachingConnectionFactory cf = context.getBean(CachingConnectionFactory.class);
+		final CountDownLatch cancelLatch = new CountDownLatch(1);
+		final CountDownLatch mismatchLatch = new CountDownLatch(1);
+		cf.addChannelListener((ShutDownChannelListener) s -> {
+			if (RabbitUtils.isNormalChannelClose(s)) {
+				cancelLatch.countDown();
+			}
+			else if (RabbitUtils.isMismatchedQueueArgs(s)) {
+				mismatchLatch.countDown();
+			}
+		});
+		return new CountDownLatch[] { cancelLatch, mismatchLatch };
 	}
 
 	@Configuration


### PR DESCRIPTION
https://build.spring.io/browse/AMQP-MEIGHT-1066/test

- Add latches to wait for channel close events
  - normal close after cancel
  - fatal close for mismatch
- Add `ShutDownChannelListener` `@FunctionalInterface`