### PR TITLE
Fix `AsyncRabbitTemplate.stop()` for NPE

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -527,10 +527,10 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 				future.setNackCause("AsyncRabbitTemplate was stopped while waiting for reply");
 				future.cancel(true);
 			}
-		}
-		if (this.internalTaskScheduler) {
-			((ThreadPoolTaskScheduler) this.taskScheduler).destroy();
-			this.taskScheduler = null;
+			if (this.internalTaskScheduler) {
+				((ThreadPoolTaskScheduler) this.taskScheduler).destroy();
+				this.taskScheduler = null;
+			}
 		}
 		this.running = false;
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
@@ -69,6 +69,8 @@ import org.springframework.util.concurrent.ListenableFutureCallback;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.6
  */
 @ContextConfiguration
@@ -360,6 +362,8 @@ public class AsyncRabbitTemplateTests {
 		TheCallback callback = new TheCallback();
 		future.addCallback(callback);
 		assertEquals(1, TestUtils.getPropertyValue(this.asyncTemplate, "pending", Map.class).size());
+		this.asyncTemplate.stop();
+		// Second stop() to be sure that it is idempotent
 		this.asyncTemplate.stop();
 		try {
 			future.get(10, TimeUnit.SECONDS);


### PR DESCRIPTION
The `this.taskScheduler` reset is done outside of the
`if (this.running) {` block causing NPE on the second `stop()` call

**Cherry-pick to 1.7.x & 1.6.x**