### PR TITLE
AMQP-750: Add possibleAuthenticationFailureFatal

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,8 @@ import org.springframework.util.backoff.BackOff;
  * A Factory bean to create a listener container.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  *
  */
@@ -126,6 +128,8 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 	private RabbitAdmin rabbitAdmin;
 
 	private Boolean missingQueuesFatal;
+
+	private Boolean possibleAuthenticationFailureFatal;
 
 	private Boolean mismatchedQueuesFatal;
 
@@ -300,6 +304,10 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 		this.missingQueuesFatal = missingQueuesFatal;
 	}
 
+	public void setPossibleAuthenticationFailureFatal(Boolean possibleAuthenticationFailureFatal) {
+		this.possibleAuthenticationFailureFatal = possibleAuthenticationFailureFatal;
+	}
+
 	public void setMismatchedQueuesFatal(boolean mismatchedQueuesFatal) {
 		this.mismatchedQueuesFatal = mismatchedQueuesFatal;
 	}
@@ -470,8 +478,11 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 			if (this.rabbitAdmin != null) {
 				container.setRabbitAdmin(this.rabbitAdmin);
 			}
-			if (this.mismatchedQueuesFatal != null) {
+			if (this.missingQueuesFatal != null) {
 				container.setMissingQueuesFatal(this.missingQueuesFatal);
+			}
+			if (this.possibleAuthenticationFailureFatal != null) {
+				container.setPossibleAuthenticationFailureFatal(this.possibleAuthenticationFailureFatal);
 			}
 			if (this.mismatchedQueuesFatal != null) {
 				container.setMismatchedQueuesFatal(this.mismatchedQueuesFatal);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RabbitNamespaceUtils.java
@@ -85,6 +85,8 @@ public final class RabbitNamespaceUtils {
 
 	private static final String MISSING_QUEUES_FATAL = "missing-queues-fatal";
 
+	private static final String POSSIBLE_AUTHENTICATION_FAILURE_FATAL = "possible-authentication-failure-fatal";
+
 	private static final String MISMATCHED_QUEUES_FATAL = "mismatched-queues-fatal";
 
 	private static final String AUTO_DECLARE = "auto-declare";
@@ -243,6 +245,12 @@ public final class RabbitNamespaceUtils {
 		String missingQueuesFatal = containerEle.getAttribute(MISSING_QUEUES_FATAL);
 		if (StringUtils.hasText(missingQueuesFatal)) {
 			containerDef.getPropertyValues().add("missingQueuesFatal", new TypedStringValue(missingQueuesFatal));
+		}
+
+		String possibleAuthenticationFailureFatal = containerEle.getAttribute(POSSIBLE_AUTHENTICATION_FAILURE_FATAL);
+		if (StringUtils.hasText(possibleAuthenticationFailureFatal)) {
+			containerDef.getPropertyValues().add("possibleAuthenticationFailureFatal",
+					new TypedStringValue(possibleAuthenticationFailureFatal));
 		}
 
 		String mismatchedQueuesFatal = containerEle.getAttribute(MISMATCHED_QUEUES_FATAL);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -308,6 +308,8 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 
 	@Override
 	protected void doInitialize() throws Exception {
+		super.doInitialize();
+
 		if (this.taskScheduler == null) {
 			ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
 			threadPoolTaskScheduler.setThreadNamePrefix(getBeanName() + "-consumerMonitor-");

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -265,9 +265,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			synchronized (this.consumersMonitor) {
 				checkStartState();
 				queueNames.map(this.consumersByQueue::remove)
-					.filter(Objects::nonNull)
-					.flatMap(Collection::stream)
-					.forEach(this::cancelConsumer);
+						.filter(Objects::nonNull)
+						.flatMap(Collection::stream)
+						.forEach(this::cancelConsumer);
 			}
 		}
 	}
@@ -308,8 +308,6 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 
 	@Override
 	protected void doInitialize() throws Exception {
-		super.doInitialize();
-
 		if (this.taskScheduler == null) {
 			ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
 			threadPoolTaskScheduler.setThreadNamePrefix(getBeanName() + "-consumerMonitor-");
@@ -894,9 +892,10 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			/*
 			 * If we have a TX Manager, but no TX, act like we are locally transacted.
 			 */
-			boolean isLocallyTransacted = channelLocallyTransacted
-					|| (isChannelTransacted()
-							&& TransactionSynchronizationManager.getResource(this.connectionFactory) == null);
+			boolean isLocallyTransacted =
+					channelLocallyTransacted ||
+							(isChannelTransacted() &&
+									TransactionSynchronizationManager.getResource(this.connectionFactory) == null);
 			try {
 				if (this.ackRequired) {
 					if (this.messagesPerAck > 1) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -410,6 +410,11 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		return true;
 	}
 
+	@Override
+	protected void doInitialize() throws Exception {
+
+	}
+
 	@ManagedMetric(metricType = MetricType.GAUGE)
 	public int getActiveConsumerCount() {
 		return this.cancellationLock.getCount();

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.0.xsd
@@ -809,6 +809,16 @@
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="possible-authentication-failure-fatal" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	When set to `true` (default), if a `PossibleAuthenticationFailureException` is thrown during connection,
+	it is considered fatal. This causes the application context to fail to initialize during startup.
+	When set to `false`, after making the 3 retries, the container will go into recovery mode, as with other problems,
+	such as the broker being down. The container will attempt to recover according to the `recoveryInterval` property.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="mismatched-queues-fatal" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerParserTests.java
@@ -95,6 +95,7 @@ public class ListenerContainerParserTests {
 		assertEquals(Long.valueOf(5555), TestUtils.getPropertyValue(container, "recoveryBackOff.interval", Long.class));
 		assertFalse(TestUtils.getPropertyValue(container, "exclusive", Boolean.class));
 		assertFalse(TestUtils.getPropertyValue(container, "missingQueuesFatal", Boolean.class));
+		assertFalse(TestUtils.getPropertyValue(container, "possibleAuthenticationFailureFatal", Boolean.class));
 		assertTrue(TestUtils.getPropertyValue(container, "autoDeclare", Boolean.class));
 		assertEquals(5, TestUtils.getPropertyValue(container, "declarationRetries"));
 		assertEquals(1000L, TestUtils.getPropertyValue(container, "failedDeclarationRetryInterval"));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerInitializationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerInitializationTests.java
@@ -75,7 +75,7 @@ public class ContainerInitializationTests {
 		catch (ApplicationContextException e) {
 			assertThat(e.getCause().getCause(), instanceOf(IllegalStateException.class));
 			assertThat(e.getMessage(), containsString("When 'mismatchedQueuesFatal' is 'true', there must be "
-				+ "exactly one RabbitAdmin in the context or you must inject one into this container; found: 0"));
+					+ "exactly one RabbitAdmin in the context or you must inject one into this container; found: 0"));
 		}
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryCachingConnectionIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryCachingConnectionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -395,7 +395,7 @@ public class MessageListenerRecoveryCachingConnectionIntegrationTests {
 		try {
 			container = doCreateContainer("nonexistent", new VanillaListener(latch), connectionFactory);
 			Properties properties = new Properties();
-			properties.setProperty("smlc.missing.queues.fatal", "false");
+			properties.setProperty("mlc.missing.queues.fatal", "false");
 			GenericApplicationContext context = new GenericApplicationContext();
 			context.getBeanFactory().registerSingleton("spring.amqp.global.properties", properties);
 			context.refresh();

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -16,6 +16,7 @@
 	<rabbit:listener-container connection-factory="connectionFactory" acknowledge="manual" concurrency="5"
 			group="containerGroup" idle-event-interval="1235" mismatched-queues-fatal="true"
 			max-concurrency="6" receive-timeout="9876" recovery-interval="5555" missing-queues-fatal="false"
+			possible-authentication-failure-fatal="false"
 			min-start-interval="1234" min-stop-interval="2345" min-consecutive-active="12" min-consecutive-idle="34"
 			declaration-retries="5" failed-declaration-retry-interval="1000" missing-queue-retry-interval="30000"
 			consumer-tag-strategy="tagger">

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4460,7 +4460,36 @@ You can also use a properties bean to set the property globally for all containe
 [source,xml]
 ----
 <util:properties id="spring.amqp.global.properties">
-    <prop key="smlc.missing.queues.fatal">false</prop>
+    <prop key="mlc.missing.queues.fatal">false</prop>
+</util:properties>
+----
+
+This global property will not be applied to any containers that have an explicit `missingQueuesFatal` property set.
+
+The default retry properties (3 retries at 5 second intervals) can be overridden using the properties below.
+
+a| image::images/tickmark.png[]
+a| image::images/tickmark.png[]
+
+| possibleAuthenticationFailureFatal
+(possible-authentication-failure-fatal)
+
+a| When set to `true` (default), if a `PossibleAuthenticationFailureException` is thrown during connection, it is considered fatal.
+This causes the application context to fail to initialize during startup.
+
+Since _version 2.0_.
+
+When set to `false`, after making the 3 retries, the container will go into recovery mode, as with other problems, such as the broker being down.
+The container will attempt to recover according to the `recoveryInterval` property.
+During each recovery attempt, each consumer will again try 4 times to start.
+This process will continue indefinitely.
+
+You can also use a properties bean to set the property globally for all containers, as follows:
+
+[source,xml]
+----
+<util:properties id="spring.amqp.global.properties">
+    <prop key="mlc.possible.authentication.failure.fatal">false</prop>
 </util:properties>
 ----
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-750

In some cases `PossibleAuthenticationFailureException` is not really
fatal error, so add `possibleAuthenticationFailureFatal` option to the
ListenerContainer to disable a fatal behavior on startup