### PR TITLE
AMQP-788 Add delegate publisher connection factory

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -432,6 +432,11 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 		return this.publisherConnectionFactory != null;
 	}
 
+	@Override
+	public ConnectionFactory getPublisherConnectionFactory() {
+		return this.publisherConnectionFactory;
+	}
+
 	protected final Connection createBareConnection() {
 		try {
 			String connectionName = this.connectionNameStrategy.obtainNewConnectionName(this);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -416,7 +416,7 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 		this.connectionNameStrategy = connectionNameStrategy;
 		if (this.publisherConnectionFactory != null) {
 			this.publisherConnectionFactory.setConnectionNameStrategy(
-					cf -> connectionNameStrategy + PUBLISHER_SUFFIX);
+					cf -> connectionNameStrategy.obtainNewConnectionName(cf) + PUBLISHER_SUFFIX);
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -63,6 +63,8 @@ import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 public abstract class AbstractConnectionFactory implements ConnectionFactory, DisposableBean, BeanNameAware,
 		ApplicationContextAware, ApplicationEventPublisherAware, ApplicationListener<ContextClosedEvent> {
 
+	private static final String PUBLISHER_SUFFIX = ".publisher";
+
 	public static final int DEFAULT_CLOSE_TIMEOUT = 30000;
 
 	private static final String BAD_URI = "setUri() was passed an invalid URI; it is ignored";
@@ -76,6 +78,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	private final CompositeChannelListener channelListener = new CompositeChannelListener();
 
 	private final AtomicInteger defaultConnectionNameStrategyCounter = new AtomicInteger();
+
+	private AbstractConnectionFactory publisherConnectionFactory;
 
 	private RecoveryListener recoveryListener = new RecoveryListener() {
 
@@ -115,7 +119,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	private volatile boolean contextStopped;
 
 	/**
-	 * Create a new AbstractConnectionFactory for the given target ConnectionFactory.
+	 * Create a new AbstractConnectionFactory for the given target ConnectionFactory,
+	 * with no publisher connection factory.
 	 * @param rabbitConnectionFactory the target ConnectionFactory
 	 */
 	public AbstractConnectionFactory(com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory) {
@@ -123,9 +128,17 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 		this.rabbitConnectionFactory = rabbitConnectionFactory;
 	}
 
+	protected final void setPublisherConnectionFactory(
+			AbstractConnectionFactory publisherConnectionFactory) {
+		this.publisherConnectionFactory = publisherConnectionFactory;
+	}
+
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setApplicationContext(applicationContext);
+		}
 	}
 
 	protected ApplicationContext getApplicationContext() {
@@ -135,6 +148,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	@Override
 	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
 		this.applicationEventPublisher = applicationEventPublisher;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setApplicationEventPublisher(applicationEventPublisher);
+		}
 	}
 
 	protected ApplicationEventPublisher getApplicationEventPublisher() {
@@ -145,6 +161,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	public void onApplicationEvent(ContextClosedEvent event) {
 		if (getApplicationContext() == event.getApplicationContext()) {
 			this.contextStopped = true;
+		}
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.onApplicationEvent(event);
 		}
 	}
 
@@ -261,6 +280,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 			Address[] addressArray = Address.parseAddresses(addresses);
 			if (addressArray.length > 0) {
 				this.addresses = addressArray;
+				if (this.publisherConnectionFactory != null) {
+					this.publisherConnectionFactory.setAddresses(addresses);
+				}
 				return;
 			}
 		}
