### PR TITLE
AMQP-765: Suppress Exception on Deferred Close [Backport]

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -1089,6 +1089,11 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 								catch (IOException e) { }
 								catch (AlreadyClosedException e) { }
 								catch (TimeoutException e) { }
+								catch (ShutdownSignalException e) {
+									if (!RabbitUtils.isNormalShutdown(e)) {
+										logger.debug("Unexpected exception on deferred close", e);
+									}
+								}
 							}
 						}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-765

When confirms/returns are enabled we defer the close; suppress
the logged exception if a normal `ShutdownSignalException` is thrown.

Conflicts:
	spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
Resolved.