### PR TITLE
AMQP-763: Allow custom queue implementation for AmqpAppender

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -148,7 +149,7 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	/**
 	 * Where LoggingEvents are queued to send.
 	 */
-	private final LinkedBlockingQueue<Event> events = new LinkedBlockingQueue<Event>();
+	private BlockingQueue<Event> events;
 
 	/**
 	 * The pool of senders.
@@ -596,6 +597,8 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 
 	@Override
 	public void start() {
+		this.events = createEventQueue();
+
 		ConnectionFactory rabbitConnectionFactory = createRabbitConnectionFactory();
 		if (rabbitConnectionFactory != null) {
 			super.start();
@@ -689,6 +692,16 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	 * @since 1.5.6
 	 */
 	protected void updateConnectionClientProperties(Map<String, Object> clientProperties) {
+	}
+
+	/**
+	 * Subclasses can override this method to inject a custom queue implementation.
+	 *
+	 * @return the queue to use for queueing logging events before processing them.
+	 * @since 2.0.1
+	 */
+	protected BlockingQueue<Event> createEventQueue() {
+		return new LinkedBlockingQueue<>();
 	}
 
 	@Override

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -160,6 +162,21 @@ public class AmqpAppenderTests {
 		assertEquals(5, TestUtils.getPropertyValue(manager, "maxSenderRetries"));
 		// change the property to true and this fails and test() randomly fails too.
 		assertFalse(TestUtils.getPropertyValue(manager, "async", Boolean.class));
+
+		assertEquals(10, TestUtils.getPropertyValue(appender, "events.items", Object[].class).length);
+
+		Object events = TestUtils.getPropertyValue(appender, "events");
+		assertEquals(ArrayBlockingQueue.class, events.getClass());
+	}
+
+	@Test
+	public void testAmqpAppenderEventQueueTypeDefaultsToLinkedBlockingQueue() throws Exception {
+		Logger logger = LogManager.getLogger("default_queue_logger");
+		AmqpAppender appender = (AmqpAppender) TestUtils.getPropertyValue(logger, "context.configuration.appenders",
+				Map.class).get("rabbitmq_default_queue");
+
+		Object events = TestUtils.getPropertyValue(appender, "events");
+		assertEquals(LinkedBlockingQueue.class, events.getClass());
 	}
 
 	@Test

--- a/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
+++ b/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
@@ -13,7 +13,15 @@
 			charset="UTF-8"
 			clientConnectionProperties="foo:bar,baz:qux"
 			async="false"
-			senderPoolSize="3" maxSenderRetries="5">
+			senderPoolSize="3" maxSenderRetries="5"
+			bufferSize="10">
+			<ArrayBlockingQueue />
+		</RabbitMQ>
+		<RabbitMQ name="rabbitmq_default_queue"
+			addresses="localhost:5672"
+			host="localhost" port="5672" user="guest" password="guest" applicationId="testAppId" charset="UTF-8"
+			routingKeyPattern="%X{applicationId}.%c.%p"
+			exchange="log4j2Test_default_queue" deliveryMode="NON_PERSISTENT">
 		</RabbitMQ>
 		<RabbitMQ name="rabbitmq_uri"
 			uri="amqp://guest:guest@localhost:5672/"
@@ -28,6 +36,9 @@
 	<Loggers>
 		<Logger name="foo" level="info">
 			<AppenderRef ref="rabbitmq" />
+		</Logger>
+		<Logger name="default_queue_logger" level="info">
+			<AppenderRef ref="rabbitmq_default_queue"/>
 		</Logger>
 		<Logger name="bar" level="info">
 			<AppenderRef ref="rabbitmq_uri" />

--- a/spring-rabbit/src/test/resources/logback-test.xml
+++ b/spring-rabbit/src/test/resources/logback-test.xml
@@ -25,6 +25,23 @@
 		<foo>bar</foo>
 	</appender>
 
+	<appender name="AMQPWithCustomQueue"
+			  class="org.springframework.amqp.rabbit.logback.AmqpAppenderIntegrationTests$CustomQueueAppender">
+		<layout>
+			<pattern><![CDATA[ %d %p %t [%c] - <%m>%n ]]></pattern>
+		</layout>
+		<addresses>localhost:5672</addresses>
+		<abbreviation>36</abbreviation>
+		<includeCallerData>true</includeCallerData>
+		<applicationId>AmqpAppenderTest</applicationId>
+		<routingKeyPattern>%property{applicationId}.%c.%p</routingKeyPattern>
+		<generateId>true</generateId>
+		<charset>UTF-8</charset>
+		<durable>false</durable>
+		<deliveryMode>NON_PERSISTENT</deliveryMode>
+		<declareExchange>true</declareExchange>
+	</appender>
+
 	<appender name="AMQPWithEncoder" class="org.springframework.amqp.rabbit.logback.AmqpAppender">
 		<encoder>
 			<pattern><![CDATA[ %d %p %t [%c] - <%m>%n ]]></pattern>
@@ -49,6 +66,10 @@
 
 	<logger name="encoded" level="DEBUG" additivity="false">
 		<appender-ref ref="AMQPWithEncoder"/>
+	</logger>
+
+	<logger name="customQueue" level="DEBUG" additivity="false">
+		<appender-ref ref="AMQPWithCustomQueue"/>
 	</logger>
 
 	<root level="INFO">

--- a/src/reference/asciidoc/logging.adoc
+++ b/src/reference/asciidoc/logging.adoc
@@ -302,3 +302,34 @@ Of course, for simple String properties like this example, the previous techniqu
 richer properties (such as adding a `Map` or numeric property).
 
 With log4j2, subclasses are not supported, due to the way log4j2 uses static factory methods.
+
+==== Providing a Custom Queue Implementation
+
+AmqpAppender uses a BlockingQueue to asynchronously publish logging events to RabbitMQ. By default a LinkedBlockingQueue is used.
+However, it is possible to supply any kind of custom BlockingQueue implementation.
+
+.logback
+[source, java]
+----
+public class MyEnhancedAppender extends AmqpAppender {
+    @Override
+    protected BlockingQueue<Event> createEventQueue() {
+        return new ArrayBlockingQueue();
+    }
+
+}
+----
+
+The Log4j2 appender supports usage of a
+https://logging.apache.org/log4j/2.x/manual/appenders.html#BlockingQueueFactory[BlockingQueueFactory].
+
+.log4j2
+[source, xml]
+----
+<Appenders>
+    ...
+    <RabbitMQ name="rabbitmq" bufferSize="10" ... >
+        <ArrayBlockingQueue/>
+    </RabbitMQ>
+</Appenders>
+----


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-763

Some issues I still have with the current solution:
* I want to ask for your opinion on `BlockingQueue#add` vs. `BlockingQueue#offer` in this case. While `offer` is usually the preferred option if potentially bounded queues are expected, I feel like it's not the appenders task to handle out-of-capacity situations so failing with a RuntimeException is fine.
* Sadly, I'm not familiar with Log4j2 but I'd like to provide the same functionality there too. Since Log4j2 does not support subclassing, my current plan is to add a `@PluginAttribute Class ...` to the appender factory and then instantiate the provided class reflectively. Does Spring provide any class instantiation utilities which should be used for this purpose? Is there a more straightforward way to do this?
* With regards to Log4j2 support, would it be more desirable to make both solution behave the same? - i.e. Instead of subclassing for Logback, also add a `queue` configuration option to the appender which accepts a class name and works the same as the Log4j2 version