### PR TITLE
AMQP-754 Expose AbstractRabbitListenerContainerFactory's adviceChain

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
@@ -176,6 +176,14 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 	}
 
 	/**
+	 * @return the advice chain that was set. Defaults to {@code null}.
+	 * @since 1.7.4
+	 */
+	public Advice[] getAdviceChain() {
+		return this.adviceChain;
+	}
+
+	/**
 	 * @param adviceChain the advice chain to set.
 	 * @see SimpleMessageListenerContainer#setAdviceChain
 	 */

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.config;
 
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
@@ -107,6 +108,8 @@ public class RabbitListenerContainerFactoryTests {
 		this.factory.setMissingQueuesFatal(true);
 		this.factory.setAfterReceivePostProcessors(afterReceivePostProcessor);
 
+		assertArrayEquals(new Advice[] {advice}, this.factory.getAdviceChain());
+
 		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
 
 		endpoint.setMessageListener(this.messageListener);
@@ -161,6 +164,8 @@ public class RabbitListenerContainerFactoryTests {
 		this.direct.setMonitorInterval(1234L);
 		this.direct.setConsumersPerQueue(42);
 		this.direct.setAfterReceivePostProcessors(afterReceivePostProcessor);
+
+		assertArrayEquals(new Advice[] {advice}, this.direct.getAdviceChain());
 
 		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
 


### PR DESCRIPTION
This allows adding additional advice if another piece of code like
Boot's SimpleRabbitListenerContainerFactoryConfigurer already set the
advice chain.