### PR TITLE
AMQP-783: Can't use blank key/trust store passwords

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -648,11 +648,11 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 			String keyStoreType = getKeyStoreType();
 			String trustStoreType = getTrustStoreType();
 			char[] keyPassphrase = null;
-			if (StringUtils.hasText(keyStorePassword)) {
+			if (keyStorePassword != null) {
 				keyPassphrase = keyStorePassword.toCharArray();
 			}
 			char[] trustPassphrase = null;
-			if (StringUtils.hasText(trustStorePassword)) {
+			if (trustStorePassword != null) {
 				trustPassphrase = trustStorePassword.toCharArray();
 			}
 			KeyManager[] keyManagers = null;


### PR DESCRIPTION
https://jira.spring.io/browse/AMQP-783

This has not been commented on yet, but I think it is a pretty benign change so I just went ahead and did it. Please let me know what you think.