### PR TITLE
AMQP-762: Reliably Release Channel Checkout Permit

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -55,6 +55,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -63,6 +64,7 @@ import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.springframework.amqp.AmqpConnectException;
 import org.springframework.amqp.AmqpTimeoutException;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
 import org.springframework.amqp.utils.test.TestUtils;
@@ -276,6 +278,65 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 		verify(mockConnection, never()).close();
 		verify(mockChannel1, never()).close();
+
+		ccf.destroy();
+	}
+
+	@Test
+	public void testCheckoutLimitWithFailures() throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
+		final com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
+		Channel mockChannel1 = mock(Channel.class);
+		final AtomicBoolean brokerDown = new AtomicBoolean();
+		doAnswer(i -> {
+			if (brokerDown.get()) {
+				throw new AmqpConnectException(null);
+			}
+			return mockConnection;
+		}).when(mockConnectionFactory).newConnection(any(ExecutorService.class), anyString());
+		when(mockConnection.createChannel()).thenReturn(mockChannel1);
+		doAnswer(i -> {
+			return !brokerDown.get();
+		}).when(mockConnection).isOpen();
+
+		// Called during physical close
+		doAnswer(i -> {
+			return !brokerDown.get();
+		}).when(mockChannel1).isOpen();
+
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ccf.setChannelCacheSize(1);
+		ccf.setChannelCheckoutTimeout(10);
+
+		Connection con = ccf.createConnection();
+
+		Channel channel1 = con.createChannel(false);
+
+		try {
+			con.createChannel(false);
+			fail("Exception expected");
+		}
+		catch (AmqpTimeoutException e) { }
+
+		// should be ignored, and added last into channel cache.
+		channel1.close();
+
+		// remove first entry in cache (channel1)
+		Channel ch1 = con.createChannel(false);
+
+		assertSame(ch1, channel1);
+
+		ch1.close();
+
+		brokerDown.set(true);
+		try {
+			con.createChannel(false);
+			fail("Exception expected");
+		}
+		catch (AmqpConnectException e) { }
+		brokerDown.set(false);
+		ch1 = con.createChannel(false);
+		ch1.close();
 
 		ccf.destroy();
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -22,11 +22,11 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -174,6 +174,7 @@ public class BlockingQueueConsumerTests {
 		verify(channel).basicQos(20);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testNoLocalConsumerConfiguration() throws Exception {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-762

When using `channelCheckoutTimeout` to limit channels, if a permit was aquired
but a channel not actually created (e.g. because the broker is down), the permit
was not released.

Add a try catch around `getCachedChannelProxy()` and release the permit.

__cherry-pick to master and 1.6.x__