### PR TITLE
Fix Race in ContainerShutDownTests

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -604,6 +604,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 				if (this.logger.isInfoEnabled()) {
 					this.logger.info(consumer + " started");
 				}
+				if (getApplicationEventPublisher() != null) {
+					getApplicationEventPublisher().publishEvent(new AsyncConsumerStartedEvent(this, consumer));
+				}
 			}
 		}
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerShutDownTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerShutDownTests.java
@@ -80,7 +80,14 @@ public class ContainerShutDownTests {
 				}
 			}
 		});
+		final CountDownLatch startLatch = new CountDownLatch(1);
+		container.setApplicationEventPublisher(e -> {
+			if (e instanceof AsyncConsumerStartedEvent) {
+				startLatch.countDown();
+			}
+		});
 		container.start();
+		assertTrue(startLatch.await(10, TimeUnit.SECONDS));
 		RabbitTemplate template = new RabbitTemplate(cf);
 		template.convertAndSend("test.shutdown", "foo");
 		assertTrue(latch.await(10, TimeUnit.SECONDS));


### PR DESCRIPTION
https://build.spring.io/browse/AMQP-MEIGHT-JOB1-1125/test/case/251270844

It is possible the template's channel is returned to the cache before the container starts.
In that case, the container gets that channel and there's only one insted of two.

Also add a consumer started event to the DMLC, which was missing.