### PR TITLE
AMQP-800: LocalizedQueueConnectionFactory Fix

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactory.java
@@ -366,9 +366,6 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 				((DisposableBean) connectionFactory).destroy();
 			}
 		}
-		if (this.defaultConnectionFactory instanceof DisposableBean) {
-			((DisposableBean) this.defaultConnectionFactory).destroy();
-		}
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-800

The `LocalizedQueueConnectionFactory` incorrectly destroyed the injected default
connection factory. It should only destroy factories that it creates.

**cherry-pick to 1.7.x**