### PR TITLE
always log QueuesNotAvailableException

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -632,6 +632,9 @@ public class BlockingQueueConsumer {
 				if (failures == null) {
 					failures = new DeclarationException(e);
 				}
+				else {
+					failures.addSuppressed(e);
+				}
 				failures.addFailedQueue(queueName);
 			}
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -586,9 +586,12 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 						"Exclusive consumer failure", e.getCause());
 				publishConsumerFailedEvent("Consumer raised exception, attempting restart", false, e);
 			}
-			else if (this.logger.isDebugEnabled()) {
-				this.logger.debug(
-						"Queue not present or basicConsume failed, scheduling consumer " + consumer + " for restart");
+			else if (e.getCause() instanceof ShutdownSignalException
+					&& RabbitUtils.isPassiveDeclarationChannelClose((ShutdownSignalException) e.getCause())) {
+				this.logger.error("Queue not present, scheduling consumer " + consumer + " for restart", e);
+			}
+			else if (this.logger.isWarnEnabled()) {
+				this.logger.warn("basicConsume failed, scheduling consumer " + consumer + " for restart", e);
 			}
 			this.consumersToRestart.add(consumer);
 			consumer = null;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1004,8 +1004,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				publishConsumerFailedEvent("Consumer thread interrupted, processing stopped", true, e);
 			}
 			catch (QueuesNotAvailableException ex) {
+				logger.error("Consumer received fatal=" + isMismatchedQueuesFatal() + " exception on startup", ex);
 				if (isMissingQueuesFatal()) {
-					logger.error("Consumer received fatal exception on startup", ex);
 					this.startupException = ex;
 					// Fatal, but no point re-throwing, so just abort.
 					aborted = true;


### PR DESCRIPTION
It makes sense to have an error logged always if queue is missing.

If that's treated as fatal, then the context is not allowed to start. If that's not fatal, then context starts, subsequent attempts to start the listener are made (infinite by default), and something in the application still does not work - that's definitely an error.

To be discussed what the exact message should be in this case.

It would be nice to have this backported.