### PR TITLE
AMQP-770: Re-add constructor with ObjectMapper

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
@@ -73,10 +73,18 @@ public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter i
 	}
 
 	/**
+	 * Construct with the provided {@link ObjectMapper} instance and trusted packed to all ({@code *}).
+	 * @since 1.7.2
+	 */
+	public Jackson2JsonMessageConverter(ObjectMapper jsonObjectMapper) {
+		this(jsonObjectMapper, "*");
+	}
+
+	/**
 	 * Construct with the provided {@link ObjectMapper} instance.
 	 * @param jsonObjectMapper the {@link ObjectMapper} to use.
 	 * @param trustedPackages the trusted Java packages for deserialization
-	 * @since 1.7.2
+	 * @since 1.7.4
 	 * @see DefaultJackson2JavaTypeMapper#setTrustedPackages(String...)
 	 */
 	public Jackson2JsonMessageConverter(ObjectMapper jsonObjectMapper, String... trustedPackages) {


### PR DESCRIPTION
Adding the varargs constructor argument breaks reflection instantiation and therefore is a breaking change to the API.