### PR TITLE
Improve Test Run Times

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,6 +127,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 			}
 			throw new RuntimeException("bar");
 		});
+		container.setReceiveTimeout(50);
 		container.start();
 		Log logger = spy(TestUtils.getPropertyValue(container, "logger", Log.class));
 		doReturn(true).when(logger).isWarnEnabled();
@@ -217,6 +218,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		admin.declareBinding(BindingBuilder.bind(dlq).to(dle).with(testQueueName));
 
 		container.setQueueNames(testQueueName);
+		container.setReceiveTimeout(50);
 		container.afterPropertiesSet();
 		container.start();
 
@@ -297,6 +299,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		container.setTxSize(messageCount);
 		container.setQueueNames(queue.getName());
 		container.setErrorHandler(errorHandler);
+		container.setReceiveTimeout(50);
 		container.afterPropertiesSet();
 		container.start();
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerLifecycleIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerLifecycleIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -239,6 +239,7 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 		}
 		container.setQueueNames(queue.getName());
 		container.setShutdownTimeout(30000);
+		container.setReceiveTimeout(50);
 		container.afterPropertiesSet();
 		container.start();
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerRetryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerRetryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,6 +230,7 @@ public class MessageListenerContainerRetryIntegrationTests {
 		container.setAdviceChain(new Advice[] { createRetryInterceptor(latch, stateful) });
 
 		container.setQueueNames(queue.getName());
+		container.setReceiveTimeout(50);
 		container.afterPropertiesSet();
 		container.start();
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryCachingConnectionIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerRecoveryCachingConnectionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -467,6 +467,7 @@ public class MessageListenerRecoveryCachingConnectionIntegrationTests {
 		container.setAcknowledgeMode(acknowledgeMode);
 		container.setRecoveryInterval(100);
 		container.setFailedDeclarationRetryInterval(100);
+		container.setReceiveTimeout(50);
 		container.afterPropertiesSet();
 		return container;
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,7 +170,6 @@ public class SimpleMessageListenerContainerIntegrationTests {
 	@After
 	public void clear() throws Exception {
 		// Wait for broker communication to finish before trying to stop container
-		Thread.sleep(300L);
 		logger.debug("Shutting down at end of test");
 		if (container != null) {
 			container.shutdown();
@@ -255,11 +254,7 @@ public class SimpleMessageListenerContainerIntegrationTests {
 			assertTrue("Timed out waiting for message", waited);
 		}
 		finally {
-			// Wait for broker communication to finish before trying to stop
-			// container
-			Thread.sleep(300L);
 			container.shutdown();
-			Thread.sleep(300L);
 		}
 		if (acknowledgeMode.isTransactionAllowed()) {
 			assertNotNull(template.receiveAndConvert(queue.getName()));
@@ -297,6 +292,7 @@ public class SimpleMessageListenerContainerIntegrationTests {
 		container.setChannelTransacted(transactional);
 		container.setAcknowledgeMode(acknowledgeMode);
 		container.setBeanName("integrationTestContainer");
+		container.setReceiveTimeout(50);
 		// requires RabbitMQ 3.2.x
 //		container.setConsumerArguments(Collections. <String, Object> singletonMap("x-priority", Integer.valueOf(10)));
 		if (externalTransaction) {

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
@@ -32,7 +32,7 @@
 		</rabbit:bindings>
 	</rabbit:direct-exchange>
 
-	<rabbit:listener-container auto-startup="false">
+	<rabbit:listener-container auto-startup="false" receive-timeout="50">
 		<rabbit:listener id="container2" ref="foo" queues="otherAnon" admin="containerAdmin" />
 	</rabbit:listener-container>
 
@@ -42,11 +42,11 @@
 		</rabbit:queue-arguments>
 	</rabbit:queue>
 
-	<rabbit:listener-container concurrency="2">
+	<rabbit:listener-container concurrency="2"  receive-timeout="50">
 		<rabbit:listener id="container3" ref="foo" queues="xExpires" admin="containerAdmin" />
 	</rabbit:listener-container>
 
-	<rabbit:listener-container auto-declare="false">
+	<rabbit:listener-container auto-declare="false"  receive-timeout="50">
 		<rabbit:listener id="container4" ref="foo" queues="anon2" admin="containerAdmin" />
 	</rabbit:listener-container>
 


### PR DESCRIPTION
- Reduce container `receiveTimeout` so containers stop faster
- Remove unnecessary `Thread.sleep()`s

Reduced runtime from 5'26'' to 3'11'' on my machine.