### PR TITLE
AMQP-780: Configurable consumer start timeout

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -77,6 +77,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	private static final long DEFAULT_STOP_CONSUMER_MIN_INTERVAL = 60000;
 
+	private static final long DEFAULT_CONSUMER_START_TIMEOUT = 60000L;
+
 	private static final int DEFAULT_CONSECUTIVE_ACTIVE_TRIGGER = 10;
 
 	private static final int DEFAULT_CONSECUTIVE_IDLE_TRIGGER = 10;
@@ -114,6 +116,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	private Long retryDeclarationInterval;
 
 	private TransactionTemplate transactionTemplate;
+
+	private long consumerStartTimeout = DEFAULT_CONSUMER_START_TIMEOUT;
 
 	/**
 	 * Default constructor for convenient dependency injection via setters.
@@ -379,6 +383,18 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 */
 	public void setRetryDeclarationInterval(long retryDeclarationInterval) {
 		this.retryDeclarationInterval = retryDeclarationInterval;
+	}
+
+	/**
+	 * When starting a consumer, if this time (ms) elapses before the consumer starts, an
+	 * error log is written; one possible cause would be if the
+	 * {@link #setTaskExecutor(java.util.concurrent.Executor) taskExecutor} has
+	 * insufficient threads to support the container concurrency. Default 60000.
+	 * @param consumerStartTimeout the timeout.
+	 * @since 1.7.5
+	 */
+	public void setConsumerStartTimeout(long consumerStartTimeout) {
+		this.consumerStartTimeout = consumerStartTimeout;
 	}
 
 	/**
@@ -859,8 +875,15 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		 * @throws TimeoutException if the consumer hasn't started
 		 * @throws InterruptedException if the consumer startup is interrupted
 		 */
-		private FatalListenerStartupException getStartupException() throws TimeoutException, InterruptedException {
-			this.start.await(60000L, TimeUnit.MILLISECONDS); //NOSONAR - ignore return value
+		private FatalListenerStartupException getStartupException() throws TimeoutException,
+					InterruptedException {
+			if (!this.start.await(
+					SimpleMessageListenerContainer.this.consumerStartTimeout, TimeUnit.MILLISECONDS)) {
+				logger.error("Consumer failed to start in "
+						+ SimpleMessageListenerContainer.this.consumerStartTimeout
+						+ " milliseconds; does the task executor have enough threads to support the container "
+						+ "concurrency?");
+			}
 			return this.startupException;
 		}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4402,6 +4402,18 @@ See <<listener-concurrency>>.
 a| image::images/tickmark.png[]
 a|
 
+| consumerStartTimeout
+(N/A)
+
+| The time in milliseconds to wait for a consumer thread to start.
+If this time elapses an error log is written; an example of when this might happen is if a `taskExecutor` was configured that has insufficient threads to support the container `concurrentConsumers`.
+
+See <<threading>>.
+Default 60000 (60 seconds).
+
+a| image::images/tickmark.png[]
+a|
+
 | startConsumerMin
 Interval
 (min-start-interval)


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-780

Log an error if a consumer doesn't start within the timeout; make the timeout configurable.

This can happen if the task executor doesn't have enough threads to support the concurrency.

__cherry-pick to 1.7.x__