### PR TITLE
AMQP-747: Add trustedPackages option Jackson

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultClassMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultClassMapper.java
@@ -207,17 +207,14 @@ public class DefaultClassMapper implements ClassMapper, InitializingBean {
 			return this.defaultMapClass;
 		}
 		try {
-			Class<?> aClass = ClassUtils.forName(classId, getClass().getClassLoader());
-			Package packageToCheck = aClass.getPackage();
-			if (packageToCheck == null || isTrustedPackage(packageToCheck.getName())) {
-				return aClass;
-			}
-			else {
-				throw new IllegalArgumentException("The class with id '" + classId + "' and name '" +
-						aClass.getName() + "' is not in the trusted packages: " +
+			if (!isTrustedPackage(classId)) {
+				throw new IllegalArgumentException("The class '" + classId + "' is not in the trusted packages: " +
 						this.trustedPackages + ". " +
 						"If you believe this class is safe to deserialize, please provide its name. " +
 						"If the serialization is only done by a trusted source, you can also enable trust all (*).");
+			}
+			else {
+				return ClassUtils.forName(classId, getClass().getClassLoader());
 			}
 		}
 		catch (ClassNotFoundException e) {
@@ -230,16 +227,16 @@ public class DefaultClassMapper implements ClassMapper, InitializingBean {
 		}
 	}
 
-	private boolean isTrustedPackage(String packageName) {
+	private boolean isTrustedPackage(String requestedType) {
 		if (!this.trustedPackages.isEmpty()) {
+			String packageName = ClassUtils.getPackageName(requestedType).replaceFirst("\\[L", "");
 			for (String trustedPackage : this.trustedPackages) {
-				if (packageName.equals(trustedPackage) || packageName.startsWith(trustedPackage + ".")) {
+				if (packageName.equals(trustedPackage)) {
 					return true;
 				}
 			}
 			return false;
 		}
-
 		return true;
 	}
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -16,6 +16,11 @@
 
 package org.springframework.amqp.support.converter;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -33,6 +38,14 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  */
 public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 		implements Jackson2JavaTypeMapper, ClassMapper {
+
+	private static final List<String> TRUSTED_PACKAGES =
+			Arrays.asList(
+					"java.util",
+					"java.lang"
+			);
+
+	private final Set<String> trustedPackages = new LinkedHashSet<String>(TRUSTED_PACKAGES);
 
 	private volatile TypePrecedence typePrecedence = TypePrecedence.INFERRED;
 
@@ -69,6 +82,26 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 	public void setTypePrecedence(TypePrecedence typePrecedence) {
 		Assert.notNull(typePrecedence, "'typePrecedence' cannot be null");
 		this.typePrecedence = typePrecedence;
+	}
+
+	/**
+	 * Specify a set of packages to trust during deserialization.
+	 * The asterisk ({@code *}) means trust all.
+	 * @param trustedPackages the trusted Java packages for deserialization
+	 * @since 1.6.11
+	 */
+	public void setTrustedPackages(String... trustedPackages) {
+		if (trustedPackages != null) {
+			for (String whiteListClass : trustedPackages) {
+				if ("*".equals(whiteListClass)) {
+					this.trustedPackages.clear();
+					break;
+				}
+				else {
+					this.trustedPackages.add(whiteListClass);
+				}
+			}
+		}
 	}
 
 	@Override
@@ -110,20 +143,47 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 	}
 
 	private JavaType getClassIdType(String classId) {
+		JavaType javaType;
 		if (getIdClassMapping().containsKey(classId)) {
-			return TypeFactory.defaultInstance().constructType(getIdClassMapping().get(classId));
+			javaType = TypeFactory.defaultInstance().constructType(getIdClassMapping().get(classId));
+		}
+		else {
+			try {
+				javaType = TypeFactory.defaultInstance()
+						.constructType(ClassUtils.forName(classId, getClassLoader()));
+			}
+			catch (ClassNotFoundException e) {
+				throw new MessageConversionException("failed to resolve class name. Class not found [" + classId + "]", e);
+			}
+			catch (LinkageError e) {
+				throw new MessageConversionException("failed to resolve class name. Linkage error [" + classId + "]", e);
+			}
 		}
 
-		try {
-			return TypeFactory.defaultInstance()
-					.constructType(ClassUtils.forName(classId, getClassLoader()));
+		Package packageToCheck = javaType.getRawClass().getPackage();
+		if (packageToCheck == null || isTrustedPackage(packageToCheck.getName())) {
+			return javaType;
 		}
-		catch (ClassNotFoundException e) {
-			throw new MessageConversionException("failed to resolve class name. Class not found [" + classId + "]", e);
+		else {
+			throw new IllegalArgumentException("The class with id '" + classId + "' and name '" +
+					javaType.getRawClass().getName() + "' is not in the trusted packages: " +
+					this.trustedPackages + ". " +
+					"If you believe this class is safe to deserialize, please provide its name. " +
+					"If the serialization is only done by a trusted source, you can also enable trust all (*).");
 		}
-		catch (LinkageError e) {
-			throw new MessageConversionException("failed to resolve class name. Linkage error [" + classId + "]", e);
+	}
+
+	private boolean isTrustedPackage(String packageName) {
+		if (!this.trustedPackages.isEmpty()) {
+			for (String trustedPackage : this.trustedPackages) {
+				if (packageName.equals(trustedPackage) || packageName.startsWith(trustedPackage + ".")) {
+					return true;
+				}
+			}
+			return false;
 		}
+
+		return true;
 	}
 
 	@Override

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
@@ -53,23 +53,36 @@ public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter i
 	private boolean typeMapperSet;
 
 	/**
+	 * Construct with an internal {@link ObjectMapper} instance and trusted packed to all ({@code *}).
+	 * @since 1.6.11
+	 */
+	public Jackson2JsonMessageConverter() {
+		this("*");
+	}
+
+	/**
 	 * Construct with an internal {@link ObjectMapper} instance.
 	 * The {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES} is set to false on
 	 * the {@link ObjectMapper}.
+	 * @param trustedPackages the trusted Java packages for deserialization
+	 * @see DefaultJackson2JavaTypeMapper#setTrustedPackages(String...)
 	 */
-	public Jackson2JsonMessageConverter() {
-		this.jsonObjectMapper = new ObjectMapper();
+	public Jackson2JsonMessageConverter(String... trustedPackages) {
+		this(new ObjectMapper(), trustedPackages);
 		this.jsonObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 	}
 
 	/**
 	 * Construct with the provided {@link ObjectMapper} instance.
 	 * @param jsonObjectMapper the {@link ObjectMapper} to use.
+	 * @param trustedPackages the trusted Java packages for deserialization
 	 * @since 1.7.2
+	 * @see DefaultJackson2JavaTypeMapper#setTrustedPackages(String...)
 	 */
-	public Jackson2JsonMessageConverter(ObjectMapper jsonObjectMapper) {
+	public Jackson2JsonMessageConverter(ObjectMapper jsonObjectMapper, String... trustedPackages) {
 		Assert.notNull(jsonObjectMapper, "'jsonObjectMapper' must not be null");
 		this.jsonObjectMapper = jsonObjectMapper;
+		((DefaultJackson2JavaTypeMapper) this.javaTypeMapper).setTrustedPackages(trustedPackages);
 	}
 
 	public Jackson2JavaTypeMapper getJavaTypeMapper() {

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/ContentTypeDelegatingMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/ContentTypeDelegatingMessageConverterTests.java
@@ -31,6 +31,8 @@ import org.springframework.amqp.core.MessageProperties;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.4.2
  *
  */
@@ -39,8 +41,10 @@ public class ContentTypeDelegatingMessageConverterTests {
 	@Test
 	public void testDelegationOutbound() {
 		ContentTypeDelegatingMessageConverter converter = new ContentTypeDelegatingMessageConverter();
-		converter.addDelegate("foo/bar", new Jackson2JsonMessageConverter());
-		converter.addDelegate(MessageProperties.CONTENT_TYPE_JSON, new Jackson2JsonMessageConverter());
+		Jackson2JsonMessageConverter messageConverter =
+				new Jackson2JsonMessageConverter(ContentTypeDelegatingMessageConverterTests.class.getPackage().getName());
+		converter.addDelegate("foo/bar", messageConverter);
+		converter.addDelegate(MessageProperties.CONTENT_TYPE_JSON, messageConverter);
 		MessageProperties props = new MessageProperties();
 		Foo foo = new Foo();
 		foo.setFoo("bar");

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapperTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapperTests.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
@@ -44,10 +45,12 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  * @author Sam Nelson
  * @author Andreas Asplund
  * @author Gary Russell
+ * @author Artem Bilan
  */
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultJackson2JavaTypeMapperTests {
+
 	@Spy
 	DefaultJackson2JavaTypeMapper javaTypeMapper = new DefaultJackson2JavaTypeMapper();
 
@@ -58,6 +61,11 @@ public class DefaultJackson2JavaTypeMapperTests {
 
 	@SuppressWarnings("rawtypes")
 	private final Class<HashMap> mapClass = HashMap.class;
+
+	@Before
+	public void setup() {
+		this.javaTypeMapper.setTrustedPackages("org.springframework.amqp.support.converter");
+	}
 
 	@Test
 	public void getAnObjectWhenClassIdNotPresent() {

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests.java
@@ -55,6 +55,8 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class Jackson2JsonMessageConverterTests {
 
+	public static final String TRUSTED_PACKAGE = Jackson2JsonMessageConverterTests.class.getPackage().getName();
+
 	private Jackson2JsonMessageConverter converter;
 
 	private SimpleTrade trade;
@@ -64,7 +66,7 @@ public class Jackson2JsonMessageConverterTests {
 
 	@Before
 	public void before() {
-		converter = new Jackson2JsonMessageConverter();
+		converter = new Jackson2JsonMessageConverter(TRUSTED_PACKAGE);
 		trade = new SimpleTrade();
 		trade.setAccountName("Acct1");
 		trade.setBuyRequest(true);
@@ -74,7 +76,6 @@ public class Jackson2JsonMessageConverterTests {
 		trade.setRequestId("R123");
 		trade.setTicker("VMW");
 		trade.setUserName("Joe Trader");
-
 	}
 
 	@Test
@@ -90,6 +91,9 @@ public class Jackson2JsonMessageConverterTests {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.setSerializerFactory(BeanSerializerFactory.instance);
 		converter = new Jackson2JsonMessageConverter(mapper);
+
+		((DefaultJackson2JavaTypeMapper) this.converter.getJavaTypeMapper())
+				.setTrustedPackages(TRUSTED_PACKAGE);
 
 		Message message = converter.toMessage(trade, new MessageProperties());
 
@@ -129,13 +133,19 @@ public class Jackson2JsonMessageConverterTests {
 		converter.setClassMapper(new DefaultClassMapper());
 		converter.setJavaTypeMapper(null);
 
+
+		((DefaultClassMapper) this.converter.getClassMapper()).setTrustedPackages(TRUSTED_PACKAGE);
+
 		SimpleTrade marshalledTrade = (SimpleTrade) converter.fromMessage(message);
 		assertEquals(trade, marshalledTrade);
 	}
 
 	@Test
 	public void shouldUseClassMapperWhenProvidedOutbound() {
-		converter.setClassMapper(new DefaultClassMapper());
+		DefaultClassMapper classMapper = new DefaultClassMapper();
+		classMapper.setTrustedPackages(TRUSTED_PACKAGE);
+
+		converter.setClassMapper(classMapper);
 		converter.setJavaTypeMapper(null);
 		Message message = converter.toMessage(trade, new MessageProperties());
 
@@ -232,7 +242,7 @@ public class Jackson2JsonMessageConverterTests {
 		MessageProperties messageProperties = new MessageProperties();
 		messageProperties.setContentType("application/json");
 		messageProperties.setInferredArgumentType(
-				(new ParameterizedTypeReference<Map<String, List<Bar>>>() { }).getType());
+				(new ParameterizedTypeReference<Map<String, List<Bar>>>() {	}).getType());
 		Message message = new Message(bytes, messageProperties);
 		Object foo = this.converter.fromMessage(message);
 		assertThat(foo, instanceOf(LinkedHashMap.class));

--- a/spring-amqp/src/test/resources/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests-context.xml
+++ b/spring-amqp/src/test/resources/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests-context.xml
@@ -8,6 +8,7 @@
 			<bean class="org.springframework.amqp.support.converter.DefaultClassMapper">
 				<property name="defaultType"
 					value="org.springframework.amqp.support.converter.Jackson2JsonMessageConverterTests$Foo" />
+				<property name="trustedPackages" value="#{T (org.springframework.amqp.support.converter.Jackson2JsonMessageConverterTests).TRUSTED_PACKAGE}"/>
 			</bean>
 		</property>
 	</bean>

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2647,7 +2647,7 @@ for convenience.
 If you inject a custom type mapper, you should set the property on the mapper instead.
 
 NOTE: When converting from the `Message`, an incoming `MessageProperties.getContentType()` must be JSON-compliant (the logic `contentType.contains("json")` is used).
-Otherwise, a `WARN` log message `Could not convert incoming message with content-type [...]`, is emitted and `message.getBody()` is returned as is - as a `byte[]``.
+Otherwise, a `WARN` log message `Could not convert incoming message with content-type [...]`, is emitted and `message.getBody()` is returned as is - as a `byte[]`.
 So, to meet the `Jackson2JsonMessageConverter` requirements on the consumer side, the producer must add the `contentType` message property, e.g. as `application/json`, `text/x-json` or simply use the `Jackson2JsonMessageConverter`, which will set the header automatically.
 
 [source, java]
@@ -2684,6 +2684,12 @@ This type inference can only be achieved when the `@RabbitListener` annotation i
 With class-level `@RabbitListener`, the converted type is used to select which `@RabbitHandler` method to invoke.
 For this reason, the infrastructure provides the `targetObject` message property which can be used by a custom
 converter to determine the type.
+====
+
+[IMPORTANT]
+====
+Starting with _version 1.6.11_, the `Jackson2JsonMessageConverter` and, therefore, `DefaultJackson2JavaTypeMapper` (`DefaultClassMapper`) provide the `trustedPackages` option to overcome https://pivotal.io/security/cve-2017-4995[Serialization Gadgets] vulnerability.
+By default, for backward compatiblity the `Jackson2JsonMessageConverter` trusts all packages - use `*` for the option.
 ====
 
 [[json-complex]]


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-747

To have a fix for the CVE-2017-4995 Jackson vulnerability add
`trustedPackages` option to the `Jackson2JsonMessageConverter`,
`DefaultJackson2JavaTypeMapper` and `DefaultClassMapper` and
consult it for the `Class` of the body during deserialization

**Cherry-pick to 1.7.x and 1.6.x**