### PR TITLE
Updated AMQP reference to 0.9.1 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Spring AMQP [<img src="https://build.spring.io/plugins/servlet/wittified/build-status/AMQP-MASTER">](https://build.spring.io/browse/AMQP-MASTER) [![Join the chat at https://gitter.im/spring-projects/spring-amqp](https://badges.gitter.im/spring-projects/spring-amqp.svg)](https://gitter.im/spring-projects/spring-amqp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 ===========
 
-This project provides support for using Spring and Java with [AMQP](http://www.amqp.org/), and in particular [RabbitMQ](http://www.rabbitmq.com/).
+This project provides support for using Spring and Java with [AMQP 0.9.1](https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf), and in particular [RabbitMQ](http://www.rabbitmq.com/).
 
 # Checking out and Building
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Spring AMQP [<img src="https://build.spring.io/plugins/servlet/wittified/build-status/AMQP-MASTER">](https://build.spring.io/browse/AMQP-MASTER) [![Join the chat at https://gitter.im/spring-projects/spring-amqp](https://badges.gitter.im/spring-projects/spring-amqp.svg)](https://gitter.im/spring-projects/spring-amqp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 ===========
 
-This project provides support for using Spring and Java with [AMQP 0.9.1](https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf), and in particular [RabbitMQ](http://www.rabbitmq.com/).
+This project provides support for using Spring and Java with [AMQP 0.9.1](https://www.rabbitmq.com/amqp-0-9-1-reference.html), and in particular [RabbitMQ](http://www.rabbitmq.com/).
 
 # Checking out and Building
 


### PR DESCRIPTION
The provided link about AMQP protocol is to the official AMQP web site which is for AMQP 1.0 spec. This commit fixes it, providing the link to the RabbitMQ AMQP 0.9.1 spec supported by this component.