### PR TITLE
AMQP-807: Use method genericReturnType() for conversion

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 
 package org.springframework.amqp.support.converter;
 
+import java.lang.reflect.Type;
 import java.util.UUID;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
+import org.springframework.lang.Nullable;
 
 /**
  * Convenient base class for {@link MessageConverter} implementations.
@@ -50,10 +52,16 @@ public abstract class AbstractMessageConverter implements MessageConverter {
 	@Override
 	public final Message toMessage(Object object, MessageProperties messageProperties)
 			throws MessageConversionException {
+		return toMessage(object, messageProperties, null);
+	}
+
+	@Override
+	public final Message toMessage(Object object, MessageProperties messageProperties, @Nullable Type genericType)
+			throws MessageConversionException {
 		if (messageProperties == null) {
 			messageProperties = new MessageProperties();
 		}
-		Message message = createMessage(object, messageProperties);
+		Message message = createMessage(object, messageProperties, genericType);
 		messageProperties = message.getMessageProperties();
 		if (this.createMessageIds && messageProperties.getMessageId() == null) {
 			messageProperties.setMessageId(UUID.randomUUID().toString());
@@ -65,11 +73,25 @@ public abstract class AbstractMessageConverter implements MessageConverter {
 	 * Crate a message from the payload object and message properties provided. The message id will be added to the
 	 * properties if necessary later.
 	 *
-	 * @param object the payload
-	 * @param messageProperties the message properties (headers)
-	 * @return a message
+	 * @param object the payload.
+	 * @param messageProperties the message properties (headers).
+	 * @return a message.
 	 */
 	protected abstract Message createMessage(Object object, MessageProperties messageProperties);
+
+	/**
+	 * Crate a message from the payload object and message properties provided. The message id will be added to the
+	 * properties if necessary later.
+	 *
+	 * @param object the payload
+	 * @param messageProperties the message properties (headers)
+	 * @param genericType the type to convert from - used to populate type headers.
+	 * @return a message
+	 * @since 2.1
+	 */
+	protected Message createMessage(Object object, MessageProperties messageProperties, @Nullable Type genericType) {
+		return createMessage(object, messageProperties);
+	}
 
 	@Override
 	public abstract Object fromMessage(Message message) throws MessageConversionException;

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,11 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 				}
 			}
 		}
