### PR TITLE
AMQP-749: Force Close Channel With Slow Consumer

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -173,10 +173,13 @@ public abstract class RabbitUtils {
 
 	/**
 	 * Sets a ThreadLocal indicating the channel MUST be physically closed.
-	 * @param b true if the channel must be closed.
+	 * @param channel the channel.
+	 * @param b true if the channel must be closed (if it's a proxy).
 	 */
-	public static void setPhysicalCloseRequired(boolean b) {
-		physicalCloseRequired.set(b);
+	public static void setPhysicalCloseRequired(Channel channel, boolean b) {
+		if (channel instanceof ChannelProxy) {
+			physicalCloseRequired.set(b);
+		}
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1815,7 +1815,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 				if (channel == null) {
 					throw new IllegalStateException("Connection returned a null channel");
 				}
-				RabbitUtils.setPhysicalCloseRequired(true);
+				RabbitUtils.setPhysicalCloseRequired(channel, true);
 				this.dedicatedChannels.set(channel);
 			}
 			catch (RuntimeException e) {
@@ -1834,9 +1834,6 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			}
 			else {
 				RabbitUtils.closeChannel(channel);
-				if (!(channel instanceof ChannelProxy)) { // clear the TL flag if the channel is not a proxy
-					RabbitUtils.isPhysicalCloseRequired();
-				}
 				RabbitUtils.closeConnection(connection);
 			}
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1834,6 +1834,9 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			}
 			else {
 				RabbitUtils.closeChannel(channel);
+				if (!(channel instanceof ChannelProxy)) { // clear the TL flag if the channel is not a proxy
+					RabbitUtils.isPhysicalCloseRequired();
+				}
 				RabbitUtils.closeConnection(connection);
 			}
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -199,6 +199,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	private String lookupKeyQualifier = "";
 
+	private boolean forceCloseChannel = true;
 	/**
 	 * {@inheritDoc}
 	 * @since 1.5
@@ -547,6 +548,25 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 */
 	public void setLookupKeyQualifier(String lookupKeyQualifier) {
 		this.lookupKeyQualifier = lookupKeyQualifier;
+	}
+
+	/**
+	 * Force close the channel if the consumer threads don't respond to a shutdown.
+	 * @return true to force close.
+	 * @since 1.7.4
+	 */
+	protected boolean isForceCloseChannel() {
+		return this.forceCloseChannel;
+	}
+
+	/**
+	 * Set to true to force close the channel if the consumer threads don't respond to a
+	 * shutdown. Default: true (since 2.0).
+	 * @param forceCloseChannel true to force close.
+	 * @since 1.7.4
+	 */
+	public void setForceCloseChannel(boolean forceCloseChannel) {
+		this.forceCloseChannel = forceCloseChannel;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -661,6 +661,9 @@ public class BlockingQueueConsumer {
 		}
 		RabbitUtils.setPhysicalCloseRequired(true);
 		ConnectionFactoryUtils.releaseResources(this.resourceHolder);
+		if (!(this.channel instanceof ChannelProxy)) { // clear the TL flag if the channel is not a proxy
+			RabbitUtils.isPhysicalCloseRequired();
+		}
 		this.deliveryTags.clear();
 		this.consumer = null;
 		this.queue.clear(); // in case we still have a client thread blocked
@@ -839,6 +842,12 @@ public class BlockingQueueConsumer {
 						}
 						catch (TimeoutException e) {
 							// no-op
+						}
+						finally {
+							if (!(getChannel() instanceof ChannelProxy)) {
+								// clear the TL flag if the channel is not a proxy
+								RabbitUtils.isPhysicalCloseRequired();
+							}
 						}
 					}
 				}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -42,7 +42,6 @@ import org.springframework.amqp.AmqpIOException;
 import org.springframework.amqp.ImmediateAcknowledgeAmqpException;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
-import org.springframework.amqp.rabbit.connection.ChannelProxy;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactoryUtils;
@@ -996,11 +995,8 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		}
 
 		private void finalizeConsumer() {
-			RabbitUtils.setPhysicalCloseRequired(true);
+			RabbitUtils.setPhysicalCloseRequired(getChannel(), true);
 			RabbitUtils.closeChannel(getChannel());
-			if (!(getChannel() instanceof ChannelProxy)) { // clear the TL flag if the channel is not a proxy
-				RabbitUtils.isPhysicalCloseRequired();
-			}
 			RabbitUtils.closeConnection(this.connection);
 			DirectMessageListenerContainer.this.cancellationLock.release(this);
 			consumerRemoved(this);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -508,13 +508,13 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 					.availablePermits());
 
 		channel1 = con.createChannel(false);
-		RabbitUtils.setPhysicalCloseRequired(true);
+		RabbitUtils.setPhysicalCloseRequired(channel1, true);
 		assertEquals(0,
 				((Semaphore) TestUtils.getPropertyValue(ccf, "checkoutPermits", Map.class).values().iterator().next())
 					.availablePermits());
 
 		channel1.close();
