### PR TITLE
Changes to build with JDK10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ subprojects { subproject ->
 	}
 
 	jacoco {
-		toolVersion = '0.7.9'
+		toolVersion = '0.8.1'
 	}
 
 	// dependencies that are common across all java projects

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/SimpleAmqpHeaderMapperTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/SimpleAmqpHeaderMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class SimpleAmqpHeaderMapperTests {
 		assertEquals(MessageDeliveryMode.NON_PERSISTENT, amqpProperties.getDeliveryMode());
 		assertEquals(1234L, amqpProperties.getDeliveryTag());
 		assertEquals("test.expiration", amqpProperties.getExpiration());
-		assertEquals(new Integer(42), amqpProperties.getMessageCount());
+		assertEquals(Integer.valueOf(42), amqpProperties.getMessageCount());
 		assertEquals("test.messageId", amqpProperties.getMessageId());
 		assertEquals("test.receivedExchange", amqpProperties.getReceivedExchange());
 		assertEquals("test.receivedRoutingKey", amqpProperties.getReceivedRoutingKey());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AbstractRabbitAnnotationDrivenTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AbstractRabbitAnnotationDrivenTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,7 +128,7 @@ public abstract class AbstractRabbitAnnotationDrivenTests {
 		assertQueues(endpoint, "queue1", "queue2");
 		assertTrue("No queue instances should be set", endpoint.getQueues().isEmpty());
 		assertEquals(true, endpoint.isExclusive());
-		assertEquals(new Integer(34), endpoint.getPriority());
+		assertEquals(Integer.valueOf(34), endpoint.getPriority());
 		assertSame(context.getBean("rabbitAdmin"), endpoint.getAdmin());
 
 		// Resolve the container and invoke a message on it

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -166,7 +166,7 @@ public class SSLConnectionTests {
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 		verify(logger).debug(captor.capture());
 		final String log = captor.getValue();
-		assertThat(log, allOf(containsString("KM: ["), containsString("TM: ["), containsString("random: java.")));
+		assertThat(log, allOf(containsString("KM: ["), containsString("TM: ["), containsString("random: ")));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerMultipleQueueIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerMultipleQueueIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,8 +103,8 @@ public class MessageListenerContainerMultipleQueueIntegrationTests {
 		messageConverter.setCreateMessageIds(true);
 		template.setMessageConverter(messageConverter);
 		for (int i = 0; i < messageCount; i++) {
-			template.convertAndSend(queue1.getName(), new Integer(i));
-			template.convertAndSend(queue2.getName(), new Integer(i));
+			template.convertAndSend(queue1.getName(), Integer.valueOf(i));
+			template.convertAndSend(queue2.getName(), Integer.valueOf(i));
 		}
 		final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		final CountDownLatch latch = new CountDownLatch(messageCount * 2);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderConfiguration.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.springframework.amqp.rabbit.logback;
 
-import javax.annotation.PreDestroy;
-
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
@@ -27,6 +25,7 @@ import org.springframework.amqp.rabbit.connection.SingleConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,9 +33,10 @@ import org.springframework.context.annotation.Scope;
 
 /**
  * @author Jon Brisbin
+ * @author Gary Russell
  */
 @Configuration
-public class AmqpAppenderConfiguration {
+public class AmqpAppenderConfiguration implements DisposableBean {
 
 	private static final String QUEUE = "amqp.appender.test";
 
@@ -51,7 +51,7 @@ public class AmqpAppenderConfiguration {
 		return new SingleConnectionFactory("localhost");
 	}
 
-	@PreDestroy
+	@Override
 	public void destroy() {
 		SingleConnectionFactory cf = new SingleConnectionFactory("localhost");
 		RabbitAdmin admin = new RabbitAdmin(cf);


### PR DESCRIPTION
- update jaCoCo version
- new `Integer(n)` is deprecated
- @PreDestroy no longer present
- SSL change