@@ -288,21 +310,34 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	public void setConnectionListeners(List<? extends ConnectionListener> listeners) {
 		this.connectionListener.setDelegates(listeners);
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setConnectionListeners(listeners);
+		}
 	}
 
 	@Override
 	public void addConnectionListener(ConnectionListener listener) {
 		this.connectionListener.addDelegate(listener);
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.addConnectionListener(listener);
+		}
 	}
 
 	@Override
 	public boolean removeConnectionListener(ConnectionListener listener) {
-		return this.connectionListener.removeDelegate(listener);
+		boolean result = this.connectionListener.removeDelegate(listener);
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.removeConnectionListener(listener); // NOSONAR
+		}
+		return result;
 	}
 
 	@Override
 	public void clearConnectionListeners() {
 		this.connectionListener.clearDelegates();
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.clearConnectionListeners();
+		}
 	}
 
 	public void setChannelListeners(List<? extends ChannelListener> listeners) {
@@ -316,10 +351,16 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	 */
 	public void setRecoveryListener(RecoveryListener recoveryListener) {
 		this.recoveryListener = recoveryListener;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setRecoveryListener(recoveryListener);
+		}
 	}
 
 	public void addChannelListener(ChannelListener listener) {
 		this.channelListener.addDelegate(listener);
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.addChannelListener(listener);
+		}
 	}
 
 	/**
@@ -340,6 +381,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 		else {
 			this.executorService = ((ThreadPoolTaskExecutor) executor).getThreadPoolExecutor();
 		}
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setExecutor(executor);
+		}
 	}
 
 	protected ExecutorService getExecutorService() {
@@ -353,6 +397,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	 */
 	public void setCloseTimeout(int closeTimeout) {
 		this.closeTimeout = closeTimeout;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setCloseTimeout(closeTimeout);
+		}
 	}
 
 	public int getCloseTimeout() {
@@ -367,11 +414,22 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	 */
 	public void setConnectionNameStrategy(ConnectionNameStrategy connectionNameStrategy) {
 		this.connectionNameStrategy = connectionNameStrategy;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setConnectionNameStrategy(
+					cf -> connectionNameStrategy + PUBLISHER_SUFFIX);
+		}
 	}
 
 	@Override
 	public void setBeanName(String name) {
 		this.beanName = name;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setBeanName(name + PUBLISHER_SUFFIX);
+		}
+	}
+
+	public boolean hasPublisherConnectionFactory() {
+		return this.publisherConnectionFactory != null;
 	}
 
 	protected final Connection createBareConnection() {
@@ -430,6 +488,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	@Override
 	public void destroy() {
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.destroy();
+		}
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -672,13 +672,6 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		return null;
 	}
 
-	@Override
-	public final Connection createPublisherConnection() throws AmqpException {
-		return this.publisherConnectionFactory != null
-				? this.publisherConnectionFactory.createConnection()
-				: createConnection();
-	}
-
 	/*
 	 * Iterate over the idle connections looking for an open one. If there are no idle,
 	 * return null, if there are no open idle, return the first closed idle so it can

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -842,7 +842,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	/**
 	 * Return the cache properties from the underlying publisher sub-factory.
 	 * @return the properties.
-	 * @since 1.7.6
+	 * @since 2.0.2
 	 */
 	@ManagedAttribute
 	public Properties getPublisherConnectionFactoryCacheProperties() {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -137,6 +137,8 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	private final AtomicInteger connectionHighWaterMark = new AtomicInteger();
 
+	private final CachingConnectionFactory publisherConnectionFactory;
+
 	private volatile long channelCheckoutTimeout = 0;
 
 	private volatile CacheMode cacheMode = CacheMode.CHANNEL;
@@ -175,28 +177,11 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	}
 
 	/**
-	 * Create a new CachingConnectionFactory given a host name
-	 * and port.
+	 * Create a new CachingConnectionFactory given a host name.
 	 * @param hostname the host name to connect to
-	 * @param port the port number
 	 */
