### PR TITLE
GH-734: Option to suppress declaring Collections

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -19,6 +19,7 @@ package org.springframework.amqp.rabbit.core;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -109,6 +110,8 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
+	private boolean declareCollections = true;
+
 	private volatile DeclarationExceptionEvent lastDeclarationExceptionEvent;
 
 	/**
@@ -152,6 +155,17 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 
 	public void setIgnoreDeclarationExceptions(boolean ignoreDeclarationExceptions) {
 		this.ignoreDeclarationExceptions = ignoreDeclarationExceptions;
+	}
+
+	/**
+	 * Set to false to disable declaring collections of {@link Declarable}.
+	 * Since the admin has to iterate over all Collection beans, this may
+	 * cause undesirable side-effects in some cases. Default true.
+	 * @param declareCollections set to false to prevent declarations of collections.
+	 * @since 1.7.7
+	 */
+	public void setDeclareCollections(boolean declareCollections) {
+		this.declareCollections = declareCollections;
 	}
 
 	/**
@@ -416,6 +430,7 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 	 * Declares all the exchanges, queues and bindings in the enclosing application context, if any. It should be safe
 	 * (but unnecessary) to call this method more than once.
 	 */
+	@Override
 	public void initialize() {
 
 		if (this.applicationContext == null) {
@@ -432,8 +447,9 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 				this.applicationContext.getBeansOfType(Binding.class).values());
 
 		@SuppressWarnings("rawtypes")
-		Collection<Collection> collections = this.applicationContext.getBeansOfType(Collection.class, false, false)
-				.values();
+		Collection<Collection> collections = this.declareCollections
+			? this.applicationContext.getBeansOfType(Collection.class, false, false).values()
+			: Collections.emptyList();
 		for (Collection<?> collection : collections) {
 			if (collection.size() > 0 && collection.iterator().next() instanceof Declarable) {
 				for (Object declarable : collection) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
@@ -265,6 +265,19 @@ public class RabbitAdminTests {
 	}
 
 	@Test
+	public void testMultiEntitiesSuppressed() {
+		ConfigurableApplicationContext ctx = new AnnotationConfigApplicationContext(Config1.class);
+		RabbitAdmin admin = ctx.getBean(RabbitAdmin.class);
+		assertNotNull(admin.getQueueProperties("q1"));
+		assertNull(admin.getQueueProperties("q2"));
+		assertNull(admin.getQueueProperties("q3"));
+		assertNull(admin.getQueueProperties("q4"));
+		admin.deleteQueue("q1");
+		admin.deleteExchange("e1");
+		ctx.close();
+	}
+
+	@Test
 	public void testAvoidHangAMQP_508() {
 		CachingConnectionFactory cf = new CachingConnectionFactory("localhost");
 		RabbitAdmin admin = new RabbitAdmin(cf);
@@ -413,6 +426,18 @@ public class RabbitAdminTests {
 					new Queue("q4", false, false, true),
 					new Binding("q4", DestinationType.QUEUE, "e4", "k4", null)
 			);
+		}
+
+	}
+
+	@Configuration
+	public static class Config1 extends Config {
+
+		@Override
+		public RabbitAdmin admin(ConnectionFactory cf) {
+			RabbitAdmin admin = super.admin(cf);
+			admin.setDeclareCollections(false);
+			return admin;
 		}
 
 	}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3756,6 +3756,8 @@ public static class Config {
 }
 -----
 
+IMPORTANT: This feature can cause undesirable side effects in some cases, because the admin has to iterate over all `Collection<?>` beans.
+Starting with _versions 1.7.7, 2.0.4_, this feature can be disabled by setting the admin property `declareCollections` to `false`.
 
 [[conditional-declaration]]
 ===== Conditional Declaration


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/734

Add `declareCollections` flag to admin (default false).

__cherry-pick to 2.0.x, 1.7.x__