### PR TITLE
AmqpAppender: Add thread name to message header

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -102,6 +102,11 @@ public class AmqpAppender extends AbstractAppender {
 	public static final String CATEGORY_LEVEL = "level";
 
 	/**
+	 * Key name for the thread name in the message properties.
+	 */
+	public static final String THREAD_HEADER_KEY = "thread";
+
+	/**
 	 * Tha manager.
 	 */
 	private final AmqpManager manager;
@@ -266,6 +271,7 @@ public class AmqpAppender extends AbstractAppender {
 			amqpProps.setContentEncoding(this.manager.contentEncoding);
 		}
 		amqpProps.setHeader(CATEGORY_NAME, name);
+		amqpProps.setHeader(THREAD_HEADER_KEY, logEvent.getThreadName());
 		amqpProps.setHeader(CATEGORY_LEVEL, level.toString());
 		if (this.manager.generateId) {
 			amqpProps.setMessageId(UUID.randomUUID().toString());

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -106,6 +106,11 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	public static final String CATEGORY_LEVEL = "level";
 
 	/**
+	 * Key name for the thread name in the message properties.
+	 */
+	public static final String THREAD_HEADER_KEY = "thread";
+
+	/**
 	 * Name of the exchange to publish log events to.
 	 */
 	private String exchangeName = "logs";
@@ -678,6 +683,7 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 		if (isIncludeCallerData()) {
 			event.getCallerData();
 		}
+		event.getThreadName();
 		this.events.add(new Event(event));
 	}
 
@@ -739,6 +745,7 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 						amqpProps.setContentEncoding(AmqpAppender.this.contentEncoding);
 					}
 					amqpProps.setHeader(CATEGORY_NAME, name);
+					amqpProps.setHeader(THREAD_HEADER_KEY, logEvent.getThreadName());
 					amqpProps.setHeader(CATEGORY_LEVEL, level.toString());
 					if (AmqpAppender.this.generateId) {
 						amqpProps.setMessageId(UUID.randomUUID().toString());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.amqp.rabbit.log4j2;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -111,6 +113,10 @@ public class AmqpAppenderTests {
 		assertNotNull(received);
 		assertEquals("testAppId.foo.INFO", received.getMessageProperties().getReceivedRoutingKey());
 		assertThat(new String(received.getBody()), startsWith("bar"));
+		Object threadName = received.getMessageProperties().getHeaders().get("thread");
+		assertNotNull(threadName);
+		assertThat(threadName, instanceOf(String.class));
+		assertThat(threadName, is(Thread.currentThread().getName()));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.logback;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -116,6 +117,10 @@ public class AmqpAppenderIntegrationTests {
 		assertThat(location, instanceOf(String.class));
 		assertThat((String) location,
 				startsWith("org.springframework.amqp.rabbit.logback.AmqpAppenderIntegrationTests.testAppenderWithProps()"));
+		Object threadName = messageProperties.getHeaders().get("thread");
+		assertNotNull(threadName);
+		assertThat(threadName, instanceOf(String.class));
+		assertThat(threadName, is(Thread.currentThread().getName()));
 		assertEquals("bar", messageProperties.getHeaders().get("foo"));
 	}
 


### PR DESCRIPTION
AmqpAppender for log4j2 and Logback now add the thread name of the log event as a header field as suggested in [AMQP-761](https://jira.spring.io/browse/AMQP-761) and spring-projects/spring-amqp-samples#27