### PR TITLE
AMQP-743: Properly stop Log4J2 AmqpAppender

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -334,6 +334,12 @@ public class AmqpAppender extends AbstractAppender {
 		}
 	}
 
+	@Override
+	protected boolean stop(long timeout, TimeUnit timeUnit, boolean changeLifeCycleState) {
+		boolean stopped = super.stop(timeout, timeUnit, changeLifeCycleState);
+		return stopped & this.manager.stop(timeout, timeUnit);
+	}
+
 	/**
 	 * Helper class to actually send LoggingEvents asynchronously.
 	 */

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
@@ -16,9 +16,11 @@
 
 package org.springframework.amqp.rabbit.log4j2;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -101,11 +103,13 @@ public class AmqpAppenderTests {
 		Message received = template.receive(queue.getName());
 		assertNotNull(received);
 		assertEquals("testAppId.foo.INFO", received.getMessageProperties().getReceivedRoutingKey());
-		assertEquals("foo\n", new String(received.getBody()));
+		// Cross-platform string comparison. Windows expects \n\r in the end of line
+		assertThat(new String(received.getBody()), startsWith("foo"));
 		received = template.receive(queue.getName());
 		assertNotNull(received);
 		assertEquals("testAppId.foo.INFO", received.getMessageProperties().getReceivedRoutingKey());
-		assertEquals("bar\n", new String(received.getBody()));	}
+		assertThat(new String(received.getBody()), startsWith("bar"));
+	}
 
 	@Test
 	public void testProperties() {

--- a/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
+++ b/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration packages="org.springframework.amqp.rabbit.log4j2">
+<Configuration packages="org.springframework.amqp.rabbit.log4j2" status="DEBUG">
 	<Appenders>
 		<Console name="STDOUT" target="SYSTEM_OUT">
 			<PatternLayout pattern="%m%n" />


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-743

The `AmqpManager` isn't registered as a lifecycle in the `LoggerContext`,
therefore the `AmqpAppender` should take care about its lifecycle.

* Override `stop()` method for the `AmqpAppender` and perform
`AmqpManager.stop()` from there
* Fix `AmqpAppenderTests` for cross-platform assertions
* Add `status="DEBUG"` to the `log4j2-amqp-appender.xml` to track
the logging configuration process

**Cherry-pick to 1.7.x & 1.6.x**