+	}
+
+	@Override
+	public void addTrustedPackages(String... packages) {
+		setTrustedPackages(packages);
 	}
 
 	@Override

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,15 +35,40 @@ public interface Jackson2JavaTypeMapper extends ClassMapper {
 	/**
 	 * The precedence for type conversion - inferred from the method parameter or message
 	 * headers. Only applies if both exist.
+	 * @since 1.6
 	 */
 	enum TypePrecedence {
 		INFERRED, TYPE_ID
 	}
 
+	/**
+	 * Set the message properties according to the type.
+	 * @param javaType the type.
+	 * @param properties the properties.
+	 */
 	void fromJavaType(JavaType javaType, MessageProperties properties);
 
+	/**
+	 * Determine the type from the message properties.
+	 * @param properties the properties.
+	 * @return the type.
+	 */
 	JavaType toJavaType(MessageProperties properties);
 
+	/**
+	 * Get the type precedence.
+	 * @return the precedence.
+	 * @since 1.6
+	 */
 	TypePrecedence getTypePrecedence();
+
+	/**
+	 * Add trusted packages.
+	 * @param packages the packages.
+	 * @since 2.1
+	 */
+	default void addTrustedPackages(String... packages) {
+		// no op
+	}
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.amqp.support.converter;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -224,6 +225,13 @@ public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter i
 	@Override
 	protected Message createMessage(Object objectToConvert, MessageProperties messageProperties)
 			throws MessageConversionException {
+		return createMessage(objectToConvert, messageProperties, null);
+	}
+
+	@Override
+	protected Message createMessage(Object objectToConvert, MessageProperties messageProperties, Type genericType)
+			throws MessageConversionException {
+
 		byte[] bytes;
 		try {
 			String jsonString = this.jsonObjectMapper
@@ -239,14 +247,12 @@ public class Jackson2JsonMessageConverter extends AbstractJsonMessageConverter i
 		messageProperties.setContentLength(bytes.length);
 
 		if (getClassMapper() == null) {
-			getJavaTypeMapper().fromJavaType(this.jsonObjectMapper.constructType(objectToConvert.getClass()),
-					messageProperties);
-
+			getJavaTypeMapper().fromJavaType(this.jsonObjectMapper.constructType(
+					genericType == null ? objectToConvert.getClass() : genericType), messageProperties);
 		}
 		else {
 			getClassMapper().fromClass(objectToConvert.getClass(),
 					messageProperties);
-
 		}
 
 		return new Message(bytes, messageProperties);

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 
 package org.springframework.amqp.support.converter;
 
+import java.lang.reflect.Type;
+
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
+import org.springframework.lang.Nullable;
 
 /**
  * Message converter interface.
@@ -34,6 +37,22 @@ public interface MessageConverter {
 	 * @throws MessageConversionException in case of conversion failure
 	 */
 	Message toMessage(Object object, MessageProperties messageProperties) throws MessageConversionException;
+
+	/**
+	 * Convert a Java object to a Message.
+	 * The default implementation calls {@link #toMessage(Object, MessageProperties)}.
+	 * @param object the object to convert
+	 * @param messageProperties The message properties.
+	 * @param genericType the type to use to populate type headers.
+	 * @return the Message
+	 * @throws MessageConversionException in case of conversion failure
+	 * @since 2.1
+	 */
+	default Message toMessage(Object object, MessageProperties messageProperties, @Nullable Type genericType)
+			throws MessageConversionException {
+
+			return toMessage(object, messageProperties);
+	}
 
 	/**
 	 * Convert from a Message to a Java object.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
@@ -115,7 +115,7 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 		Assert.state(this.messageHandlerMethodFactory != null,
 				"Could not create message listener - MessageHandlerMethodFactory not set");
 		MessagingMessageListenerAdapter messageListener = createMessageListenerInstance();
-		messageListener.setHandlerMethod(configureListenerAdapter(messageListener));
+		messageListener.setHandlerAdapter(configureListenerAdapter(messageListener));
 		String replyToAddress = getDefaultReplyToAddress();
 		if (replyToAddress != null) {
 			messageListener.setResponseAddress(replyToAddress);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
@@ -122,17 +122,17 @@ public class DelegatingInvocableHandler {
 	 * @throws Exception raised if no suitable argument resolver can be found,
 	 * or the method raised an exception.
 	 */
-	public Object invoke(Message<?> message, Object... providedArgs) throws Exception {
+	public InvocationResult invoke(Message<?> message, Object... providedArgs) throws Exception {
 		Class<? extends Object> payloadClass = message.getPayload().getClass();
 		InvocableHandlerMethod handler = getHandlerForPayload(payloadClass);
 		Object result = handler.invoke(message, providedArgs);
 		if (message.getHeaders().get(AmqpHeaders.REPLY_TO) == null) {
 			Expression replyTo = this.handlerSendTo.get(handler);
 			if (replyTo != null) {
-				result = new AbstractAdaptableMessageListener.ResultHolder(result, replyTo);
+				return new InvocationResult(result, replyTo, handler.getMethod().getGenericReturnType());
 			}
 		}
-		return result;
+		return new InvocationResult(result, null, handler.getMethod().getGenericReturnType());
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/HandlerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/HandlerAdapter.java
@@ -46,9 +46,10 @@ public class HandlerAdapter {
 		this.delegatingHandler = delegatingHandler;
 	}
 
-	public Object invoke(Message<?> message, Object... providedArgs) throws Exception {
+	public InvocationResult invoke(Message<?> message, Object... providedArgs) throws Exception {
 		if (this.invokerHandlerMethod != null) {
-			return this.invokerHandlerMethod.invoke(message, providedArgs);
+			return new InvocationResult(this.invokerHandlerMethod.invoke(message, providedArgs),
+					null, this.invokerHandlerMethod.getMethod().getGenericReturnType());
 		}
 		else if (this.delegatingHandler.hasDefaultHandler()) {
 			// Needed to avoid returning raw Message which matches Object

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/InvocationResult.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/InvocationResult.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import java.lang.reflect.Type;
+
+import org.springframework.expression.Expression;
+
+/**
+ * The result of a listener method invocation.
+ *
+ * @author Gary Russell
+ * @since 2.1
+ */
+public final class InvocationResult {
+
+	private final Object returnValue;
+
+	private final Expression sendTo;
+
+	private final Type returnType;
+
+	public InvocationResult(Object result, Expression sendTo, Type returnType) {
+		this.returnValue = result;
+		this.sendTo = sendTo;
+		this.returnType = returnType;
+	}
+
+	public Object getReturnValue() {
+		return this.returnValue;
+	}
+
+	public Expression getSendTo() {
+		return this.sendTo;
+	}
+
+
+	public Type getReturnType() {
+		return this.returnType;
+	}
+
+	@Override
+	public String toString() {
+		return "InvocationResult [returnValue=" + this.returnValue
+				+ (this.sendTo != null ? ", sendTo=" + this.sendTo : "")
+				+ ", returnType=" + this.returnType + "]";
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
@@ -297,7 +297,7 @@ public class MessageListenerAdapter extends AbstractAdaptableMessageListener {
 		Object[] listenerArguments = buildListenerArguments(convertedMessage);
 		Object result = invokeListenerMethod(methodName, listenerArguments, message);
 		if (result != null) {
-			handleResult(result, message, channel);
+			handleResult(new InvocationResult(result, null, null), message, channel);
 		}
 		else {
 			logger.trace("No result object given - no result to handle");

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public class MessagingMessageListenerAdapterTests {
 
 		Channel session = mock(Channel.class);
 		MessagingMessageListenerAdapter listener = getSimpleInstance("echo", Message.class);
-		org.springframework.amqp.core.Message replyMessage = listener.buildMessage(session, result);
+		org.springframework.amqp.core.Message replyMessage = listener.buildMessage(session, result, null);
 
 		assertNotNull("reply should never be null", replyMessage);
 		assertEquals("Response", new String(replyMessage.getBody()));
@@ -229,7 +229,7 @@ public class MessagingMessageListenerAdapterTests {
 
 	protected MessagingMessageListenerAdapter createInstance(Method m, boolean returnExceptions) {
 		MessagingMessageListenerAdapter adapter = new MessagingMessageListenerAdapter(null, m, returnExceptions, null);
-		adapter.setHandlerMethod(new HandlerAdapter(factory.createInvocableHandlerMethod(sample, m)));
+		adapter.setHandlerAdapter(new HandlerAdapter(factory.createInvocableHandlerMethod(sample, m)));
 		return adapter;
 	}
 
@@ -246,7 +246,7 @@ public class MessagingMessageListenerAdapterTests {
 		methods.add(this.factory.createInvocableHandlerMethod(sample, m1));
 		methods.add(this.factory.createInvocableHandlerMethod(sample, m2));
 		DelegatingInvocableHandler handler = new DelegatingInvocableHandler(methods, this.sample, null, null);
-		adapter.setHandlerMethod(new HandlerAdapter(handler));
+		adapter.setHandlerAdapter(new HandlerAdapter(handler));
 		return adapter;
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-807

When converting `@RabbitListener` results, use the generic return type
of the method, instead of `object.getClass()` to properly convey
type information in message headers.

Otherwise, `List<Foo>` becomes `List<Map>` on the receiving side, since
the list content type is erased.