### PR TITLE
Fix possible memory leak during DirectMessageListenerContainer startup

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -554,7 +554,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			connection = getConnectionFactory().createConnection();
 		}
 		catch (Exception e) {
-			this.consumersToRestart.add(new SimpleConsumer(null, null, queue));
+			addConsumerToRestart(new SimpleConsumer(null, null, queue));
 				throw e instanceof AmqpConnectException
 						? (AmqpConnectException) e
 						: new AmqpConnectException(e);
@@ -598,10 +598,10 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			}
 
 			if (consumer == null) {
-				this.consumersToRestart.add(new SimpleConsumer(null, null, queue));
+				addConsumerToRestart(new SimpleConsumer(null, null, queue));
 			}
 			else {
-				this.consumersToRestart.add(consumer);
+				addConsumerToRestart(consumer);
 				consumer = null;
 			}
 		}
@@ -699,6 +699,12 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		finally {
 			this.consumers.remove(consumer);
 			consumerRemoved(consumer);
+		}
+	}
+
+	private void addConsumerToRestart(SimpleConsumer consumer) {
+		if (this.started) {
+			this.consumersToRestart.add(consumer);
 		}
 	}
 
@@ -1002,7 +1008,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 					list.remove(this);
 				}
 				DirectMessageListenerContainer.this.consumers.remove(this);
-				DirectMessageListenerContainer.this.consumersToRestart.add(this);
+				DirectMessageListenerContainer.this.addConsumerToRestart(this);
 			}
 			finalizeConsumer();
 		}


### PR DESCRIPTION
DirectMessageListenerContainer now clears the list of consumers to restart if a consumer fails to start during startup. This is necessary to prevent `consumersToRestart` from growing indefinitely while the container is in startup phase.

Fixes spring-projects/spring-amqp#641