### PR TITLE
AMQP-748: Increase default prefetch for SimpleListenerContainer

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -92,6 +92,7 @@ import com.rabbitmq.client.ShutdownSignalException;
  * @author Gary Russell
  * @author Alex Panchenko
  * @author Johno Crawford
+ * @author Arnaud Cogoluègnes
  */
 public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 		implements MessageListenerContainer, ApplicationContextAware, BeanNameAware, DisposableBean,
@@ -101,7 +102,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	public static final boolean DEFAULT_DEBATCHING_ENABLED = true;
 
-	public static final int DEFAULT_PREFETCH_COUNT = 1;
+	public static final int DEFAULT_PREFETCH_COUNT = 250;
 
 	/**
 	 * The default recovery interval: 5000 ms = 5 seconds.

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/MissingIdRetryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/MissingIdRetryTests.java
@@ -64,6 +64,7 @@ import org.springframework.retry.support.RetryTemplate;
 
 /**
  * @author Gary Russell
+ * @author Arnaud Cogoluègnes
  * @since 1.1.2
  *
  */
@@ -141,6 +142,7 @@ public class MissingIdRetryTests {
 		RabbitTemplate template = ctx.getBean(RabbitTemplate.class);
 		ConnectionFactory connectionFactory = ctx.getBean(ConnectionFactory.class);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setPrefetchCount(1);
 		container.setMessageListener(new MessageListenerAdapter(new POJO()));
 		container.setQueueNames("retry.test.queue");
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4198,6 +4198,7 @@ a| image::images/tickmark.png[]
 The higher this is the faster the messages can be delivered, but the higher the risk of non-sequential processing.
 Ignored if the `acknowledgeMode` is NONE.
 This will be increased, if necessary, to match the `txSize` or `messagePerAck`.
+Defaults to 250 since 2.0; set to 1 to revert to previous behavior.
 
 a| image::images/tickmark.png[]
 a| image::images/tickmark.png[]

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4213,7 +4213,7 @@ a| image::images/tickmark.png[]
 | prefetchCount
 (prefetch)
 
-a| The number of messages to accept from the broker in one socket frame.
+a| The number of unacknowledged messages that can be outstanding at each consumer.
 The higher this is the faster the messages can be delivered, but the higher the risk of non-sequential processing.
 Ignored if the `acknowledgeMode` is NONE.
 This will be increased, if necessary, to match the `txSize` or `messagePerAck`.

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1336,6 +1336,25 @@ if (received) {
 IMPORTANT: Spring AMQP also supports annotated-listener endpoints through the use of the `@RabbitListener` annotation and provides an open infrastructure to register endpoints programmatically.
 This is by far the most convenient way to setup an asynchronous consumer, see <<async-annotation-driven>> for more details.
 
+[IMPORTANT]
+====
+The prefetch default value used to be 1, which could lead to under-utilization of efficient consumers.
+Starting with _version 2.0_, the default prefetch value is now 250, which should keep consumers busy in most common scenarios and
+thus improve throughput.
+
+There are nevertheless scenarios where the prefetch value should
+be low: for example, with large messages, especially if the processing is slow (messages could add up
+to a large amount of memory in the client process), and if strict message ordering is necessary
+(the prefetch value should be set back to 1 in this case).
+
+Also, with low-volume messaging and multiple consumers (including concurrency within a single listener container instance), you may wish to reduce the prefetch to get a more even distribution of messages across consumers.
+
+See <<containerAttributes>>.
+
+For more background about prefetch, see this post about https://www.rabbitmq.com/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3/[consumer utilization in RabbitMQ]
+and this post about https://www.rabbitmq.com/blog/2012/05/11/some-queuing-theory-throughput-latency-and-bandwidth/[queuing theory].
+====
+
 ====== Message Listener
 
 For asynchronous Message reception, a dedicated component (not the `AmqpTemplate`) is involved.
@@ -4194,11 +4213,18 @@ a| image::images/tickmark.png[]
 | prefetchCount
 (prefetch)
 
-| The number of messages to accept from the broker in one socket frame.
+a| The number of messages to accept from the broker in one socket frame.
 The higher this is the faster the messages can be delivered, but the higher the risk of non-sequential processing.
 Ignored if the `acknowledgeMode` is NONE.
 This will be increased, if necessary, to match the `txSize` or `messagePerAck`.
 Defaults to 250 since 2.0; set to 1 to revert to previous behavior.
+
+IMPORTANT: There are scenarios where the prefetch value should
+be low: for example, with large messages, especially if the processing is slow (messages could add up
+to a large amount of memory in the client process), and if strict message ordering is necessary
+(the prefetch value should be set back to 1 in this case).
+Also, with low-volume messaging and multiple consumers (including concurrency within a single listener container instance), you may wish to reduce the prefetch to get a more even distribution of messages across consumers.
+
 
 a| image::images/tickmark.png[]
 a| image::images/tickmark.png[]

--- a/src/reference/asciidoc/index-docinfo.xml
+++ b/src/reference/asciidoc/index-docinfo.xml
@@ -37,6 +37,10 @@
 				<firstname>Stéphane</firstname>
 				<surname>Nicoll</surname>
 		</author>
+		<author>
+			<firstname>Arnaud</firstname>
+			<surname>Cogoluègnes</surname>
+		</author>
 </authorgroup>
 <legalnotice>
 	<para>

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -68,6 +68,20 @@ See <<message-listener-adapter>> for more information.
 
 ===== Listener Container Changes
 
+====== Prefetch default value
+
+The prefetch default value used to be 1, which could lead to under-utilization of efficient consumers.
+The default prefetch value is now 250, which should keep consumers busy in most common scenarios and
+thus improve throughput.
+
+IMPORTANT: There are nevertheless scenarios where the prefetch value should
+be low: with larges messages, especially if the processing is slow (messages could add up
+to a large amount of memory in the client process), and if strict message ordering is necessary
+(the prefetch value should be set back to 1 in this case).
+
+For more background about prefetch, see this post about https://www.rabbitmq.com/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3/[consumer utilization in RabbitMQ]
+and this post about https://www.rabbitmq.com/blog/2012/05/11/some-queuing-theory-throughput-latency-and-bandwidth/[queuing theory].
+
 ====== Message Count
 
 Previously, `MessageProperties.getMessageCount()` returned `0` for messages emitted by the container.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -75,9 +75,10 @@ The default prefetch value is now 250, which should keep consumers busy in most 
 thus improve throughput.
 
 IMPORTANT: There are nevertheless scenarios where the prefetch value should
-be low: with larges messages, especially if the processing is slow (messages could add up
+be low: for example, with large messages, especially if the processing is slow (messages could add up
 to a large amount of memory in the client process), and if strict message ordering is necessary
 (the prefetch value should be set back to 1 in this case).
+Also, with low-volume messaging and multiple consumers (including concurrency within a single listener container instance), you may wish to reduce the prefetch to get a more even distribution of messages across consumers.
 
 For more background about prefetch, see this post about https://www.rabbitmq.com/blog/2014/04/14/finding-bottlenecks-with-rabbitmq-3-3/[consumer utilization in RabbitMQ]
 and this post about https://www.rabbitmq.com/blog/2012/05/11/some-queuing-theory-throughput-latency-and-bandwidth/[queuing theory].


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-748

The prefetch default value used to be 1, which could lead to
under-utilization of efficient consumers. The default prefetch value
is now 250, which should keep consumers busy in most
common scenarios and thus improve throughput.