### PR TITLE
Properly handle connection errors and `null` consumers in DirectMessageListenerContainer#doConsumeFromQueue 

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -595,8 +595,14 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			else if (this.logger.isWarnEnabled()) {
 				this.logger.warn("basicConsume failed, scheduling consumer " + consumer + " for restart", e);
 			}
-			this.consumersToRestart.add(consumer);
-			consumer = null;
+
+			if (consumer == null) {
+				this.consumersToRestart.add(new SimpleConsumer(null, null, queue));
+			}
+			else {
+				this.consumersToRestart.add(consumer);
+				consumer = null;
+			}
 		}
 		synchronized (this.consumersMonitor) {
 			if (consumer != null) {


### PR DESCRIPTION
DirectMessageListenerContainer#doConsumeFromQueue now properly adds the consumer back to the list of consumers to restart in case of an AmqpConnectException

Fixes spring-projects/spring-amqp#637