### PR TITLE
AMQP-776: More Consumer Events

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -55,6 +55,7 @@ import org.springframework.amqp.rabbit.support.Delivery;
 import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
 import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
 import org.springframework.amqp.support.ConsumerTagStrategy;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.backoff.BackOffExecution;
@@ -144,6 +145,8 @@ public class BlockingQueueConsumer {
 	private long shutdownTimeout;
 
 	private boolean locallyTransacted;
+
+	private ApplicationEventPublisher applicationEventPublisher;
 
 	private volatile long abortStarted;
 
@@ -346,6 +349,10 @@ public class BlockingQueueConsumer {
 	 */
 	public void setLocallyTransacted(boolean locallyTransacted) {
 		this.locallyTransacted = locallyTransacted;
+	}
+
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
 	}
 
 	/**
@@ -633,6 +640,9 @@ public class BlockingQueueConsumer {
 		}
 		else {
 			logger.error("Null consumer tag received for queue " + queue);
+		}
+		if (this.applicationEventPublisher != null) {
+			this.applicationEventPublisher.publishEvent(new ConsumeOkEvent(this, queue, consumerTag));
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConsumeOkEvent.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConsumeOkEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import org.springframework.amqp.event.AmqpEvent;
+
+/**
+ * @author Gary Russell
+ * @since 1.7.5
+ *
+ */
+@SuppressWarnings("serial")
+public class ConsumeOkEvent extends AmqpEvent {
+
+	private final String queue;
+
+	private final String consumerTag;
+
+	public ConsumeOkEvent(Object source, String queue, String consumerTag) {
+		super(source);
+		this.queue = queue;
+		this.consumerTag = consumerTag;
+	}
+
+	@Override
+	public String toString() {
+		return "ConsumeOkEvent [queue=" + this.queue + ", consumerTag=" + this.consumerTag
+				+ ", consumer=" + getSource() + "]";
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -986,6 +986,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			if (this.logger.isDebugEnabled()) {
 				this.logger.debug("New " + this + " consumeOk");
 			}
+			if (getApplicationEventPublisher() != null) {
+				getApplicationEventPublisher().publishEvent(new ConsumeOkEvent(this, getQueue(), consumerTag));
+			}
 		}
 
 		@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -677,6 +677,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		}
 		consumer.setBackOffExecution(getRecoveryBackOff().start());
 		consumer.setShutdownTimeout(getShutdownTimeout());
+		consumer.setApplicationEventPublisher(getApplicationEventPublisher());
 		return consumer;
 	}
 
@@ -1083,6 +1084,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			catch (Error e) { //NOSONAR
 				// ok to catch Error - we're aborting so will stop
 				logger.error("Consumer thread error, thread abort.", e);
+				logConsumerException(e);
 				aborted = true;
 			}
 			catch (Throwable t) { //NOSONAR

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -267,11 +267,15 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		assertNull(template.receiveAndConvert(queue.getName()));
 		container.stop();
 		assertTrue(eventLatch.await(10, TimeUnit.SECONDS));
-		assertThat(events.size(), equalTo(4));
+		assertThat(events.size(), equalTo(8));
 		assertThat(events.get(0), instanceOf(AsyncConsumerStartedEvent.class));
-		assertSame(events.get(1), eventRef.get());
-		assertThat(events.get(2), instanceOf(AsyncConsumerRestartedEvent.class));
-		assertThat(events.get(3), instanceOf(AsyncConsumerStoppedEvent.class));
+		assertThat(events.get(1), instanceOf(ConsumeOkEvent.class));
+		assertThat(events.get(2), instanceOf(ConsumeOkEvent.class));
+		assertSame(events.get(3), eventRef.get());
+		assertThat(events.get(4), instanceOf(AsyncConsumerRestartedEvent.class));
+		assertThat(events.get(5), instanceOf(ConsumeOkEvent.class));
+		assertThat(events.get(6), instanceOf(ConsumeOkEvent.class));
+		assertThat(events.get(7), instanceOf(AsyncConsumerStoppedEvent.class));
 	}
 
 	@Test
@@ -320,13 +324,15 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		context.refresh();
 		container1.setApplicationContext(context);
 		container1.setExclusive(true);
+		final CountDownLatch consumeLatch1 = new CountDownLatch(1);
+		container1.setApplicationEventPublisher(event -> {
+			if (event instanceof ConsumeOkEvent) {
+				consumeLatch1.countDown();
+			}
+		});
 		container1.afterPropertiesSet();
 		container1.start();
-		int n = 0;
-		while (n++ < 100 && container1.getActiveConsumerCount() < 1) {
-			Thread.sleep(100);
-		}
-		assertTrue(n < 100);
+		assertTrue(consumeLatch1.await(10, TimeUnit.SECONDS));
 		CountDownLatch latch2 = new CountDownLatch(1000);
 		SimpleMessageListenerContainer container2 = new SimpleMessageListenerContainer(template.getConnectionFactory());
 		container2.setMessageListener(new MessageListenerAdapter(new PojoListener(latch2)));
