### PR TITLE
AMQP-764: Move Setting stopped to destroy()

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryIntegrationTests.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -59,6 +60,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 
+import org.springframework.amqp.AmqpApplicationContextClosedException;
 import org.springframework.amqp.AmqpAuthenticationException;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpIOException;
@@ -72,6 +74,8 @@ import org.springframework.amqp.rabbit.junit.BrokerTestUtils;
 import org.springframework.amqp.rabbit.test.LogLevelAdjuster;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
@@ -492,6 +496,25 @@ public class CachingConnectionFactoryIntegrationTests {
 				com.rabbitmq.client.Connection.class);
 		assertEquals(CF_INTEGRATION_CONNECTION_NAME, rabbitConnection.getClientProperties().get("connection_name"));
 		this.connectionFactory.destroy();
+	}
+
+	@Test
+	public void testDestroy() {
+		Connection connection1 = this.connectionFactory.createConnection();
+		this.connectionFactory.destroy();
+		Connection connection2 = this.connectionFactory.createConnection();
+		assertSame(connection1, connection2);
+		ApplicationContext context = mock(ApplicationContext.class);
+		this.connectionFactory.setApplicationContext(context);
+		this.connectionFactory.onApplicationEvent(new ContextClosedEvent(context));
+		this.connectionFactory.destroy();
+		try {
+			connection2 = this.connectionFactory.createConnection();
+			fail("Expected exception");
+		}
+		catch (AmqpApplicationContextClosedException e) {
+			assertThat(e.getMessage(), containsString("is closed"));
+		}
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerIntegrationTests.java
@@ -571,7 +571,6 @@ public class DirectMessageListenerContainerIntegrationTests {
 
 		cf.addConnectionListener(connection -> {
 			cf.onApplicationEvent(new ContextClosedEvent(context));
-			cf.stop();
 			cf.destroy();
 		});
 
@@ -608,7 +607,6 @@ public class DirectMessageListenerContainerIntegrationTests {
 		new RabbitTemplate(cf).convertAndSend(Q1, "foo");
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
 		cf.onApplicationEvent(new ContextClosedEvent(context));
-		cf.stop();
 		cf.destroy();
 		int n = 0;
 		while (n++ < 100 && container.isRunning()) {
@@ -635,7 +633,6 @@ public class DirectMessageListenerContainerIntegrationTests {
 		rabbitTemplate.convertAndSend(Q1, "bar");
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
 		container.stop();
-		cf.stop();
 		cf.destroy();
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-764

Fixes https://github.com/spring-projects/spring-amqp/issues/651

Previously, `stopped` was set in `stop()` after the context was closed.
This was done to prevent inadvertent re-opening of the connection which
would prevent the application from terminating.

This was too early since other beans destroyed before the factory might
need to send messages.

Remove `Smartlifecycle` and move setting `stopped` to `destroy()`, but
still only after the context is closed; since `destroy()` can be called
by users to reset the connection (although `resetConnection()` is now the
preferred way to do that.