### PR TITLE
AMQP-772: Container MPP - Discard Message

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1265,6 +1265,10 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 			if (this.afterReceivePostProcessors != null) {
 				for (MessagePostProcessor processor : this.afterReceivePostProcessors) {
 					message = processor.postProcessMessage(message);
+					if (message == null) {
+						throw new ImmediateAcknowledgeAmqpException(
+								"Message Post Processor returned 'null', discarding message");
+					}
 				}
 			}
 			Object batchFormat = message.getMessageProperties().getHeaders().get(MessageProperties.SPRING_BATCH_FORMAT);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -863,7 +863,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			}
 			catch (ImmediateAcknowledgeAmqpException e) {
 				if (this.logger.isDebugEnabled()) {
-					this.logger.debug("User requested ack for failed delivery: " + deliveryTag);
+					this.logger.debug("User requested ack for failed delivery '"
+							+ e.getMessage() + "': "
+							+ deliveryTag);
 				}
 				handleAck(deliveryTag, channelLocallyTransacted);
 			}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -747,7 +747,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			}
 			catch (ImmediateAcknowledgeAmqpException e) {
 				if (this.logger.isDebugEnabled()) {
-					this.logger.debug("User requested ack for failed delivery: "
+					this.logger.debug("User requested ack for failed delivery '"
+							+ e.getMessage() + "': "
 							+ message.getMessageProperties().getDeliveryTag());
 				}
 				break;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -216,8 +216,9 @@ public abstract class ExternalTxManagerTests {
 
 		transactionManager.rolledBack = false;
 		transactionManager.latch = new CountDownLatch(1);
+		container.setAfterReceivePostProcessors(m -> null);
 		container.setMessageListener(m -> {
-			throw new ImmediateAcknowledgeAmqpException("foo");
+			// NOSONAR
 		});
 		commitLatch.set(new CountDownLatch(1));
 		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
@@ -185,8 +185,9 @@ public abstract class LocallyTransactedTests {
 		verify(onlyChannel, times(2)).basicNack(anyLong(), anyBoolean(), anyBoolean());
 		verify(onlyChannel, times(2)).txRollback();
 
+		container.setAfterReceivePostProcessors(m -> null);
 		container.setMessageListener(m -> {
-			throw new ImmediateAcknowledgeAmqpException("foo");
+			// NOSONAR
 		});
 		commitLatch.set(new CountDownLatch(1));
 		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4699,6 +4699,16 @@ a| image::images/tickmark.png[]
 a| image::images/tickmark.png[]
 a| image::images/tickmark.png[]
 
+| afterReceivePostProcessors
+(N/A)
+
+| An array of `MessagePostProcessor` s which are invoked, before invoking the listener.
+Post processors can implement `PriorityOrdered`, `Ordered`; the array is sorted with un-ordered members invoked last.
+If a post processor returns `null`, the message is discarded (and acknowledged, if appropriate).
+
+a| image::images/tickmark.png[]
+a| image::images/tickmark.png[]
+
 |===
 
 [[listener-concurrency]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -98,6 +98,9 @@ See <<transaction-rollback>> for more information.
 If the container threads do not respond to a shutdown within `shutdownTimeout`, the channel(s) will be forced closed, by default.
 See <<containerAttributes>> for more information.
 
+====== After Receive Message Post Processors
+
+If a `MessagePostProcessor` in the `afterReceiveMessagePostProcessors` property returns `null`, the message is discarded (and acknowledged if appropriate).
 
 ===== Connection Factory Changes
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-772

If an `afterReceivePostProcessor` in the listener container configuration
returns `null`, discard the message.