### PR TITLE
AMQP-817: Synthetic NACKs on separate thread

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -623,7 +623,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		}
 		if (this.publisherConfirms || this.publisherReturns) {
 			if (!(channel instanceof PublisherCallbackChannelImpl)) {
-				channel = new PublisherCallbackChannelImpl(channel);
+				channel = new PublisherCallbackChannelImpl(channel, getExecutorService());
 			}
 		}
 		if (channel != null) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-817

Previously, synthetic nacks were processed on the client thread, which caused
a deadlock if the user attempted some operation such as creating a new channel
on that thread.

Also, when generated from a application-level `close()` a similar deadlock between
the connection factory and `PublisherCallbackChannelImpl` could occur.

Synthetic nacks are now always processed on a separate thread.