### PR TITLE
AMQP-764: Move Setting stopped to destroy() [Backport]

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -53,7 +53,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.SmartLifecycle;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
@@ -97,7 +96,7 @@ import com.rabbitmq.client.ShutdownSignalException;
 @ManagedResource
 public class CachingConnectionFactory extends AbstractConnectionFactory
 		implements InitializingBean, ShutdownListener, ApplicationContextAware, ApplicationListener<ContextClosedEvent>,
-				PublisherCallbackChannelConnectionFactory, SmartLifecycle {
+				PublisherCallbackChannelConnectionFactory {
 
 	private static final int DEFAULT_CHANNEL_CACHE_SIZE = 25;
 
@@ -164,10 +163,6 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	private volatile boolean contextStopped;
 
 	private volatile boolean stopped;
-
-	private volatile boolean running;
-
-	private int phase = Integer.MIN_VALUE + 1000;
 
 	private volatile ConditionalExceptionLogger closeExceptionLogger = new DefaultChannelCloseLogger();
 
@@ -670,14 +665,22 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	}
 
 	/**
-	 * Close the underlying shared connection. The provider of this ConnectionFactory needs to care for proper shutdown.
+	 * Close the underlying shared connection. Use {@link #resetConnection()} to close the
+	 * connection while the application is still running.
 	 * <p>
-	 * As this bean implements DisposableBean, a bean factory will automatically invoke this on destruction of its
-	 * cached singletons.
+	 * As this bean implements DisposableBean, a bean factory will automatically invoke
+	 * this on destruction of its cached singletons.
+	 * <p>
+	 * If called after the context is closed, the connection factory can no longer server
+	 * up connections.
 	 */
 	@Override
 	public final void destroy() {
 		resetConnection();
+		if (this.contextStopped) {
+			this.stopped = true;
+			this.deferredCloseExecutor.shutdownNow();
+		}
 	}
 
 	/**
@@ -701,55 +704,64 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		}
 	}
 
-	@Override
+	/**
+	 * @deprecated - no longer used.
+	 */
+	@Deprecated
 	public void start() {
-		this.running = true;
-	}
-
-	@Override
-	public boolean isRunning() {
-		return this.running;
-	}
-
-	@Override
-	public int getPhase() {
-		return this.phase;
+		// empty
 	}
 
 	/**
-	 * Defaults to phase {@link Integer#MIN_VALUE - 1000} so the factory is
-	 * stopped in a very late phase, allowing other beans to use the connection
-	 * to clean up.
+	 * @deprecated - no longer used.
+	 * @return true.
+	 */
+	@Deprecated
+	public boolean isRunning() {
+		return true;
+	}
+
+	/**
+	 * @deprecated - no longer used.
+	 * @return 0.
+	 */
+	@Deprecated
+	public int getPhase() {
+		return 0;
+	}
+
+	/**
+	 * @deprecated - no longer used.
 	 * @see #getPhase()
 	 * @param phase the phase.
 	 * @since 1.5.3
 	 */
+	@Deprecated
 	public void setPhase(int phase) {
-		this.phase = phase;
+		// empty
 	}
 
-	@Override
+	/**
+	 * @deprecated - no longer used.
+	 * @return true.
+	 */
+	@Deprecated
 	public boolean isAutoStartup() {
 		return true;
 	}
 
 	/**
-	 * Stop the connection factory to prevent its connection from being used.
-	 * Note: ignored unless the application context is in the process of being stopped.
+	 * @deprecated - no longer used.
 	 */
-	@Override
+	@Deprecated
 	public void stop() {
-		if (this.contextStopped) {
-			this.running = false;
-			this.stopped = true;
-			this.deferredCloseExecutor.shutdownNow();
-		}
-		else {
-			logger.warn("stop() is ignored unless the application context is being stopped");
-		}
 	}
 
-	@Override
+	/**
+	 * @deprecated - no longer used.
+	 * @param callback the callback.
+	 */
+	@Deprecated
 	public void stop(Runnable callback) {
 		stop();
 		callback.run();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-764

Fixes https://github.com/spring-projects/spring-amqp/issues/651

Previously, `stopped` was set in `stop()` after the context was closed.
This was done to prevent inadvertent re-opening of the connection which
would prevent the application from terminating.

This was too early since other beans destroyed before the factory might
need to send messages.

Remove `Smartlifecycle` and move setting `stopped` to `destroy()`, but
still only after the context is closed; since `destroy()` can be called
by users to reset the connection (although `resetConnection()` is now the
preferred way to do that.

__cherry-pick to 1.6.x__