### PR TITLE
AMQP-785: SMLC Lifecycle fixes

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1084,11 +1084,16 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * Stop the shared Connection, call {@link #doShutdown()}, and close this container.
 	 */
 	public void shutdown() {
-		logger.debug("Shutting down Rabbit listener container");
 		synchronized (this.lifecycleMonitor) {
+			if (!isActive()) {
+				logger.info("Shutdown ignored - container is not active already");
+				return;
+			}
 			this.active = false;
 			this.lifecycleMonitor.notifyAll();
 		}
+
+		logger.debug("Shutting down Rabbit listener container");
 
 		// Shut down the invokers.
 		try {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1139,6 +1139,9 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 */
 	@Override
 	public void start() {
+		if (isRunning()) {
+			return;
+		}
 		if (!this.initialized) {
 			synchronized (this.lifecycleMonitor) {
 				if (!this.initialized) {
@@ -1500,7 +1503,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 		return e;
 	}
 
-	protected final void publishConsumerFailedEvent(String reason, boolean fatal, Throwable t) {
+	protected void publishConsumerFailedEvent(String reason, boolean fatal, Throwable t) {
 		if (this.applicationEventPublisher != null) {
 			this.applicationEventPublisher
 					.publishEvent(t == null ? new ListenerContainerConsumerTerminatedEvent(this, reason) :

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ActiveObjectCounter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ActiveObjectCounter.java
@@ -26,12 +26,16 @@ import java.util.concurrent.TimeUnit;
 /**
  * A mechanism to keep track of active objects.
  * @param <T> the object type.
+ *
  * @author Dave Syer
+ * @author Artem Bilan
  *
  */
 public class ActiveObjectCounter<T> {
 
 	private final ConcurrentMap<T, CountDownLatch> locks = new ConcurrentHashMap<T, CountDownLatch>();
+
+	private volatile boolean active = true;
 
 	public void add(T object) {
 		CountDownLatch lock = new CountDownLatch(1);
@@ -73,6 +77,15 @@ public class ActiveObjectCounter<T> {
 
 	public void reset() {
 		this.locks.clear();
+		this.active = true;
+	}
+
+	public void deactivate() {
+		this.active = false;
+	}
+
+	public boolean isActive() {
+		return this.active;
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -65,7 +65,10 @@ import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.Recoverable;
+import com.rabbitmq.client.RecoveryListener;
 import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.client.impl.recovery.AutorecoveringChannel;
 import com.rabbitmq.utility.Utility;
 
 /**
@@ -80,7 +83,7 @@ import com.rabbitmq.utility.Utility;
  * @author Alex Panchenko
  * @author Johno Crawford
  */
-public class BlockingQueueConsumer {
+public class BlockingQueueConsumer implements RecoveryListener {
 
 	private static Log logger = LogFactory.getLog(BlockingQueueConsumer.class);
 
@@ -151,6 +154,10 @@ public class BlockingQueueConsumer {
 	private volatile long abortStarted;
 
 	private volatile boolean normalCancel;
+
+	volatile Thread thread;
+
+	volatile boolean declaring;
 
 	/**
 	 * Create a consumer. The consumer must not attempt to use
@@ -552,10 +559,12 @@ public class BlockingQueueConsumer {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Starting consumer " + this);
 		}
+		this.thread = Thread.currentThread();
 		try {
 			this.resourceHolder = ConnectionFactoryUtils.getTransactionalResourceHolder(this.connectionFactory,
 					this.transactional);
 			this.channel = this.resourceHolder.getChannel();
+			addRecoveryListener();
 		}
 		catch (AmqpAuthenticationException e) {
 			throw new FatalListenerStartupException("Authentication failure", e);
@@ -566,6 +575,7 @@ public class BlockingQueueConsumer {
 
 		// mirrored queue might be being moved
 		int passiveDeclareRetries = this.declarationRetries;
+		this.declaring = true;
 		do {
 			try {
 				attemptPassiveDeclarations();
@@ -582,7 +592,10 @@ public class BlockingQueueConsumer {
 							Thread.sleep(this.failedDeclarationRetryInterval);
 						}
 						catch (InterruptedException e1) {
+							this.declaring = false;
 							Thread.currentThread().interrupt();
+							this.activeObjectCounter.release(this);
+							throw RabbitExceptionTranslator.convertRabbitAccessException(e1);
 						}
 					}
 				}
@@ -595,6 +608,7 @@ public class BlockingQueueConsumer {
 					this.lastRetryDeclaration = System.currentTimeMillis();
 				}
 				else {
+					this.declaring = false;
 					this.activeObjectCounter.release(this);
 					throw new QueuesNotAvailableException("Cannot prepare queue for listener. "
 							+ "Either the queue doesn't exist or the broker will not allow us to use it.", e);
@@ -602,6 +616,7 @@ public class BlockingQueueConsumer {
 			}
 		}
 		while (passiveDeclareRetries-- > 0);
+		this.declaring = false;
 
 		if (!this.acknowledgeMode.isAutoAck()) {
 			// Set basicQos before calling basicConsume (otherwise if we are not acking the broker
@@ -625,6 +640,19 @@ public class BlockingQueueConsumer {
 		}
 		catch (IOException e) {
 			throw RabbitExceptionTranslator.convertRabbitAccessException(e);
+		}
+	}
+
+	/**
+	 * Add a listener if necessary so we can immediately close an autorecovered
+	 * channel if necessary since the async consumer will no longer exist.
+	 */
+	private void addRecoveryListener() {
+		if (this.channel instanceof ChannelProxy) {
+			if (((ChannelProxy) this.channel).getTargetChannel() instanceof AutorecoveringChannel) {
+				((AutorecoveringChannel) ((ChannelProxy) this.channel).getTargetChannel())
+						.addRecoveryListener(this);
+			}
 		}
 	}
 
@@ -801,6 +829,25 @@ public class BlockingQueueConsumer {
 
 		return true;
 
+	}
+
+	@Override
+	public void handleRecovery(Recoverable recoverable) {
+		// should never get here
+		handleRecoveryStarted(recoverable);
+	}
+
+	@Override
+	public void handleRecoveryStarted(Recoverable recoverable) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Closing an autorecovered channel: " + recoverable);
+		}
+		try {
+			((Channel) recoverable).close();
+		}
+		catch (IOException | TimeoutException e) {
+			logger.debug("Error closing an autorecovered channel");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-785

- Only stop the container on one thread
- Ignore concurrent stops
- Interrupt consumer threads that are attempting to declare queues
- In `restart()` don't start a new consumer if the container is stopping
- Defer publishing consumer failure events until container is stopped
- Add a RecoveryListener if needed to ensure channels are never recovered
- Fix event publishing for `Error` - it is fatal

__backport to 1.7.x will require work__