### PR TITLE
AMQP-797: Defer caching publisher callback channel

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -1098,14 +1098,14 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			}
 		}
 
-		private void returnToCache(ChannelProxy proxy) {
+		private void returnToCache(Channel proxy) {
 			synchronized (this.channelList) {
 				// Allow for multiple close calls...
 				if (CachingConnectionFactory.this.active && !this.channelList.contains(proxy)) {
 					if (logger.isTraceEnabled()) {
 						logger.trace("Returning cached Channel: " + this.target);
 					}
-					this.channelList.addLast(proxy);
+					this.channelList.addLast((ChannelProxy) proxy);
 					setHighWaterMark();
 					this.theConnection.channelsAwaitingAcks.remove(proxy);
 				}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -95,7 +95,7 @@ import com.rabbitmq.client.ShutdownSignalException;
  */
 @ManagedResource
 public class CachingConnectionFactory extends AbstractConnectionFactory
-		implements InitializingBean, ShutdownListener, PublisherCallbackChannelConnectionFactory {
+		implements InitializingBean, ShutdownListener {
 
 	private static final int DEFAULT_CHANNEL_CACHE_SIZE = 25;
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -32,6 +33,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -792,31 +794,27 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	/*
 	 * Reset the Channel cache and underlying shared Connection, to be reinitialized on next access.
 	 */
-	protected void reset(List<ChannelProxy> channels, List<ChannelProxy> txChannels) {
+	protected void reset(List<ChannelProxy> channels, List<ChannelProxy> txChannels,
+			Collection<ChannelProxy> channelsAwaitingAcks) {
 		this.active = false;
-		synchronized (channels) {
-			for (ChannelProxy channel : channels) {
-				try {
-					channel.close();
-				}
-				catch (Exception ex) {
-					logger.trace("Could not close cached Rabbit Channel", ex);
-				}
-			}
-			channels.clear();
-		}
-		synchronized (txChannels) {
-			for (ChannelProxy channel : txChannels) {
-				try {
-					channel.close();
-				}
-				catch (Exception ex) {
-					logger.trace("Could not close cached Rabbit Channel", ex);
-				}
-			}
-			txChannels.clear();
-		}
+		closeAndClear(channels);
+		closeAndClear(txChannels);
+		closeAndClear(channelsAwaitingAcks);
 		this.active = true;
+	}
+
+	protected void closeAndClear(Collection<ChannelProxy> theChannels) {
+		synchronized (theChannels) {
+			for (ChannelProxy channel : theChannels) {
+				try {
+					channel.close();
+				}
+				catch (Exception ex) {
+					logger.trace("Could not close cached Rabbit Channel", ex);
+				}
+			}
+			theChannels.clear();
+		}
 	}
 
 	@ManagedAttribute
@@ -921,7 +919,9 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 		private final boolean transactional;
 
-		private volatile boolean confirmSelected = CachingConnectionFactory.this.simplePublisherConfirms;
+		private final boolean confirmSelected = CachingConnectionFactory.this.simplePublisherConfirms;
+
+		private final boolean publisherConfirms = CachingConnectionFactory.this.publisherConfirms;
 
 		private volatile Channel target;
 
@@ -959,7 +959,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 				// Handle close method: don't pass the call on.
 				if (CachingConnectionFactory.this.active) {
 					synchronized (this.channelList) {
-						if (!RabbitUtils.isPhysicalCloseRequired() &&
+						if (CachingConnectionFactory.this.active && !RabbitUtils.isPhysicalCloseRequired() &&
 								(this.channelList.size() < getChannelCacheSize()
 										|| this.channelList.contains(proxy))) {
 							releasePermitIfNecessary(proxy);
@@ -1088,13 +1088,27 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 					}
 				}
 			}
-			// Allow for multiple close calls...
-			if (!this.channelList.contains(proxy)) {
-				if (logger.isTraceEnabled()) {
-					logger.trace("Returning cached Channel: " + this.target);
+			if (CachingConnectionFactory.this.active && this.publisherConfirms
+					&& proxy instanceof PublisherCallbackChannel) {
+				this.theConnection.channelsAwaitingAcks.add(proxy);
+				((PublisherCallbackChannel) proxy).setAfterAckCallback(this::returnToCache, proxy);
+			}
+			else {
+				returnToCache(proxy);
+			}
+		}
+
+		private void returnToCache(ChannelProxy proxy) {
+			synchronized (this.channelList) {
+				// Allow for multiple close calls...
+				if (CachingConnectionFactory.this.active && !this.channelList.contains(proxy)) {
+					if (logger.isTraceEnabled()) {
+						logger.trace("Returning cached Channel: " + this.target);
+					}
+					this.channelList.addLast(proxy);
+					setHighWaterMark();
+					this.theConnection.channelsAwaitingAcks.remove(proxy);
 				}
-				this.channelList.addLast(proxy);
-				setHighWaterMark();
 			}
 		}
 
@@ -1177,6 +1191,8 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 		private final AtomicBoolean closeNotified = new AtomicBoolean(false);
 
+		private final Set<ChannelProxy> channelsAwaitingAcks = ConcurrentHashMap.newKeySet();
+
 		private volatile Connection target;
 
 		ChannelCachingConnectionProxy(Connection target) {
@@ -1248,11 +1264,12 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		public void destroy() {
 			if (CachingConnectionFactory.this.cacheMode == CacheMode.CHANNEL) {
 				reset(CachingConnectionFactory.this.cachedChannelsNonTransactional,
-						CachingConnectionFactory.this.cachedChannelsTransactional);
+						CachingConnectionFactory.this.cachedChannelsTransactional, this.channelsAwaitingAcks);
 			}
 			else {
 				reset(CachingConnectionFactory.this.allocatedConnectionNonTransactionalChannels.get(this),
-						CachingConnectionFactory.this.allocatedConnectionTransactionalChannels.get(this));
+						CachingConnectionFactory.this.allocatedConnectionTransactionalChannels.get(this),
+						this.channelsAwaitingAcks);
 			}
 			if (this.target != null) {
 				RabbitUtils.closeConnection(this.target);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactory.java
@@ -65,4 +65,22 @@ public interface ConnectionFactory {
 		return false;
 	}
 
+	/**
+	 * Return true if publisher confirms are enabled.
+	 * @return publisherConfirms.
+	 * @since 2.1
+	 */
+	default boolean isPublisherConfirms() {
+		return false;
+	}
+
+	/**
+	 * Return true if publisher returns are enabled.
+	 * @return publisherReturns.
+	 * @since 2.1
+	 */
+	default boolean isPublisherReturns() {
+		return false;
+	}
+
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,13 @@ package org.springframework.amqp.rabbit.connection;
  * Connection factories implementing this interface return a connection that
  * provides {@code PublisherCallbackChannel} channel instances when confirms
  * or returns are enabled.
+ * @deprecated in favor of default methods on ConnectionFactory.
  *
  * @author Gary Russell
  * @since 1.5
  *
  */
+@Deprecated
 public interface PublisherCallbackChannelConnectionFactory {
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannel.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannel.java
@@ -84,10 +84,9 @@ public interface PublisherCallbackChannel extends Channel {
 	/**
 	 * Set a callback to be invoked after the ack/nack has been handled.
 	 * @param callback the callback.
-	 * @param proxyForThis the proxy for this channel.
 	 * @since 2.1
 	 */
-	void setAfterAckCallback(Consumer<Channel> callback, Channel proxyForThis);
+	void setAfterAckCallback(Consumer<Channel> callback);
 
 	/**
 	 * Listeners implementing this interface can participate

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannel.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannel.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.function.Consumer;
 
-import org.springframework.amqp.rabbit.connection.ChannelProxy;
-
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 
@@ -86,10 +84,10 @@ public interface PublisherCallbackChannel extends Channel {
 	/**
 	 * Set a callback to be invoked after the ack/nack has been handled.
 	 * @param callback the callback.
-	 * @param proxy the proxy.
+	 * @param proxyForThis the proxy for this channel.
 	 * @since 2.1
 	 */
-	void setAfterAckCallback(Consumer<ChannelProxy> callback, ChannelProxy proxy);
+	void setAfterAckCallback(Consumer<Channel> callback, Channel proxyForThis);
 
 	/**
 	 * Listeners implementing this interface can participate

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannel.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.springframework.amqp.rabbit.support;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.function.Consumer;
+
+import org.springframework.amqp.rabbit.connection.ChannelProxy;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
@@ -49,13 +52,19 @@ public interface PublisherCallbackChannel extends Channel {
 	 */
 	Collection<PendingConfirm> expire(Listener listener, long cutoffTime);
 
-    /**
-     * Get the {@link PendingConfirm}s count.
-     * @param listener the listener.
-     * @return Count of the pending confirms.
-     */
+	/**
+	 * Get the {@link PendingConfirm}s count.
+	 * @param listener the listener.
+	 * @return Count of the pending confirms.
+	 */
+	int getPendingConfirmsCount(Listener listener);
 
-    int getPendingConfirmsCount(Listener listener);
+	/**
+	 * Get the total pending confirms count.
+	 * @return the count.
+	 * @since 2.1
+	 */
+	int getPendingConfirmsCount();
 
 	/**
 	 * Adds a pending confirmation to this channel's map.
@@ -73,6 +82,14 @@ public interface PublisherCallbackChannel extends Channel {
 	 * @since 1.4.
 	 */
 	Channel getDelegate();
+
+	/**
+	 * Set a callback to be invoked after the ack/nack has been handled.
+	 * @param callback the callback.
+	 * @param proxy the proxy.
+	 * @since 2.1
+	 */
+	void setAfterAckCallback(Consumer<ChannelProxy> callback, ChannelProxy proxy);
 
 	/**
 	 * Listeners implementing this interface can participate

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.amqp.rabbit.connection.ChannelProxy;
 import org.springframework.util.Assert;
 
 import com.rabbitmq.client.AMQP;
@@ -90,10 +91,27 @@ public class PublisherCallbackChannelImpl
 
 	private final SortedMap<Long, Listener> listenerForSeq = new ConcurrentSkipListMap<Long, Listener>();
 
+	private volatile java.util.function.Consumer<ChannelProxy> afterAckCallback;
+
+	private volatile ChannelProxy proxy;
+
 	public PublisherCallbackChannelImpl(Channel delegate) {
 		delegate.addShutdownListener(this);
 		this.delegate = delegate;
 	}
+
+	@Override
+	public synchronized void setAfterAckCallback(java.util.function.Consumer<ChannelProxy> callback,
+			ChannelProxy proxy) {
+		if (getPendingConfirmsCount() == 0) {
+			callback.accept(proxy);
+		}
+		else {
+			this.afterAckCallback = callback;
+			this.proxy = proxy;
+		}
+	}
+
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // BEGIN PURE DELEGATE METHODS
@@ -792,16 +810,24 @@ public class PublisherCallbackChannelImpl
 		this.listeners.clear();
 	}
 
-    @Override
-    public synchronized int getPendingConfirmsCount(Listener listener) {
-        SortedMap<Long, PendingConfirm> pendingConfirmsForListener = this.pendingConfirms.get(listener);
-        if (pendingConfirmsForListener == null) {
-            return 0;
-        }
-        else {
-            return pendingConfirmsForListener.entrySet().size();
-        }
-    }
+	@Override
+	public synchronized int getPendingConfirmsCount(Listener listener) {
+		SortedMap<Long, PendingConfirm> pendingConfirmsForListener = this.pendingConfirms.get(listener);
+		if (pendingConfirmsForListener == null) {
+			return 0;
+		}
+		else {
+			return pendingConfirmsForListener.entrySet().size();
+		}
+	}
+
+	@Override
+	public synchronized int getPendingConfirmsCount() {
+		return this.pendingConfirms.values().stream()
+				.map(m -> m.size())
+				.mapToInt(Integer::valueOf)
+				.sum();
+	}
 
 	/**
 	 * Add the listener and return the internal map of pending confirmations for that listener.
@@ -866,6 +892,18 @@ public class PublisherCallbackChannelImpl
 	}
 
 	private synchronized void processAck(long seq, boolean ack, boolean multiple, boolean remove) {
+		try {
+			doProcessAck(seq, ack, multiple, remove);
+		}
+		finally {
+			if (this.afterAckCallback != null && getPendingConfirmsCount() == 0) {
+				this.afterAckCallback.accept(this.proxy);
+				this.afterAckCallback = null;
+			}
+		}
+	}
+
+	private void doProcessAck(long seq, boolean ack, boolean multiple, boolean remove) {
 		if (multiple) {
 			/*
 			 * Piggy-backed ack - extract all Listeners for this and earlier

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -99,7 +99,7 @@ public class PublisherCallbackChannelImpl
 
 	@Override
 	public synchronized void setAfterAckCallback(java.util.function.Consumer<Channel> callback) {
-		if (getPendingConfirmsCount() == 0) {
+		if (getPendingConfirmsCount() == 0 && callback != null) {
 			callback.accept(this);
 		}
 		else {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/PublisherCallbackChannelImpl.java
@@ -92,22 +92,18 @@ public class PublisherCallbackChannelImpl
 
 	private volatile java.util.function.Consumer<Channel> afterAckCallback;
 
-	private volatile Channel proxyForThis;
-
 	public PublisherCallbackChannelImpl(Channel delegate) {
 		delegate.addShutdownListener(this);
 		this.delegate = delegate;
 	}
 
 	@Override
-	public synchronized void setAfterAckCallback(java.util.function.Consumer<Channel> callback,
-			Channel proxyForThis) {
+	public synchronized void setAfterAckCallback(java.util.function.Consumer<Channel> callback) {
 		if (getPendingConfirmsCount() == 0) {
-			callback.accept(proxyForThis);
+			callback.accept(this);
 		}
 		else {
 			this.afterAckCallback = callback;
-			this.proxyForThis = proxyForThis;
 		}
 	}
 
@@ -896,7 +892,7 @@ public class PublisherCallbackChannelImpl
 		}
 		finally {
 			if (this.afterAckCallback != null && getPendingConfirmsCount() == 0) {
-				this.afterAckCallback.accept(this.proxyForThis);
+				this.afterAckCallback.accept(this);
 				this.afterAckCallback = null;
 			}
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
@@ -750,12 +750,15 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		doAnswer(invocation -> sent.incrementAndGet() < closeAfter).when(mockChannel1).isOpen();
 		final CountDownLatch sentAll = new CountDownLatch(1);
 		exec.execute(() -> {
-			for (int i = 0; i < 1000; i++) {
-				try {
-					template.convertAndSend(ROUTE, (Object) "message", new CorrelationData("abc"));
+			template.invoke(t -> {
+				for (int i = 0; i < 1000; i++) {
+					try {
+						t.convertAndSend(ROUTE, (Object) "message", new CorrelationData("abc"));
+					}
+					catch (AmqpException e) { }
 				}
-				catch (AmqpException e) { }
-			}
+				return null;
+			});
 			sentAll.countDown();
 		});
 		assertTrue(sentAll.await(10, TimeUnit.SECONDS));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests3.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests3.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
+import org.springframework.amqp.rabbit.support.CorrelationData;
+import org.springframework.amqp.utils.test.TestUtils;
+
+import com.rabbitmq.client.Channel;
+
+/**
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+@RabbitAvailable(queues = RabbitTemplatePublisherCallbacksIntegrationTests3.QUEUE)
+public class RabbitTemplatePublisherCallbacksIntegrationTests3 {
+
+	public static final String QUEUE = "defer.close";
+
+	@Test
+	@Disabled
+	public void testRepublishOnNackThreadNoExchange() throws Exception {
+		CachingConnectionFactory cf = new CachingConnectionFactory(
+				RabbitAvailableCondition.getBrokerRunning().getConnectionFactory());
+		cf.setPublisherConfirms(true);
+		final RabbitTemplate template = new RabbitTemplate(cf);
+		final CountDownLatch confirmLatch = new CountDownLatch(2);
+		template.setConfirmCallback((cd, a, c) -> {
+			if (confirmLatch.getCount() == 2) {
+				template.convertAndSend(QUEUE, ((MyCD) cd).payload); // deadlock creating new channel
+			}
+			confirmLatch.countDown();
+		});
+		template.convertAndSend("bad.exchange", "junk", "foo", new MyCD("foo"));
+		assertThat(confirmLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(template.receive(QUEUE, 10_000)).isNotNull();
+	}
+
+	@Test
+	public void testDeferredChannelCache() throws Exception {
+		final CachingConnectionFactory cf = new CachingConnectionFactory(
+				RabbitAvailableCondition.getBrokerRunning().getConnectionFactory());
+		cf.setPublisherReturns(true);
+		cf.setPublisherConfirms(true);
+		final RabbitTemplate template = new RabbitTemplate(cf);
+		final CountDownLatch returnLatch = new CountDownLatch(1);
+		final CountDownLatch confirmLatch = new CountDownLatch(1);
+		final AtomicInteger cacheCount = new AtomicInteger();
+		template.setConfirmCallback((cd, a, c) -> {
+			cacheCount.set(TestUtils.getPropertyValue(cf, "cachedChannelsNonTransactional", List.class).size());
+			confirmLatch.countDown();
+		});
+		template.setReturnCallback((m, r, rt, e, rk) -> {
+			returnLatch.countDown();
+		});
+		template.setMandatory(true);
+		Connection conn = cf.createConnection();
+		Channel channel1 = conn.createChannel(false);
+		Channel channel2 = conn.createChannel(false);
+		channel1.close();
+		channel2.close();
+		conn.close();
+		assertThat(TestUtils.getPropertyValue(cf, "cachedChannelsNonTransactional", List.class).size()).isEqualTo(2);
+		template.convertAndSend("", QUEUE + "junk", "foo", new MyCD("foo"));
+		assertThat(returnLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(confirmLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(cacheCount.get()).isEqualTo(1);
+		cf.destroy();
+	}
+
+	private static class MyCD extends CorrelationData {
+
+		private final String payload;
+
+		MyCD(String payload) {
+			this.payload = payload;
+		}
+
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -33,7 +33,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,7 +56,6 @@ import org.springframework.amqp.core.ReceiveAndReplyCallback;
 import org.springframework.amqp.rabbit.connection.AbstractRoutingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ChannelProxy;
-import org.springframework.amqp.rabbit.connection.PublisherCallbackChannelConnectionFactory;
 import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.SingleConnectionFactory;
 import org.springframework.amqp.rabbit.support.PublisherCallbackChannel;
@@ -255,11 +253,9 @@ public class RabbitTemplateTests {
 	@Test
 	public void testPublisherConfirmsReturnsSetup() {
 		org.springframework.amqp.rabbit.connection.ConnectionFactory cf =
-				mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class,
-						withSettings().extraInterfaces(PublisherCallbackChannelConnectionFactory.class));
-		PublisherCallbackChannelConnectionFactory pcccf = (PublisherCallbackChannelConnectionFactory) cf;
-		when(pcccf.isPublisherConfirms()).thenReturn(true);
-		when(pcccf.isPublisherReturns()).thenReturn(true);
+				mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		when(cf.isPublisherConfirms()).thenReturn(true);
+		when(cf.isPublisherReturns()).thenReturn(true);
 		org.springframework.amqp.rabbit.connection.Connection conn =
 				mock(org.springframework.amqp.rabbit.connection.Connection.class);
 		when(cf.createConnection()).thenReturn(conn);

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -839,8 +839,7 @@ public AmqpTemplate rabbitTemplate() {
 ----
 
 Starting with _version 1.4_, in addition to the `retryTemplate` property, the `recoveryCallback` option is supported on the `RabbitTemplate`.
-It is used as a second argument for the `RetryTemplate.execute(RetryCallback<T, E> retryCallback,
-			RecoveryCallback<T>recoveryCallback)`.
+It is used as a second argument for the `RetryTemplate.execute(RetryCallback<T, E> retryCallback, RecoveryCallback<T>recoveryCallback)`.
 
 NOTE: The `RecoveryCallback` is somewhat limited in that the retry context only contains the `lastThrowable` field.
 For more sophisticated use cases, you should use an external `RetryTemplate` so that you can convey additional information to the `RecoveryCallback` via the context's attributes:
@@ -954,6 +953,11 @@ channel on which a message is published is returned to the cache instead of bein
 You can monitor channel usage using the RabbitMQ management plugin; if you see channels being opened/closed rapidly you
 should consider increasing the cache size to reduce overhead on the server.
 
+IMPORTANT: Before _version 2.1_, channels enabled for publisher confirms were returned to the cache before the confirm(s) were received.
+Some other process could check out the channel and perform some operation that causes the channel to close - such as publishing a message to a non-existent exchange.
+This could cause the confirmation to be lost; _version 2.1_ and later no longer return the channel to the cache while confirmations are outstanding.
+Since the `RabbitTemplate` performs a logical `close()` on the channel after each operation; in general, this means that only one confirm will be outstanding on a channel at a time.
+
 See also <<scoped-operations>> for a simpler mechanism for waiting for publisher confirms.
 
 [[scoped-operations]]
@@ -965,6 +969,7 @@ There may be times, however, where you want to have more control over the use of
 
 Starting with _version 2.0_, a new method `invoke` is provided, with an `OperationsCallback`.
 Any operations performed within the scope of the callback, and on the provided `RabbitOperations` argument, will use the same dedicated `Channel`, which will be closed at the end (not returned to a cache).
+If the channel is a `PublisherCallbackChannel`, it will be returned to the cache after all confirms have been received (see <<template-confirms>> above).
 
 [source, java]
 ----

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -18,3 +18,9 @@ RabbitMQ `ConnectionFactory` instances created by the `RabbitConnectionFactoryBe
 
 Certain classes have moved to different packages; most are internal classes and won't affect user applications.
 Two exceptions are `ChannelAwareMessageListener` and `RabbitListenerErrorHandler`; these interfaces are now in `org.springframework.amqp.rabbit.listener.api`.
+
+
+===== Publisher Confirms Changes
+
+Channels enabled for publisher confirms are not returned to the cache while there are outstanding confirms.
+See <<template-confirms>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-797

Defer caching publisher callback channels until acks received.

- another user might perform an erroneous call that forces the channel closed and the confirmations
  will be lost.
- if the factory is destroyed with channels in that state, force them closed to generate nacks