### PR TITLE
Remove Bogus DEBUG log.

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -565,7 +565,9 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 					logOrRethrowDeclarationException(queue, "queue", e);
 				}
 			}
-			this.logger.debug("Queue with name that starts with 'amq.' cannot be declared.");
+			else if (this.logger.isDebugEnabled()) {
+				this.logger.debug(queue.getName() + ": Queue with name that starts with 'amq.' cannot be declared.");
+			}
 		}
 		return declareOks.toArray(new DeclareOk[declareOks.size()]);
 	}


### PR DESCRIPTION
"Queue with name that starts with 'amq.' cannot be declared." logged unconditionally.

__Cherry-pick to 1.6.x, 1.7.x__