-	public CachingConnectionFactory(String hostname, int port) {
-		super(newRabbitConnectionFactory());
-		if (!StringUtils.hasText(hostname)) {
-			hostname = getDefaultHostName();
-		}
-		setHost(hostname);
-		setPort(port);
-	}
-
-	/**
-	 * Create a new CachingConnectionFactory given a {@link URI}.
-	 * @param uri the amqp uri configuring the connection
-	 * @since 1.5
-	 */
-	public CachingConnectionFactory(URI uri) {
-		super(newRabbitConnectionFactory());
-		setUri(uri);
+	public CachingConnectionFactory(String hostname) {
+		this(hostname, com.rabbitmq.client.ConnectionFactory.DEFAULT_AMQP_PORT);
 	}
 
 	/**
@@ -209,11 +194,32 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	}
 
 	/**
-	 * Create a new CachingConnectionFactory given a host name.
+	 * Create a new CachingConnectionFactory given a host name
+	 * and port.
 	 * @param hostname the host name to connect to
+	 * @param port the port number
 	 */
-	public CachingConnectionFactory(String hostname) {
-		this(hostname, com.rabbitmq.client.ConnectionFactory.DEFAULT_AMQP_PORT);
+	public CachingConnectionFactory(String hostname, int port) {
+		super(newRabbitConnectionFactory());
+		if (!StringUtils.hasText(hostname)) {
+			hostname = getDefaultHostName();
+		}
+		setHost(hostname);
+		setPort(port);
+		this.publisherConnectionFactory = new CachingConnectionFactory(getRabbitConnectionFactory(), true);
+		setPublisherConnectionFactory(this.publisherConnectionFactory);
+	}
+
+	/**
+	 * Create a new CachingConnectionFactory given a {@link URI}.
+	 * @param uri the amqp uri configuring the connection
+	 * @since 1.5
+	 */
+	public CachingConnectionFactory(URI uri) {
+		super(newRabbitConnectionFactory());
+		setUri(uri);
+		this.publisherConnectionFactory = new CachingConnectionFactory(getRabbitConnectionFactory(), true);
+		setPublisherConnectionFactory(this.publisherConnectionFactory);
 	}
 
 	/**
@@ -221,12 +227,30 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	 * @param rabbitConnectionFactory the target ConnectionFactory
 	 */
 	public CachingConnectionFactory(com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory) {
+		this(rabbitConnectionFactory, false);
+	}
+
+	/**
+	 * Create a new CachingConnectionFactory for the given target ConnectionFactory.
+	 * @param rabbitConnectionFactory the target ConnectionFactory
+	 * @param isPublisherFactory true if this is the publisher sub-factory.
+	 */
+	private CachingConnectionFactory(com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory,
+			boolean isPublisherFactory) {
 		super(rabbitConnectionFactory);
-		if (rabbitConnectionFactory.isAutomaticRecoveryEnabled()) {
-			logger.warn("***\nAutomatic Recovery is Enabled in the provided connection factory;\n"
+		if (!isPublisherFactory) {
+			if (rabbitConnectionFactory.isAutomaticRecoveryEnabled()) {
+				logger.warn("***\nAutomatic Recovery is Enabled in the provided connection factory;\n"
 					+ "while Spring AMQP is compatible with this feature, it\n"
 					+ "prefers to use its own recovery mechanisms; when this option is true, you may receive\n"
 					+ "'AutoRecoverConnectionNotCurrentlyOpenException's until the connection is recovered.");
+			}
+			this.publisherConnectionFactory = new CachingConnectionFactory(getRabbitConnectionFactory(),
+					true);
+			setPublisherConnectionFactory(this.publisherConnectionFactory);
+		}
+		else {
+			this.publisherConnectionFactory = null;
 		}
 	}
 
@@ -246,6 +270,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	public void setChannelCacheSize(int sessionCacheSize) {
 		Assert.isTrue(sessionCacheSize >= 1, "Channel cache size must be 1 or higher");
 		this.channelCacheSize = sessionCacheSize;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setChannelCacheSize(sessionCacheSize);
+		}
 	}
 
 	public int getChannelCacheSize() {
@@ -260,6 +287,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		Assert.isTrue(!this.initialized, "'cacheMode' cannot be changed after initialization.");
 		Assert.notNull(cacheMode, "'cacheMode' must not be null.");
 		this.cacheMode = cacheMode;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setCacheMode(cacheMode);
+		}
 	}
 
 	public int getConnectionCacheSize() {
@@ -269,6 +299,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	public void setConnectionCacheSize(int connectionCacheSize) {
 		Assert.isTrue(connectionCacheSize >= 1, "Connection cache size must be 1 or higher.");
 		this.connectionCacheSize = connectionCacheSize;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setConnectionCacheSize(connectionCacheSize);
+		}
 	}
 
 	/**
@@ -282,6 +315,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	public void setConnectionLimit(int connectionLimit) {
 		Assert.isTrue(connectionLimit >= 1, "Connection limit must be 1 or higher.");
 		this.connectionLimit = connectionLimit;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setConnectionLimit(connectionLimit);
+		}
 	}
 
 	@Override
@@ -296,10 +332,16 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	public void setPublisherReturns(boolean publisherReturns) {
 		this.publisherReturns = publisherReturns;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setPublisherReturns(publisherReturns);
+		}
 	}
 
 	public void setPublisherConfirms(boolean publisherConfirms) {
 		this.publisherConfirms = publisherConfirms;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setPublisherConfirms(publisherConfirms);
+		}
 	}
 
 	/**
@@ -316,6 +358,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	 */
 	public void setChannelCheckoutTimeout(long channelCheckoutTimeout) {
 		this.channelCheckoutTimeout = channelCheckoutTimeout;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setChannelCheckoutTimeout(channelCheckoutTimeout);
+		}
 	}
 
 	/**
@@ -329,6 +374,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	public void setCloseExceptionLogger(ConditionalExceptionLogger closeExceptionLogger) {
 		Assert.notNull(closeExceptionLogger, "'closeExceptionLogger' cannot be null");
 		this.closeExceptionLogger = closeExceptionLogger;
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setCloseExceptionLogger(closeExceptionLogger);
+		}
 	}
 
 	@Override
@@ -339,6 +387,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 					"When the cache mode is 'CHANNEL', the connection cache size cannot be configured.");
 		}
 		initCacheWaterMarks();
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.afterPropertiesSet();
+		}
 	}
 
 	private void initCacheWaterMarks() {
@@ -350,7 +401,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	@Override
 	public void setConnectionListeners(List<? extends ConnectionListener> listeners) {
-		super.setConnectionListeners(listeners);
+		super.setConnectionListeners(listeners); // handles publishing sub-factory
 		// If the connection is already alive we assume that the new listeners want to be notified
 		if (this.connection.target != null) {
 			this.getConnectionListener().onCreate(this.connection);
@@ -359,7 +410,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	@Override
 	public void addConnectionListener(ConnectionListener listener) {
-		super.addConnectionListener(listener);
+		super.addConnectionListener(listener); // handles publishing sub-factory
 		// If the connection is already alive we assume that the new listener wants to be notified
 		if (this.connection.target != null) {
 			listener.onCreate(this.connection);
@@ -621,6 +672,13 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		return null;
 	}
 
+	@Override
+	public final Connection createPublisherConnection() throws AmqpException {
+		return this.publisherConnectionFactory != null
+				? this.publisherConnectionFactory.createConnection()
+				: createConnection();
+	}
+
 	/*
 	 * Iterate over the idle connections looking for an open one. If there are no idle,
 	 * return null, if there are no open idle, return the first closed idle so it can
@@ -676,6 +734,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	 */
 	@Override
 	public final void destroy() {
+		super.destroy();
 		resetConnection();
 		if (getContextStopped()) {
 			this.stopped = true;
@@ -701,6 +760,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 				count.set(0);
 			}
 			this.connectionHighWaterMark.set(0);
+		}
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.resetConnection();
 		}
 	}
 
