### PR TITLE
AMQP-756: Add support for no-local consumers.

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
@@ -103,6 +103,8 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 
 	private Map<String, Object> consumerArgs;
 
+	private Boolean noLocal;
+
 	private Boolean exclusive;
 
 	private Boolean defaultRequeueRejected;
@@ -250,6 +252,10 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 
 	public void setConsumerArguments(Map<String, Object> args) {
 		this.consumerArgs = args;
+	}
+
+	public void setNoLocal(Boolean noLocal) {
+		this.noLocal = noLocal;
 	}
 
 	public void setExclusive(boolean exclusive) {
@@ -441,6 +447,9 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 			}
 			if (this.consumerArgs != null) {
 				container.setConsumerArguments(this.consumerArgs);
+			}
+			if (this.noLocal != null) {
+				container.setNoLocal(this.noLocal);
 			}
 			if (this.exclusive != null) {
 				container.setExclusive(this.exclusive);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -189,6 +189,8 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	private volatile boolean exclusive;
 
+	private volatile boolean noLocal;
+
 	private volatile boolean defaultRequeueRejected = true;
 
 	private volatile int prefetchCount = DEFAULT_PREFETCH_COUNT;
@@ -664,6 +666,22 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 */
 	protected boolean isExclusive() {
 		return this.exclusive;
+	}
+
+	/**
+	 * Set to true for an no-local consumer.
+	 * @param noLocal true for an no-local consumer.
+	 */
+	public void setNoLocal(boolean noLocal) {
+		this.noLocal = noLocal;
+	}
+
+	/**
+	 * Return whether the consumers should be no-local.
+	 * @return true for no-local consumers.
+	 */
+	protected boolean isNoLocal() {
+		return noLocal;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -115,6 +115,8 @@ public class BlockingQueueConsumer {
 
 	private final Map<String, Object> consumerArgs = new HashMap<String, Object>();
 
+	private final boolean noLocal;
+
 	private final boolean exclusive;
 
 	private final Set<Long> deliveryTags = new LinkedHashSet<Long>();
@@ -226,10 +228,35 @@ public class BlockingQueueConsumer {
 	 * @param queues The queues.
 	 */
 	public BlockingQueueConsumer(ConnectionFactory connectionFactory,
+								 MessagePropertiesConverter messagePropertiesConverter,
+								 ActiveObjectCounter<BlockingQueueConsumer> activeObjectCounter, AcknowledgeMode acknowledgeMode,
+								 boolean transactional, int prefetchCount, boolean defaultRequeueRejected,
+								 Map<String, Object> consumerArgs, boolean exclusive, String... queues) {
+		this(connectionFactory, messagePropertiesConverter, activeObjectCounter, acknowledgeMode, transactional,
+				prefetchCount, defaultRequeueRejected, consumerArgs, false, exclusive, queues);
+	}
+
+	/**
+	 * Create a consumer. The consumer must not attempt to use
+	 * the connection factory or communicate with the broker
+	 * until it is started.
+	 * @param connectionFactory The connection factory.
+	 * @param messagePropertiesConverter The properties converter.
+	 * @param activeObjectCounter The active object counter; used during shutdown.
+	 * @param acknowledgeMode The acknowledge mode.
+	 * @param transactional Whether the channel is transactional.
+	 * @param prefetchCount The prefetch count.
+	 * @param defaultRequeueRejected true to reject requeued messages.
+	 * @param consumerArgs The consumer arguments (e.g. x-priority).
+	 * @param noLocal true if the consumer is to be no-local.
+	 * @param exclusive true if the consumer is to be exclusive.
+	 * @param queues The queues.
+	 */
+	public BlockingQueueConsumer(ConnectionFactory connectionFactory,
 			MessagePropertiesConverter messagePropertiesConverter,
 			ActiveObjectCounter<BlockingQueueConsumer> activeObjectCounter, AcknowledgeMode acknowledgeMode,
 			boolean transactional, int prefetchCount, boolean defaultRequeueRejected,
-			Map<String, Object> consumerArgs, boolean exclusive, String... queues) {
+			Map<String, Object> consumerArgs, boolean noLocal, boolean exclusive, String... queues) {
 		this.connectionFactory = connectionFactory;
 		this.messagePropertiesConverter = messagePropertiesConverter;
 		this.activeObjectCounter = activeObjectCounter;
@@ -240,6 +267,7 @@ public class BlockingQueueConsumer {
 		if (consumerArgs != null && consumerArgs.size() > 0) {
 			this.consumerArgs.putAll(consumerArgs);
 		}
+		this.noLocal = noLocal;
 		this.exclusive = exclusive;
 		this.queues = Arrays.copyOf(queues, queues.length);
 		this.queue = new LinkedBlockingQueue<Delivery>(prefetchCount);
@@ -591,7 +619,7 @@ public class BlockingQueueConsumer {
 
 	private void consumeFromQueue(String queue) throws IOException {
 		String consumerTag = this.channel.basicConsume(queue, this.acknowledgeMode.isAutoAck(),
-				(this.tagStrategy != null ? this.tagStrategy.createConsumerTag(queue) : ""), false, this.exclusive,
+				(this.tagStrategy != null ? this.tagStrategy.createConsumerTag(queue) : ""), this.noLocal, this.exclusive,
 				this.consumerArgs, this.consumer);
 		if (consumerTag != null) {
 			this.consumerTags.put(consumerTag, queue);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -573,7 +573,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			consumer.consumerTag = channel.basicConsume(queue, getAcknowledgeMode().isAutoAck(),
 					(getConsumerTagStrategy() != null
 							? getConsumerTagStrategy().createConsumerTag(queue) : ""),
-					false, isExclusive(), getConsumerArguments(), consumer);
+					isNoLocal(), isExclusive(), getConsumerArguments(), consumer);
 		}
 		catch (AmqpApplicationContextClosedException e) {
 			throw new AmqpConnectException(e);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -646,7 +646,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		int actualPrefetchCount = getPrefetchCount() > this.txSize ? getPrefetchCount() : this.txSize;
 		consumer = new BlockingQueueConsumer(getConnectionFactory(), getMessagePropertiesConverter(),
 				this.cancellationLock, getAcknowledgeMode(), isChannelTransacted(), actualPrefetchCount,
-				isDefaultRequeueRejected(), getConsumerArguments(), isExclusive(), queues);
+				isDefaultRequeueRejected(), getConsumerArguments(), isNoLocal(), isExclusive(), queues);
 		if (this.declarationRetries != null) {
 			consumer.setDeclarationRetries(this.declarationRetries);
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willThrow;
@@ -46,7 +47,6 @@ import org.apache.logging.log4j.Level;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.AcknowledgeMode;
@@ -137,13 +137,13 @@ public class BlockingQueueConsumerTests {
 		Channel channel = mock(Channel.class);
 
 		when(connectionFactory.createConnection()).thenReturn(connection);
-		when(connection.createChannel(Mockito.anyBoolean())).thenReturn(channel);
+		when(connection.createChannel(anyBoolean())).thenReturn(channel);
 		when(channel.isOpen()).thenReturn(true);
-		when(channel.queueDeclarePassive(Mockito.anyString()))
+		when(channel.queueDeclarePassive(anyString()))
 				.then(invocation -> {
 					String arg = invocation.getArgument(0);
 					if ("good".equals(arg)) {
-						return Mockito.any(AMQP.Queue.DeclareOk.class);
+						return any(AMQP.Queue.DeclareOk.class);
 					}
 					else {
 						throw new IOException();
@@ -162,6 +162,27 @@ public class BlockingQueueConsumerTests {
 		blockingQueueConsumer.start();
 
 		verify(channel).basicQos(20);
+	}
+
+	@Test
+	public void testNoLocalConsumerConfiguration() throws Exception {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		Connection connection = mock(Connection.class);
+		Channel channel = mock(Channel.class);
+
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		when(connection.createChannel(anyBoolean())).thenReturn(channel);
+		when(channel.isOpen()).thenReturn(true);
+
+		final String queue = "testQ";
+		final boolean noLocal = true;
+
+		BlockingQueueConsumer blockingQueueConsumer = new BlockingQueueConsumer(connectionFactory,
+				new DefaultMessagePropertiesConverter(), new ActiveObjectCounter<BlockingQueueConsumer>(),
+				AcknowledgeMode.AUTO, true, 1, true, null, noLocal, false, queue);
+		blockingQueueConsumer.start();
+		verify(channel).basicConsume(eq(queue), eq(AcknowledgeMode.AUTO.isAutoAck()), eq(""), eq(noLocal), eq(false), anyMap(), any(Consumer.class));
+		blockingQueueConsumer.stop();
 	}
 
 	@Test
@@ -236,7 +257,7 @@ public class BlockingQueueConsumerTests {
 		deliveryTags.add(1L);
 		dfa.setPropertyValue("deliveryTags", deliveryTags);
 		blockingQueueConsumer.rollbackOnExceptionIfNecessary(ex);
-		Mockito.verify(channel).basicNack(1L, true, expectedRequeue);
+		verify(channel).basicNack(1L, true, expectedRequeue);
 	}
 
 	@Test
@@ -251,7 +272,7 @@ public class BlockingQueueConsumerTests {
 		when(connection.createChannel(anyBoolean())).thenReturn(channel);
 		final AtomicBoolean isOpen = new AtomicBoolean(true);
 		doReturn(isOpen.get()).when(channel).isOpen();
-		when(channel.queueDeclarePassive(Mockito.anyString()))
+		when(channel.queueDeclarePassive(anyString()))
 				.then(invocation -> mock(AMQP.Queue.DeclareOk.class));
 		when(channel.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
 						anyMap(), any(Consumer.class))).thenReturn("consumerTag");
@@ -283,7 +304,7 @@ public class BlockingQueueConsumerTests {
 		when(connection.createChannel(anyBoolean())).thenReturn(channel);
 		final AtomicBoolean isOpen = new AtomicBoolean(true);
 		doReturn(isOpen.get()).when(channel).isOpen();
-		when(channel.queueDeclarePassive(Mockito.anyString()))
+		when(channel.queueDeclarePassive(anyString()))
 				.then(invocation -> mock(AMQP.Queue.DeclareOk.class));
 		when(channel.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
 						anyMap(), any(Consumer.class))).thenReturn("consumerTag");


### PR DESCRIPTION
https://jira.spring.io/browse/AMQP-756

Currently the no-local boolean is hardcoded when creating consumers and the class cannot be easily extended to add support, this pull request adds support for configuring the no-local flag.