-		RabbitUtils.setPhysicalCloseRequired(false);
+		RabbitUtils.setPhysicalCloseRequired(channel1, false);
 		con.close();
 		verify(mockChannel1).close();
 		verify(mockConnection1, never()).close();
@@ -1385,7 +1385,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 			Connection con = ccf.createConnection();
 
 			Channel channel = con.createChannel(false);
-			RabbitUtils.setPhysicalCloseRequired(true);
+			RabbitUtils.setPhysicalCloseRequired(channel, true);
 			when(mockChannel.isOpen()).thenReturn(false);
 			final CountDownLatch physicalCloseLatch = new CountDownLatch(1);
 			doAnswer(i -> {
@@ -1398,7 +1398,6 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 			assertTrue(physicalCloseLatch.await(10, TimeUnit.SECONDS));
 		}
 		finally {
-			RabbitUtils.setPhysicalCloseRequired(false);
 			executor.shutdownNow();
 		}
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerShutDownTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerShutDownTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.junit.BrokerRunning;
+import org.springframework.amqp.utils.test.TestUtils;
+
+/**
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class ContainerShutDownTests {
+
+	@ClassRule
+	public static BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues("test.shutdown");
+
+	@AfterClass
+	public static void tearDown() {
+		brokerRunning.removeTestQueues();
+	}
+
+	@Test
+	public void testUninterruptibleListenerSMLC() throws Exception {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		testUninterruptibleListener(container);
+	}
+
+	@Test
+	public void testUninterruptibleListenerDMLC() throws Exception {
+		DirectMessageListenerContainer container = new DirectMessageListenerContainer();
+		testUninterruptibleListener(container);
+	}
+
+	public void testUninterruptibleListener(AbstractMessageListenerContainer container) throws Exception {
+		CachingConnectionFactory cf = new CachingConnectionFactory("localhost");
+		container.setConnectionFactory(cf);
+		container.setShutdownTimeout(500);
+		container.setQueueNames("test.shutdown");
+		final CountDownLatch latch = new CountDownLatch(1);
+		container.setMessageListener(m -> {
+			while (true) {
+				try {
+					latch.countDown();
+					Thread.sleep(100);
+				}
+				catch (InterruptedException e) {
+					// Thread.currentThread().interrupt(); // eat it
+				}
+			}
+		});
+		container.start();
+		RabbitTemplate template = new RabbitTemplate(cf);
+		template.convertAndSend("test.shutdown", "foo");
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		Connection connection = cf.createConnection();
+		Map<?, ?> channels = TestUtils.getPropertyValue(connection, "target.delegate._channelManager._channelMap", Map.class);
+		assertThat(channels.size(), equalTo(2));
+		container.stop();
+		assertThat(channels.size(), equalTo(1));
+
+		cf.destroy();
+	}
+
+}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4188,7 +4188,15 @@ a| image::images/tickmark.png[]
 | When a container shuts down (e.g.
 if its enclosing `ApplicationContext` is closed) it waits for in-flight messages to be processed up to this limit.
 Defaults to 5 seconds.
-After the limit is reached, if the channel is not transacted messages will be discarded.
+
+a| image::images/tickmark.png[]
+a| image::images/tickmark.png[]
+
+| forceCloseChannel
+(N/A)
+
+| If the consumers don't respond to a shutdown within `shutdownTimeout`, if this is `true`, the channel will be closed, causing any unacked messages to be requeued.
+Default `true` since 2.0; set to false to revert to previous behavior.
 
 a| image::images/tickmark.png[]
 a| image::images/tickmark.png[]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -78,6 +78,12 @@ This property only applies when using `basicGet` (e.g. from `RabbitTemplate.rece
 Message requeue on transaction rollback is now consistent, regardless of whether or not a transaction manager is configured.
 See <<transaction-rollback>> for more information.
 
+====== Shutdown Behavior
+
+If the container threads do not respond to a shutdown within `shutdownTimeout`, the channel(s) will be forced closed, by default.
+See <<containerAttributes>> for more information.
+
+
 ===== Connection Factory Changes
 
 The connection and channel listener interfaces now provide a mechanism to obtain information about exceptions.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-749

If the consumer thread does not respond to a shutdown (e.g. "stuck" in user code),
the channel remains open and messages remain in an unack'd state.

Add a boolean (default true in 2.0) controlling the behaviour and allowing the container
to force close the channel - thus requeuing any unack'd messages.

Since this code runs on the thread that calls `stop()`, we need to always be sure that
the physical close required `ThreadLocal` is cleared.

There are test cases where a mix of mock and real channels are used and the TL was dirty, causing
side-effects; but this could really be a concern for a real application too.


__I will backport to 1.7.x after review/merge__