### PR TITLE
AMQP-796: Fix Admin Transaction

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,6 +155,18 @@ public final class ConnectionFactoryUtils {
 			channel = ConsumerChannelRegistry.getConsumerChannel(connectionFactory);
 			if (channel == null && connection == null) {
 				connection = resourceFactory.createConnection();
+				if (resourceHolder == null) {
+					/*
+					 * While creating a connection, a connection listener might have created a
+					 * transactional channel and bound it to the transaction.
+					 */
+					resourceHolder = (RabbitResourceHolder) TransactionSynchronizationManager
+							.getResource(connectionFactory);
+					if (resourceHolder != null) {
+						channel = resourceHolder.getChannel();
+						resourceHolderToUse = resourceHolder;
+					}
+				}
 				resourceHolderToUse.addConnection(connection);
 			}
 			if (channel == null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -475,6 +475,10 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 			}
 		}
 
+		if (exchanges.size() == 0 && queues.size() == 0 && bindings.size() == 0) {
+			this.logger.debug("Nothing to declare");
+			return;
+		}
 		this.rabbitTemplate.execute(channel -> {
 			declareExchanges(channel, exchanges.toArray(new Exchange[exchanges.size()]));
 			declareQueues(channel, queues.toArray(new Queue[queues.size()]));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-796

If an admin uses a transactional `RabbitTemplate` it will start a transaction.
If the connection was opened due to a `RabbitTemplate` operation it should participate
in the same transaction.
Previously, the template used a second channel and treated it as a local transaction.

Also fix the `RabbitAdmin` so it does no work if there is nothing to declare.

__cherry-pick to 1.7.x__