### PR TITLE
AMQP-801-2: Introduce ConsumerDecorator

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -958,6 +958,8 @@ public class BlockingQueueConsumer implements RecoveryListener {
 
 		private final ApplicationEventPublisher applicationEventPublisher;
 
+		private String consumerTag;
+
 		ConsumerDecorator(String queue, Consumer delegate, ApplicationEventPublisher applicationEventPublisher) {
 			this.queue = queue;
 			this.delegate = delegate;
@@ -966,6 +968,7 @@ public class BlockingQueueConsumer implements RecoveryListener {
 
 
 		public void handleConsumeOk(String consumerTag) {
+			this.consumerTag = consumerTag;
 			this.delegate.handleConsumeOk(consumerTag);
 			if (this.applicationEventPublisher != null) {
 				this.applicationEventPublisher.publishEvent(new ConsumeOkEvent(this.delegate, this.queue, consumerTag));
@@ -992,6 +995,13 @@ public class BlockingQueueConsumer implements RecoveryListener {
 
 		public void handleRecoverOk(String consumerTag) {
 			this.delegate.handleRecoverOk(consumerTag);
+		}
+
+		@Override
+		public String toString() {
+			return "ConsumerDecorator{" + "queue='" + this.queue + '\'' +
+					", consumerTag='" + this.consumerTag + '\'' +
+					'}';
 		}
 
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConsumeOkEvent.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConsumeOkEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import org.springframework.amqp.event.AmqpEvent;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.7.5
  *
  */
@@ -34,6 +36,24 @@ public class ConsumeOkEvent extends AmqpEvent {
 		super(source);
 		this.queue = queue;
 		this.consumerTag = consumerTag;
+	}
+
+	/**
+	 * Obtain the queue name a consumer has been subscribed.
+	 * @return the queue name a consumer subscribed.
+	 * @since 1.7.7
+	 */
+	public String getQueue() {
+		return this.queue;
+	}
+
+	/**
+	 * Obtain the consumer tag assigned to the consumer.
+	 * @return the consumer tag for subscription.
+	 * @since 1.7.7
+	 */
+	public String getConsumerTag() {
+		return this.consumerTag;
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConsumeOkEvent.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConsumeOkEvent.java
@@ -19,6 +19,9 @@ package org.springframework.amqp.rabbit.listener;
 import org.springframework.amqp.event.AmqpEvent;
 
 /**
+ * An {@link AmqpEvent} emitted by the listener container
+ * when consumer is subscribed to the queue.
+ *
  * @author Gary Russell
  * @author Artem Bilan
  *
@@ -32,6 +35,13 @@ public class ConsumeOkEvent extends AmqpEvent {
 
 	private final String consumerTag;
 
+	/**
+	 * Instantiate a {@link ConsumeOkEvent} based on the provided
+	 * consumer, queue and consumer tag.
+	 * @param source the consumer subscribed to the queue
+	 * @param queue the queue to consume
+	 * @param consumerTag the tag indicate a consumer subscription
+	 */
 	public ConsumeOkEvent(Object source, String queue, String consumerTag) {
 		super(source);
 		this.queue = queue;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -92,6 +93,7 @@ import com.rabbitmq.client.Channel;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 1.3
  *
  */
@@ -277,7 +279,11 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		assertThat(events.size(), equalTo(8));
 		assertThat(events.get(0), instanceOf(AsyncConsumerStartedEvent.class));
 		assertThat(events.get(1), instanceOf(ConsumeOkEvent.class));
+		ConsumeOkEvent consumeOkEvent = (ConsumeOkEvent) events.get(1);
+		assertThat(consumeOkEvent.getQueue(), isOneOf(this.queue.getName(), this.queue1.getName()));
 		assertThat(events.get(2), instanceOf(ConsumeOkEvent.class));
+		consumeOkEvent = (ConsumeOkEvent) events.get(2);
+		assertThat(consumeOkEvent.getQueue(), isOneOf(this.queue.getName(), this.queue1.getName()));
 		assertSame(events.get(3), eventRef.get());
 		assertThat(events.get(4), instanceOf(AsyncConsumerRestartedEvent.class));
 		assertThat(events.get(5), instanceOf(ConsumeOkEvent.class));


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-801

To properly assign the queue to the `ConsumeOkEvent`, we need perform
such a logic in the `Consumer.handleConsumeOk()`.

* Introduce `BlockingQueueConsumer.ConsumerDecorator` to be created on
each `channel.basicConsume()` for wrapping the target `InternalConsumer`
per queue
* Add getters to the `ConsumeOkEvent` for better interoperability
* Assert assigned queue names for the `ConsumeOkEvent`s in the
`SimpleMessageListenerContainerIntegration2Tests`

**Cherry-pick to 1.7.x**