### PR TITLE
AMQP-753 Adds possibility to set MessagePostProcessors

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
@@ -97,6 +98,8 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 	private Boolean autoStartup;
 
 	private Integer phase;
+
+	private MessagePostProcessor[] afterReceivePostProcessors;
 
 	protected final AtomicInteger counter = new AtomicInteger();
 
@@ -260,6 +263,14 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 		this.phase = phase;
 	}
 
+	/**
+	 * @param afterReceivePostProcessors the post processors.
+	 * @see AbstractMessageListenerContainer#setAfterReceivePostProcessors(MessagePostProcessor...)
+	 */
+	public void setAfterReceivePostProcessors(MessagePostProcessor... afterReceivePostProcessors) {
+		this.afterReceivePostProcessors = afterReceivePostProcessors;
+	}
+
 
 	@Override
 	public C createListenerContainer(RabbitListenerEndpoint endpoint) {
@@ -324,6 +335,9 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 		}
 		if (this.phase != null) {
 			instance.setPhase(this.phase);
+		}
+		if (this.afterReceivePostProcessors != null) {
+			instance.setAfterReceivePostProcessors(this.afterReceivePostProcessors);
 		}
 		instance.setListenerId(endpoint.getId());
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 
 import org.aopalliance.aop.Advice;
@@ -30,6 +31,7 @@ import org.junit.rules.ExpectedException;
 
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;
@@ -84,6 +86,7 @@ public class RabbitListenerContainerFactoryTests {
 		Executor executor = mock(Executor.class);
 		PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
 		Advice advice = mock(Advice.class);
+		MessagePostProcessor afterReceivePostProcessor = mock(MessagePostProcessor.class);
 
 		setBasicConfig(this.factory);
 		this.factory.setTaskExecutor(executor);
@@ -102,6 +105,7 @@ public class RabbitListenerContainerFactoryTests {
 		BackOff recoveryBackOff = new ExponentialBackOff();
 		this.factory.setRecoveryBackOff(recoveryBackOff);
 		this.factory.setMissingQueuesFatal(true);
+		this.factory.setAfterReceivePostProcessors(afterReceivePostProcessor);
 
 		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
 
@@ -130,6 +134,9 @@ public class RabbitListenerContainerFactoryTests {
 		assertEquals(true, fieldAccessor.getPropertyValue("missingQueuesFatal"));
 		assertEquals(messageListener, container.getMessageListener());
 		assertEquals("myQueue", container.getQueueNames()[0]);
+		List<?> actualAfterReceivePostProcessors = (List<?>) fieldAccessor.getPropertyValue("afterReceivePostProcessors");
+		assertEquals("Wrong number of afterReceivePostProcessors", 1, actualAfterReceivePostProcessors.size());
+		assertSame("Wrong advice", afterReceivePostProcessor, actualAfterReceivePostProcessors.get(0));
 	}
 
 	@Test
@@ -138,6 +145,7 @@ public class RabbitListenerContainerFactoryTests {
 		TaskScheduler scheduler = mock(TaskScheduler.class);
 		PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
 		Advice advice = mock(Advice.class);
+		MessagePostProcessor afterReceivePostProcessor = mock(MessagePostProcessor.class);
 
 		setBasicConfig(this.direct);
 		this.direct.setTaskExecutor(executor);
@@ -152,6 +160,7 @@ public class RabbitListenerContainerFactoryTests {
 		this.direct.setTaskScheduler(scheduler);
 		this.direct.setMonitorInterval(1234L);
 		this.direct.setConsumersPerQueue(42);
+		this.direct.setAfterReceivePostProcessors(afterReceivePostProcessor);
 
 		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
 
@@ -176,6 +185,9 @@ public class RabbitListenerContainerFactoryTests {
 		assertSame(scheduler, fieldAccessor.getPropertyValue("taskScheduler"));
 		assertEquals(1234L, fieldAccessor.getPropertyValue("monitorInterval"));
 		assertEquals(42, fieldAccessor.getPropertyValue("consumersPerQueue"));
+		List<?> actualAfterReceivePostProcessors = (List<?>) fieldAccessor.getPropertyValue("afterReceivePostProcessors");
+		assertEquals("Wrong number of afterReceivePostProcessors", 1, actualAfterReceivePostProcessors.size());
+		assertSame("Wrong afterReceivePostProcessor", afterReceivePostProcessor, actualAfterReceivePostProcessors.get(0));
 	}
 
 	private void setBasicConfig(AbstractRabbitListenerContainerFactory<?> factory) {


### PR DESCRIPTION
It is now possible to configure `afterReceivePostProcessors` on `AbstractRabbitListenerContainerFactory`, which in turn will delegate this to `RabbitListenerContainer#setAfterReceivePostProcessors`.

See further conversation [AMQP-753](https://jira.spring.io/browse/AMQP-753)