### PR TITLE
Log Connection Attempts

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -379,11 +380,18 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 			com.rabbitmq.client.Connection rabbitConnection;
 			if (this.addresses != null) {
+				if (this.logger.isInfoEnabled()) {
+					this.logger.info("Attempting to connect to: " + Arrays.toString(this.addresses));
+				}
 				rabbitConnection = this.rabbitConnectionFactory.newConnection(this.executorService, this.addresses,
 						connectionName);
 
 			}
 			else {
+				if (this.logger.isInfoEnabled()) {
+					this.logger.info("Attempting to connect to: " + this.rabbitConnectionFactory.getHost()
+							+ ":" + this.rabbitConnectionFactory.getPort());
+				}
 				rabbitConnection = this.rabbitConnectionFactory.newConnection(this.executorService, connectionName);
 			}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactoryTests.java
@@ -88,7 +88,9 @@ public abstract class AbstractConnectionFactoryTests {
 		Connection con = connectionFactory.createConnection();
 		assertEquals(1, called.get());
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-		verify(logger).info(captor.capture());
+		verify(logger, times(2)).info(captor.capture());
+		assertThat(captor.getAllValues().get(0),
+				containsString("Attempting to connect to: null:0"));
 		assertThat(captor.getValue(),
 				allOf(containsString("Created new connection: "), containsString("SimpleConnection")));
 
@@ -105,6 +107,19 @@ public abstract class AbstractConnectionFactoryTests {
 
 		verify(mockConnectionFactory, times(1)).newConnection(any(ExecutorService.class), anyString());
 
+		connectionFactory.setAddresses("foo:5672,bar:5672");
+		con = connectionFactory.createConnection();
+		assertEquals(1, called.get());
+		captor = ArgumentCaptor.forClass(String.class);
+		verify(logger, times(4)).info(captor.capture());
+		assertThat(captor.getAllValues().get(2),
+				containsString("Attempting to connect to: [foo:5672, bar:5672]"));
+		assertThat(captor.getValue(),
+				allOf(containsString("Created new connection: "), containsString("SimpleConnection")));
+
+		con.close();
+		connectionFactory.destroy();
+		assertEquals(0, called.get());
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -61,6 +61,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.commons.logging.Log;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -1507,6 +1508,11 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.createConnection();
 		verify(mock).isAutomaticRecoveryEnabled();
 		verify(mock).setHost("abc");
+		Log logger = TestUtils.getPropertyValue(ccf, "logger", Log.class);
+		if (logger.isInfoEnabled()) {
+			verify(mock).getHost();
+			verify(mock).getPort();
+		}
 		verify(mock).newConnection(any(ExecutorService.class), anyString());
 		verifyNoMoreInteractions(mock);
 	}
@@ -1550,6 +1556,11 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		InOrder order = inOrder(mock);
 		order.verify(mock).isAutomaticRecoveryEnabled();
 		order.verify(mock).setUri(uri);
+		Log logger = TestUtils.getPropertyValue(ccf, "logger", Log.class);
+		if (logger.isInfoEnabled()) {
+			order.verify(mock).getHost();
+			order.verify(mock).getPort();
+		}
 		order.verify(mock).newConnection(any(ExecutorService.class), anyString());
 		verifyNoMoreInteractions(mock);
 	}


### PR DESCRIPTION
In many complex environments e.g. boot properties, cloud connectors, environment overrides etc.
it can be difficult to debug connection problems.

Add INFO logs with configured broker address(es) before connecting.

__cherry-pick to 1.7.x__