### PR TITLE
GH-672: Fix SpEL parsing for @RabbitListener

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -726,10 +726,6 @@ public class RabbitListenerAnnotationBeanPostProcessor
 	private Object resolveExpression(String value) {
 		String resolvedValue = resolve(value);
 
-		if (!(resolvedValue.startsWith("#{") && value.endsWith("}"))) {
-			return resolvedValue;
-		}
-
 		return this.resolver.evaluate(resolvedValue, this.expressionContext);
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -580,7 +580,7 @@ public class EnableRabbitIntegrationTests {
 
 	@Test
 	public void testMeta() throws Exception {
-		rabbitTemplate.convertSendAndReceive("test.metaFanout", "", "foo");
+		this.rabbitTemplate.convertAndSend("test.metaFanout", "", "foo");
 		assertTrue(this.metaListener.latch.await(10, TimeUnit.SECONDS));
 	}
 
@@ -765,7 +765,7 @@ public class EnableRabbitIntegrationTests {
 			return foo + ":" + queue;
 		}
 
-		@RabbitListener(queues = "test.simple", group = "testGroup")
+		@RabbitListener(queues = "test.#{'${my.queue.suffix:SIMPLE}'.toLowerCase()}", group = "testGroup")
 		public String capitalize(String foo) {
 			return foo.toUpperCase();
 		}


### PR DESCRIPTION
Fixes spring-projects/spring-amqp#672

The `StandardBeanExpressionResolver` is based on the
`TemplateAwareExpressionParser` which can parse any string to the
`LiteralExpression` or to the `CompositeStringExpression` if
template tokens (`#{` & `}`) are present in the source expression.
This way we don't need to deal with literal concatenations within
templated expression.
The expression like `#{'foo.' + myBean.bar}` can be replaced
with the `foo.#{myBean.bar}`