@@ -335,20 +341,14 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		container2.setRecoveryInterval(1000);
 		container2.setExclusive(true); // not really necessary, but likely people will make all consumers exclusive.
 		final AtomicReference<ListenerContainerConsumerFailedEvent> eventRef = new AtomicReference<>();
-		container2.setApplicationEventPublisher(new ApplicationEventPublisher() {
-
-			@Override
-			public void publishEvent(Object event) {
-				//NOSONAR
+		final CountDownLatch consumeLatch2 = new CountDownLatch(1);
+		container2.setApplicationEventPublisher(event -> {
+			if (event instanceof ListenerContainerConsumerFailedEvent) {
+				eventRef.set((ListenerContainerConsumerFailedEvent) event);
 			}
-
-			@Override
-			public void publishEvent(ApplicationEvent event) {
-				if (event instanceof ListenerContainerConsumerFailedEvent) {
-					eventRef.set((ListenerContainerConsumerFailedEvent) event);
-				}
+			else if (event instanceof ConsumeOkEvent) {
+				consumeLatch2.countDown();
 			}
-
 		});
 		container2.afterPropertiesSet();
 		Log containerLogger = spy(TestUtils.getPropertyValue(container2, "logger", Log.class));
@@ -362,6 +362,7 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		assertEquals(1000, latch2.getCount());
 		container1.stop();
 		// container 2 should recover and process the next batch of messages
+		assertTrue(consumeLatch2.await(10, TimeUnit.SECONDS));
 		for (int i = 0; i < 1000; i++) {
 			template.convertAndSend(queue.getName(), i + "foo");
 		}
@@ -585,6 +586,28 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		verify(logger).error(captor.capture());
 		assertThat(captor.getValue(), equalTo("Consumer failed to start in 100 milliseconds; does the task "
 				+ "executor have enough threads to support the container concurrency?"));
+	}
+
+	@Test
+	public void testErrorStopsContainer() throws Exception {
+		this.container = createContainer((MessageListener) (m) -> {
+			throw new Error("testError");
+		}, false, this.queue.getName());
+		final CountDownLatch latch = new CountDownLatch(1);
+		this.container.setApplicationEventPublisher(event -> {
+			if (event instanceof ListenerContainerConsumerFailedEvent) {
+				latch.countDown();
+			}
+		});
+		this.container.setDefaultRequeueRejected(false);
+		this.container.start();
+		this.template.convertAndSend(this.queue.getName(), "foo");
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		int n = 0;
+		while (n++ < 100 && this.container.isRunning()) {
+			Thread.sleep(100);
+		}
+		assertFalse(this.container.isRunning());
 	}
 
 	private boolean containerStoppedForAbortWithBadListener() throws InterruptedException {

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1588,7 +1588,7 @@ Batched messages are automatically de-batched by listener containers (using the 
 See <<template-batching>> for more information about batching.
 
 [[consumer-events]]
-===== Consumer Failure Events
+===== Consumer Events
 
 The containers publish application events whenever a listener
 (consumer) experiences a failure of some kind.
@@ -1612,6 +1612,15 @@ event, a `WARN` log is issued. To change this logging behavior, provide a custom
 See also <<channel-close-logging>>.
 
 Fatal errors are always logged at `ERROR` level; this it not modifiable.
+
+Several other events are published at various stages of the container lifecycle:
+
+- `AsyncConsumerStartedEvent` (when the consumer is started)
+- `AsyncConsumerRestartedEvent` (when the consumer is restarted after a failure - `SimpleMessageListenerContainer` only)
+- `AsyncConsumerTerminatedEvent` (when a consumer is stopped normally)
+- `AsyncConsumerStoppedEvent` (when the consumer is stopped - `SimpleMessageListenerContainer` only)
+- `ConsumeOkEvent` (when a `consumeOk` is received from the broker, contains the queue name and `consumerTag`)
+- `ListenerContainerIdleEvent` (see <<idle-containers>>)
 
 [[consumerTags]]
 ===== Consumer Tags

--- a/src/reference/asciidoc/quick-tour.adoc
+++ b/src/reference/asciidoc/quick-tour.adoc
@@ -30,9 +30,7 @@ compile 'org.springframework.amqp:spring-rabbit:{spring-amqp-version}'
 
 The minimum Spring Framework version dependency is 5.0.x.
 
-The minimum `amqp-client` java client library version is 4.1.0.
-
-Note the this refers to the java client library; generally, it will work with older broker versions.
+The minimum `amqp-client` java client library version is 5.0.0.
 
 ===== Very, Very Quick
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-776
JIRA: https://jira.spring.io/browse/AMQP-777
JIRA: https://jira.spring.io/browse/AMQP-782

Publish an event when a consumer successfully consumes from a queue.
Publish an event when an SMLC listener throws an `Error`.
Doc polishing.

Update minimum client version in docs; remove reference to broker version
since that's no longer linked to the client.

__cherry-pick to 1.7.x (minus DMLC change)__