@@ -782,6 +844,19 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			}
 		}
 		return props;
+	}
+
+	/**
+	 * Return the cache properties from the underlying publisher sub-factory.
+	 * @return the properties.
+	 * @since 1.7.6
+	 */
+	@ManagedAttribute
+	public Properties getPublisherConnectionFactoryCacheProperties() {
+		if (this.publisherConnectionFactory != null) {
+			return this.publisherConnectionFactory.getCacheProperties();
+		}
+		return new Properties();
 	}
 
 	private void putConnectionName(Properties props, ConnectionProxy connection, String keySuffix) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactory.java
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.connection;
 
 import org.springframework.amqp.AmqpException;
+import org.springframework.lang.Nullable;
 
 /**
  * An interface based ConnectionFactory for creating {@link com.rabbitmq.client.Connection Connections}.
@@ -47,13 +48,12 @@ public interface ConnectionFactory {
 	void clearConnectionListeners();
 
 	/**
-	 * Return a separate connection for publishers (if implemented).
-	 * @return the connection.
-	 * @throws AmqpException an exception.
+	 * Return a separate connection factory for publishers (if implemented).
+	 * @return the publisher connection factory, or null.
 	 * @since 2.0.2
 	 */
-	default Connection createPublisherConnection() throws AmqpException {
-		return createConnection();
+	default @Nullable ConnectionFactory getPublisherConnectionFactory() {
+		return null;
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,5 +45,15 @@ public interface ConnectionFactory {
 	boolean removeConnectionListener(ConnectionListener listener);
 
 	void clearConnectionListeners();
+
+	/**
+	 * Return a separate connection for publishers (if implemented).
+	 * @return the connection.
+	 * @throws AmqpException an exception.
+	 * @since 2.0.2
+	 */
+	default Connection createPublisherConnection() throws AmqpException {
+		return createConnection();
+	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -215,7 +215,7 @@ public final class ConnectionFactoryUtils {
 	 * @param connectionFactory the connection factory.
 	 * @param publisherConnectionIfPossible true to use the publisher factory, if present.
 	 * @return the connection.
-	 * @since 1.7.6
+	 * @since 2.0.2
 	 */
 	public static Connection createConnection(final ConnectionFactory connectionFactory,
 			final boolean publisherConnectionIfPossible) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -103,8 +103,8 @@ public final class ConnectionFactoryUtils {
 
 			@Override
 			public Connection createConnection() throws IOException {
-				return publisherConnectionIfPossible ? connectionFactory.createPublisherConnection()
-						: connectionFactory.createConnection();
+				return ConnectionFactoryUtils.createConnection(connectionFactory,
+						publisherConnectionIfPossible);
 			}
 
 			@Override
@@ -208,6 +208,24 @@ public final class ConnectionFactoryUtils {
 		if (resourceHolder != null) {
 			resourceHolder.addDeliveryTag(channel, tag);
 		}
+	}
+
+	/**
+	 * Create a connection with this connection factory and/or its publisher factory.
+	 * @param connectionFactory the connection factory.
+	 * @param publisherConnectionIfPossible true to use the publisher factory, if present.
+	 * @return the connection.
+	 * @since 1.7.6
+	 */
+	public static Connection createConnection(final ConnectionFactory connectionFactory,
+			final boolean publisherConnectionIfPossible) {
+		if (publisherConnectionIfPossible) {
+			ConnectionFactory publisherFactory = connectionFactory.getPublisherConnectionFactory();
+			if (publisherFactory != null) {
+				return publisherFactory.createConnection();
+			}
+		}
+		return connectionFactory.createConnection();
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -72,6 +72,22 @@ public final class ConnectionFactoryUtils {
 	 */
 	public static RabbitResourceHolder getTransactionalResourceHolder(final ConnectionFactory connectionFactory,
 			final boolean synchedLocalTransactionAllowed) {
+		return getTransactionalResourceHolder(connectionFactory, synchedLocalTransactionAllowed, false);
+	}
+
+	/**
+	 * Obtain a RabbitMQ Channel that is synchronized with the current transaction, if any.
+	 * @param connectionFactory the ConnectionFactory to obtain a Channel for
+	 * @param synchedLocalTransactionAllowed whether to allow for a local RabbitMQ transaction that is synchronized with
+	 * a Spring-managed transaction (where the main transaction might be a JDBC-based one for a specific DataSource, for
+	 * example), with the RabbitMQ transaction committing right after the main transaction. If not allowed, the given
+	 * ConnectionFactory needs to handle transaction enlistment underneath the covers.
+	 * @param publisherConnectionIfPossible obtain a connection from a separate publisher connection
+	 * if possible.
+	 * @return the transactional Channel, or <code>null</code> if none found
+	 */
+	public static RabbitResourceHolder getTransactionalResourceHolder(final ConnectionFactory connectionFactory,
+			final boolean synchedLocalTransactionAllowed, final boolean publisherConnectionIfPossible) {
 
 		return doGetTransactionalResourceHolder(connectionFactory, new ResourceFactory() {
 
@@ -87,7 +103,8 @@ public final class ConnectionFactoryUtils {
 
 			@Override
 			public Connection createConnection() throws IOException {
-				return connectionFactory.createConnection();
+				return publisherConnectionIfPossible ? connectionFactory.createPublisherConnection()
+						: connectionFactory.createConnection();
 			}
 
 			@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
@@ -43,21 +43,6 @@ public interface RabbitOperations extends AmqpTemplate {
 	<T> T execute(ChannelCallback<T> action) throws AmqpException;
 
 	/**
-	 * Execute the callback with a channel and reliably close the channel afterwards.
-	 * @param action the call back.
-	 * @param publisherConnectionIfPossible true to use a separate publisher connection if possible.
-	 * @param <T> the return type.
-	 * @return the result from the
-	 * {@link ChannelCallback#doInRabbit(com.rabbitmq.client.Channel)}.
-	 * @throws AmqpException if one occurs.
-	 * @since 2.0.2
-	 */
-	default <T> T execute(ChannelCallback<T> action, boolean publisherConnectionIfPossible)
-			throws AmqpException {
-		return execute(action);
-	}
-
-	/**
 	 * Invoke the callback and run all operations on the template argument in a dedicated
 	 * thread-bound channel and reliably close the channel afterwards.
 	 * @param action the call back.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
@@ -43,20 +43,6 @@ public interface RabbitOperations extends AmqpTemplate {
 	<T> T execute(ChannelCallback<T> action) throws AmqpException;
 
 	/**
-	 * Execute the callback with a channel and reliably close the channel afterwards.
-	 * @param action the call back.
-	 * @param publisherConnectionIfPossible true to use a separate publisher connection if possible.
-	 * @param <T> the return type.
-	 * @return the result from the
-	 * {@link ChannelCallback#doInRabbit(com.rabbitmq.client.Channel)}.
-	 * @throws AmqpException if one occurs.
-	 * @since 2.0.2
-	 */
-	default <T> T execute(ChannelCallback<T> action, boolean publisherConnectionIfPossible) throws AmqpException {
-		return execute(action);
-	}
-
-	/**
 	 * Invoke the callback and run all operations on the template argument in a dedicated
 	 * thread-bound channel and reliably close the channel afterwards.
 	 * @param action the call back.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
@@ -43,6 +43,20 @@ public interface RabbitOperations extends AmqpTemplate {
 	<T> T execute(ChannelCallback<T> action) throws AmqpException;
 
 	/**
+	 * Execute the callback with a channel and reliably close the channel afterwards.
+	 * @param action the call back.
+	 * @param publisherConnectionIfPossible true to use a separate publisher connection if possible.
+	 * @param <T> the return type.
+	 * @return the result from the
+	 * {@link ChannelCallback#doInRabbit(com.rabbitmq.client.Channel)}.
+	 * @throws AmqpException if one occurs.
+	 * @since 2.0.2
+	 */
+	default <T> T execute(ChannelCallback<T> action, boolean publisherConnectionIfPossible) throws AmqpException {
+		return execute(action);
+	}
+
+	/**
 	 * Invoke the callback and run all operations on the template argument in a dedicated
 	 * thread-bound channel and reliably close the channel afterwards.
 	 * @param action the call back.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitOperations.java
@@ -43,6 +43,21 @@ public interface RabbitOperations extends AmqpTemplate {
 	<T> T execute(ChannelCallback<T> action) throws AmqpException;
 
 	/**
+	 * Execute the callback with a channel and reliably close the channel afterwards.
+	 * @param action the call back.
+	 * @param publisherConnectionIfPossible true to use a separate publisher connection if possible.
+	 * @param <T> the return type.
+	 * @return the result from the
+	 * {@link ChannelCallback#doInRabbit(com.rabbitmq.client.Channel)}.
+	 * @throws AmqpException if one occurs.
+	 * @since 2.0.2
+	 */
+	default <T> T execute(ChannelCallback<T> action, boolean publisherConnectionIfPossible)
+			throws AmqpException {
+		return execute(action);
+	}
+
+	/**
 	 * Invoke the callback and run all operations on the template argument in a dedicated
 	 * thread-bound channel and reliably close the channel afterwards.
 	 * @param action the call back.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -828,7 +828,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 				doExecute(channel -> {
 					channel.queueDeclarePassive(Address.AMQ_RABBITMQ_REPLY_TO);
 					return null;
-				}, true);
+				}, this.usePublisherConnection);
 				return true;
 			}
 			catch (Exception e) {
@@ -1628,7 +1628,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			CorrelationData correlationData) {
 		ConnectionFactory connectionFactory = obtainTargetConnectionFactory(
 				this.sendConnectionFactorySelectorExpression, message);
-		if (connectionFactory.getPublisherConnectionFactory() != null) {
+		if (this.usePublisherConnection && connectionFactory.getPublisherConnectionFactory() != null) {
 			connectionFactory = connectionFactory.getPublisherConnectionFactory();
 		}
 		DirectReplyToMessageListenerContainer container = this.directReplyToContainers.get(connectionFactory);
@@ -1758,6 +1758,11 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	@Override
 	public <T> T execute(ChannelCallback<T> action) {
 		return doExecute(action, false);
+	}
+
+	@Override
+	public <T> T execute(ChannelCallback<T> action, boolean publisherConnectionIfPossible) {
+		return doExecute(action, publisherConnectionIfPossible);
 	}
 
 	private <T> T doExecute(ChannelCallback<T> action, boolean publisherConnectionIfPossible) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1808,12 +1808,8 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 				}
 			}
 			else {
-				if (publisherConnectionIfPossible) {
-					connection = connectionFactory.createPublisherConnection(); // NOSONAR - RabbitUtils
-				}
-				else {
-					connection = connectionFactory.createConnection(); // NOSONAR - RabbitUtils
-				}
+				connection = ConnectionFactoryUtils.createConnection(connectionFactory,
+						publisherConnectionIfPossible); // NOSONAR - RabbitUtils closes
 				if (connection == null) {
 					throw new IllegalStateException("Connection factory returned a null connection");
 				}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -130,6 +130,43 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
+	public void testPublisherConnection() throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
+		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
+		Channel mockChannel = mock(Channel.class);
+
+		when(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).thenReturn(mockConnection);
+		when(mockConnection.createChannel()).thenReturn(mockChannel);
+		when(mockChannel.isOpen()).thenReturn(true);
+		when(mockConnection.isOpen()).thenReturn(true);
+
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ccf.setExecutor(mock(ExecutorService.class));
+		Connection con = ccf.createPublisherConnection();
+
+		Channel channel = con.createChannel(false);
+		channel.close(); // should be ignored, and placed into channel cache.
+		con.close(); // should be ignored
+
+		Connection con2 = ccf.createPublisherConnection();
+		/*
+		 * will retrieve same channel object that was just put into channel cache
+		 */
+		Channel channel2 = con2.createChannel(false);
+		channel2.close(); // should be ignored
+		con2.close(); // should be ignored
+
+		assertSame(con, con2);
+		assertSame(channel, channel2);
+		verify(mockConnection, never()).close();
+		verify(mockChannel, never()).close();
+
+		assertNull(TestUtils.getPropertyValue(ccf, "connection.target"));
+		assertNotNull(TestUtils.getPropertyValue(ccf, "publisherConnectionFactory.connection.target"));
+		assertSame(con, TestUtils.getPropertyValue(ccf, "publisherConnectionFactory.connection"));
+	}
+
+	@Test
 	public void testWithConnectionFactoryCacheSize() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -142,13 +142,13 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
 		ccf.setExecutor(mock(ExecutorService.class));
-		Connection con = ccf.createPublisherConnection();
+		Connection con = ccf.getPublisherConnectionFactory().createConnection();
 
 		Channel channel = con.createChannel(false);
 		channel.close(); // should be ignored, and placed into channel cache.
 		con.close(); // should be ignored
 
-		Connection con2 = ccf.createPublisherConnection();
+		Connection con2 = ccf.getPublisherConnectionFactory().createConnection();
 		/*
 		 * will retrieve same channel object that was just put into channel cache
 		 */

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateDirectReplyToContainerIntegrationPubCFTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateDirectReplyToContainerIntegrationPubCFTests.java
@@ -20,7 +20,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 
 /**
  * @author Gary Russell
- * @since 1.7.6
+ * @since 2.0.2
  *
  */
 public class RabbitTemplateDirectReplyToContainerIntegrationPubCFTests

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateDirectReplyToContainerIntegrationPubCFTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateDirectReplyToContainerIntegrationPubCFTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.core;
+
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+
+/**
+ * @author Gary Russell
+ * @since 1.7.6
+ *
+ */
+public class RabbitTemplateDirectReplyToContainerIntegrationPubCFTests
+		extends RabbitTemplateDirectReplyToContainerIntegrationTests {
+
+	@Override
+	protected RabbitTemplate createSendAndReceiveRabbitTemplate(ConnectionFactory connectionFactory) {
+		RabbitTemplate srTemplate = super.createSendAndReceiveRabbitTemplate(connectionFactory);
+		srTemplate.setUsePublisherConnection(true);
+		return srTemplate;
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationPubCFTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationPubCFTests.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 
 /**
  * @author Gary Russell
- * @since 1.7.6
+ * @since 2.0.2
  *
  */
 public class RabbitTemplateIntegrationPubCFTests extends RabbitTemplateIntegrationTests {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationPubCFTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationPubCFTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.core;
+
+import org.junit.Before;
+
+/**
+ * @author Gary Russell
+ * @since 1.7.6
+ *
+ */
+public class RabbitTemplateIntegrationPubCFTests extends RabbitTemplateIntegrationTests {
+
+	@Override
+	@Before
+	public void create() {
+		super.create();
+		this.template.setUsePublisherConnection(true);
+		this.routingTemplate.setUsePublisherConnection(true);
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -170,10 +170,10 @@ public class RabbitTemplateIntegrationTests {
 
 	private CachingConnectionFactory connectionFactory;
 
-	private RabbitTemplate template;
+	protected RabbitTemplate template;
 
 	@Autowired
-	private RabbitTemplate routingTemplate;
+	protected RabbitTemplate routingTemplate;
 
 	@Autowired
 	private ConnectionFactory cf1;
@@ -475,6 +475,7 @@ public class RabbitTemplateIntegrationTests {
 
 	@Test
 	public void testSendAndReceiveUndeliverable() throws Exception {
+		this.connectionFactory.setBeanName("testSendAndReceiveUndeliverable");
 		template.setMandatory(true);
 		try {
 			template.convertSendAndReceive(ROUTE + "xxxxxxxx", "undeliverable");

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1028,6 +1028,14 @@ Examples:
 
 The first example is a literal expression; the second obtains the `username` property from a connection factory bean in the application context.
 
+[[separate-connection]]
+===== Using a Separate Connection
+
+Starting with _version 2.0.2_, set the `usePublisherConnection` property to `true` to use a different connection to that used by listener containers, when possible.
+This is to avoid consumers being blocked when a producer is blocked for any reason.
+The `CachingConnectionFactory` now maintains a second internal connection factory for this purpose.
+If the rabbit template is running in a transaction started by the listener container, the container's channel is used, regardless of this setting.
+
 [[sending-messages]]
 ==== Sending messages
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -3,6 +3,12 @@
 
 ==== Changes in 2.0 Since 1.7
 
+===== CachingConnectionFactory
+
+Starting with _version 2.0.2_, the `RabbitTemplate` can be configured to use a different connection to that used by listener containers.
+This is to avoid deadlocked consumers when producers are blocked for any reason.
+See <<separate-connection>> for more information.
+
 ===== AMQP Client library
 
 Spring AMQP now uses the new 5.0.x version of the `amqp-client` library provided by the RabbitMQ team.


### PR DESCRIPTION
#JIRA: https://jira.spring.io/browse/AMQP-788

To avoid deadlocks, it is best to use a different connection for producers and
consumers (unless the producer is partiticipating in a consumer transaction).

- Add a delegate `publisherConnectionFactory` to the `CachingConnecetionFactory`.
- Use the same underlying `com.rabbitmq.client.ConnectionFactory` in each.
- Propagate all properties to the delegate.
 - Except, enhance the connection name and bean name with `.publisher`.
- Add a boolean `usePublisherConnection` to the `RabbitTemplate`.
 - If true, use `createPublisherConnection()` when appropriate.

TODO: Docs (after review)