### PR TITLE
Upgrade to Gradle 4.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,6 @@ subprojects { subproject ->
 			// restrict memory usage, so tests don't fail with exit code 137 on travis
 			maxHeapSize = '256m'
 		}
-		useJUnitPlatform()
 	}
 
 	task testAll(type: Test, dependsOn: check)
@@ -184,10 +183,6 @@ subprojects { subproject ->
 		}
 	}
 
-	testAll {
-		useJUnitPlatform()
-	}
-
 	tasks.withType(Test).all {
 		// suppress all console output during testing unless running `gradle -i`
 		logging.captureStandardOutput(LogLevel.INFO)
@@ -196,6 +191,7 @@ subprojects { subproject ->
 		if (name ==~ /(springIo.*)|(testAll)/) {
 			systemProperty 'RUN_LONG_INTEGRATION_TESTS', 'true'
 		}
+		useJUnitPlatform()
 	}
 
 	task sourcesJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -89,9 +89,9 @@ subprojects { subproject ->
 		hamcrestVersion = '1.3'
 		jackson2Version = '2.9.1'
 		junit4Version = '4.12'
-		junitJupiterVersion = '5.0.2'
-		junitPlatformVersion = '1.0.2'
-		junitVintageVersion = '4.12.2'
+		junitJupiterVersion = '5.1.0'
+		junitPlatformVersion = '1.1.0'
+		junitVintageVersion = '5.1.0'
 		log4jVersion = '2.8.2'
 		logbackVersion = '1.2.3'
 		mockitoVersion = '2.11.0'
@@ -128,12 +128,12 @@ subprojects { subproject ->
 		testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 		testRuntime "org.apache.logging.log4j:log4j-jcl:$log4jVersion"
 
-		testCompile "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
-		testRuntime "org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}"
-		testRuntime "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
+		testCompile "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+		testRuntime "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
+		testRuntime "org.junit.platform:junit-platform-launcher:$junitPlatformVersion"
 
 		// To support JUnit 4 tests
-		testRuntime "org.junit.vintage:junit-vintage-engine:${junitVintageVersion}"
+		testRuntime "org.junit.vintage:junit-vintage-engine:$junitVintageVersion"
 
 		// To avoid compiler warnings about @API annotations in JUnit code
 		testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
@@ -173,6 +173,7 @@ subprojects { subproject ->
 			// restrict memory usage, so tests don't fail with exit code 137 on travis
 			maxHeapSize = '256m'
 		}
+		useJUnitPlatform()
 	}
 
 	task testAll(type: Test, dependsOn: check)
@@ -181,6 +182,10 @@ subprojects { subproject ->
 		if (graph.hasTask(testAll)) {
 			test.enabled = false
 		}
+	}
+
+	testAll {
+		useJUnitPlatform()
 	}
 
 	tasks.withType(Test).all {
@@ -286,7 +291,7 @@ project('spring-rabbit-junit') {
 			exclude group: 'org.springframework', module: 'spring-web'
 		}
 		compile "org.springframework:spring-web:$springVersion"
-		compile ("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}", optional)
+		compile ("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion", optional)
 		compileOnly 'org.apiguardian:apiguardian-api:1.0.0'
 
 	}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip


### PR DESCRIPTION
- add support for JUnit5 tests
- resume gradle testing of JUnit5 tests - `RabbitTemplateMPPIntegrationTests.java`, `SimpleMessageListenerContainerLongTests.java`