### PR TITLE
AMQP-779: User correlationId with reply container

### DIFF
--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2975,6 +2975,11 @@ Of course, the client and server must use the same header for correlation data.
 NOTE: Spring AMQP version 1.1 used a custom property `spring_reply_correlation` for this data.
 If you wish to revert to this behavior with the current version, perhaps to maintain compatibility with another application using 1.1, you must set the attribute to `spring_reply_correlation`.
 
+By default, the template will generate its own correlation id (ignoring any user-supplied value).
+If you wish to use your own correlationId, set the `RabbitTemplate` 's `userCorrelationId` property to `true`.
+
+IMPORTANT: The correlationId must be unique to avoid the possibility of wrong reply being returned for a request.
+
 [[reply-listener]]
 ===== Reply Listener Container
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-779

Allow the use of a user-supplied correlationId instead of one
generated by the `RabbitTemplate`.

It is the user's responsibility to ensure uniqueness.

__The backport to 1.7.x will need some work because of the `String` Vs. `byte[]`
correlationId changes__