### PR TITLE
[1.7.x] AmqpAppender for log4j, log4j2 and Logback now add the thread name as a message header field

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j/AmqpAppender.java
@@ -135,6 +135,11 @@ public class AmqpAppender extends AppenderSkeleton {
 	public static final String CATEGORY_LEVEL = "level";
 
 	/**
+	 * Key name for the thread name in the message properties.
+	 */
+	public static final String THREAD_HEADER_KEY = "thread";
+
+	/**
 	 * Name of the exchange to publish log events to.
 	 */
 	private String exchangeName = "logs";
@@ -559,6 +564,7 @@ public class AmqpAppender extends AppenderSkeleton {
 						amqpProps.setContentEncoding(AmqpAppender.this.contentEncoding);
 					}
 					amqpProps.setHeader(CATEGORY_NAME, name);
+					amqpProps.setHeader(THREAD_HEADER_KEY, logEvent.getThreadName());
 					amqpProps.setHeader(CATEGORY_LEVEL, level.toString());
 					if (AmqpAppender.this.generateId) {
 						amqpProps.setMessageId(UUID.randomUUID().toString());

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -96,6 +96,11 @@ public class AmqpAppender extends AbstractAppender {
 	public static final String CATEGORY_LEVEL = "level";
 
 	/**
+	 * Key name for the thread name in the message properties.
+	 */
+	public static final String THREAD_HEADER_KEY = "thread";
+
+	/**
 	 * Tha manager.
 	 */
 	private final AmqpManager manager;
@@ -241,6 +246,7 @@ public class AmqpAppender extends AbstractAppender {
 			amqpProps.setContentEncoding(this.manager.contentEncoding);
 		}
 		amqpProps.setHeader(CATEGORY_NAME, name);
+		amqpProps.setHeader(THREAD_HEADER_KEY, logEvent.getThreadName());
 		amqpProps.setHeader(CATEGORY_LEVEL, level.toString());
 		if (this.manager.generateId) {
 			amqpProps.setMessageId(UUID.randomUUID().toString());

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -95,6 +95,12 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	 */
 	public static final String CATEGORY_LEVEL = "level";
 
+
+	/**
+	 * Key name for the thread name in the message properties.
+	 */
+	public static final String THREAD_HEADER_KEY = "thread";
+
 	/**
 	 * Name of the exchange to publish log events to.
 	 */
@@ -482,6 +488,7 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 		if (isIncludeCallerData()) {
 			event.getCallerData();
 		}
+		event.getThreadName();
 		this.events.add(new Event(event));
 	}
 
@@ -550,6 +557,7 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 						amqpProps.setContentEncoding(AmqpAppender.this.contentEncoding);
 					}
 					amqpProps.setHeader(CATEGORY_NAME, name);
+					amqpProps.setHeader(THREAD_HEADER_KEY, logEvent.getThreadName());
 					amqpProps.setHeader(CATEGORY_LEVEL, level.toString());
 					if (AmqpAppender.this.generateId) {
 						amqpProps.setMessageId(UUID.randomUUID().toString());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j/AmqpAppenderIntegrationTests.java
@@ -16,7 +16,9 @@
 
 package org.springframework.amqp.rabbit.log4j;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -140,6 +142,10 @@ public class AmqpAppenderIntegrationTests {
 		assertNotNull(messageProperties.getHeaders().get(propertyName));
 		assertEquals(propertyValue, messageProperties.getHeaders().get(propertyName));
 		assertEquals("bar", messageProperties.getHeaders().get("foo"));
+		Object threadName = messageProperties.getHeaders().get("thread");
+		assertNotNull(threadName);
+		assertThat(threadName, instanceOf(String.class));
+		assertThat(threadName, is(Thread.currentThread().getName()));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/test/AmqpAppenderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/test/AmqpAppenderTests.java
@@ -16,9 +16,12 @@
 
 package org.springframework.amqp.rabbit.log4j2.test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
@@ -66,6 +69,10 @@ public class AmqpAppenderTests {
 		Message received = template.receive(queue.getName());
 		assertNotNull(received);
 		assertEquals("testAppId.foo.INFO", received.getMessageProperties().getReceivedRoutingKey());
+		Object threadName = received.getMessageProperties().getHeaders().get("thread");
+		assertNotNull(threadName);
+		assertThat(threadName, instanceOf(String.class));
+		assertThat(threadName, is(Thread.currentThread().getName()));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.logback;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -118,6 +119,10 @@ public class AmqpAppenderIntegrationTests {
 		assertThat(location, instanceOf(String.class));
 		assertThat((String) location,
 				startsWith("org.springframework.amqp.rabbit.logback.AmqpAppenderIntegrationTests.testAppenderWithProps()"));
+		Object threadName = messageProperties.getHeaders().get("thread");
+		assertNotNull(threadName);
+		assertThat(threadName, instanceOf(String.class));
+		assertThat(threadName, is(Thread.currentThread().getName()));
 		assertEquals("bar", messageProperties.getHeaders().get("foo"));
 	}
 


### PR DESCRIPTION
AmqpAppender for log4j, log4j2 and Logback now add the thread name of the log event as a header field as suggested in [AMQP-761](https://jira.spring.io/browse/AMQP-761) and spring-projects/spring-amqp-samples#27