### PR TITLE
too many debug logs in nextMessage

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -459,7 +459,9 @@ public class BlockingQueueConsumer {
 	 * @throws ShutdownSignalException if the connection is shut down while waiting
 	 */
 	public Message nextMessage() throws InterruptedException, ShutdownSignalException {
-		logger.trace("Retrieving delivery for " + this);
+		if (logger.isTraceEnabled()) {
+		    logger.trace("Retrieving delivery for " + this);
+        }
 		return handle(this.queue.take());
 	}
 
@@ -471,8 +473,8 @@ public class BlockingQueueConsumer {
 	 * @throws ShutdownSignalException if the connection is shut down while waiting
 	 */
 	public Message nextMessage(long timeout) throws InterruptedException, ShutdownSignalException {
-		if (logger.isDebugEnabled()) {
-			logger.debug("Retrieving delivery for " + this);
+		if (logger.isTraceEnabled()) {
+			logger.trace("Retrieving delivery for " + this);
 		}
 		checkShutdown();
 		if (this.missingQueues.size() > 0) {


### PR DESCRIPTION
Can we lower the log level from DEBUG to TRACE in nextMessage()? There are too many these kind of messages.