### PR TITLE
AMQP-759: Expose queue size hook

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -354,6 +354,14 @@ public class AmqpAppender extends AbstractAppender {
 	}
 
 	/**
+	 * Returns the number of events waiting to be send.
+	 * @return the number of events waiting to be send.
+	 */
+	public int getQueuedEventCount() {
+		return this.events.size();
+	}
+
+	/**
 	 * Helper class to actually send LoggingEvents asynchronously.
 	 */
 	protected class EventSender implements Runnable {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -547,6 +547,14 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	}
 
 	/**
+	 * Returns the number of events waiting to be send.
+	 * @return the number of events waiting to be send.
+	 */
+	public int getQueuedEventCount() {
+		return this.events.size();
+	}
+
+	/**
 	 * Set additional client connection properties to be added to the rabbit connection,
 	 * with the form {@code key:value[,key:value]...}.
 	 *


### PR DESCRIPTION
AMQP-759: Expose queue size hook

https://jira.spring.io/browse/AMQP-759

AmqpAppender for Logback and Log4J 2 now expose the current send queue length