### PR TITLE
AMQP-811: Listener container factory improvements

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -224,7 +224,7 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 		this.container = null;
 		this.replyAddress = null;
 		this.directReplyToContainer = new DirectReplyToMessageListenerContainer(this.template.getConnectionFactory());
-		this.directReplyToContainer.setChannelAwareMessageListener(this);
+		this.directReplyToContainer.setMessageListener(this);
 	}
 
 	/**
@@ -239,7 +239,7 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 		this.container = null;
 		this.replyAddress = null;
 		this.directReplyToContainer = new DirectReplyToMessageListenerContainer(this.template.getConnectionFactory());
-		this.directReplyToContainer.setChannelAwareMessageListener(this);
+		this.directReplyToContainer.setMessageListener(this);
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
@@ -353,10 +353,7 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 		if (this.applicationEventPublisher != null) {
 			instance.setApplicationEventPublisher(this.applicationEventPublisher);
 		}
-		if (endpoint.getAutoStartup() != null) {
-			instance.setAutoStartup(endpoint.getAutoStartup());
-		}
-		else if (this.autoStartup != null) {
+		if (this.autoStartup != null) {
 			instance.setAutoStartup(this.autoStartup);
 		}
 		if (this.phase != null) {
@@ -365,9 +362,14 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 		if (this.afterReceivePostProcessors != null) {
 			instance.setAfterReceivePostProcessors(this.afterReceivePostProcessors);
 		}
-		instance.setListenerId(endpoint.getId());
+		if (endpoint != null) {
+			if (endpoint.getAutoStartup() != null) {
+				instance.setAutoStartup(endpoint.getAutoStartup());
+			}
+			instance.setListenerId(endpoint.getId());
 
-		endpoint.setupListenerContainer(instance);
+			endpoint.setupListenerContainer(instance);
+		}
 		if (this.beforeSendReplyPostProcessors != null
 				&& instance.getMessageListener() instanceof AbstractAdaptableMessageListener) {
 			((AbstractAdaptableMessageListener) instance.getMessageListener())

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/DirectRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/DirectRabbitListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class DirectRabbitListenerContainerFactory
 		if (this.monitorInterval != null) {
 			instance.setMonitorInterval(this.monitorInterval);
 		}
-		if (endpoint.getConcurrency() != null) {
+		if (endpoint != null && endpoint.getConcurrency() != null) {
 			try {
 				instance.setConsumersPerQueue(Integer.parseInt(endpoint.getConcurrency()));
 			}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executor;
 import org.aopalliance.aop.Advice;
 
 import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -82,7 +83,7 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 
 	private Boolean exposeListenerChannel;
 
-	private Object messageListener;
+	private MessageListener messageListener;
 
 	private ErrorHandler errorHandler;
 
@@ -211,7 +212,7 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 		this.exposeListenerChannel = exposeListenerChannel;
 	}
 
-	public void setMessageListener(Object messageListener) {
+	public void setMessageListener(MessageListener messageListener) {
 		this.messageListener = messageListener;
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,11 +141,14 @@ public class SimpleRabbitListenerContainerFactory
 		if (this.txSize != null) {
 			instance.setTxSize(this.txSize);
 		}
-		String concurrency = endpoint.getConcurrency();
-		if (concurrency != null) {
-			instance.setConcurrency(concurrency);
+		String concurrency = null;
+		if (endpoint != null) {
+			concurrency = endpoint.getConcurrency();
+			if (concurrency != null) {
+				instance.setConcurrency(concurrency);
+			}
 		}
-		else if (this.concurrentConsumers != null) {
+		if (concurrency == null && this.concurrentConsumers != null) {
 			instance.setConcurrentConsumers(this.concurrentConsumers);
 		}
 		if ((concurrency == null || !(concurrency.contains("-"))) && this.maxConcurrentConsumers != null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -394,15 +394,16 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	/**
 	 * Set the message listener implementation to register. This can be either a Spring
 	 * {@link MessageListener} object or a Spring {@link ChannelAwareMessageListener}
-	 * object. Using the strongly typed
-	 * {@link #setChannelAwareMessageListener(ChannelAwareMessageListener)} is preferred.
+	 * object.
 	 *
 	 * @param messageListener The listener.
 	 * @throws IllegalArgumentException if the supplied listener is not a
 	 * {@link MessageListener} or a {@link ChannelAwareMessageListener}
+	 * @deprecated use {@link #setMessageListener(MessageListener)}.
 	 * @see MessageListener
 	 * @see ChannelAwareMessageListener
 	 */
+	@Deprecated
 	public void setMessageListener(Object messageListener) {
 		checkMessageListener(messageListener);
 		this.messageListener = messageListener;
@@ -410,7 +411,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	/**
 	 * Set the {@link MessageListener}; strongly typed version of
-	 * {@link #setMessageListener(Object)}.
+	 * {@code setMessageListener(Object)}.
 	 * @param messageListener the listener.
 	 * @since 2.0
 	 */
@@ -420,10 +421,13 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 
 	/**
 	 * Set the {@link ChannelAwareMessageListener}; strongly typed version of
-	 * {@link #setMessageListener(Object)}.
+	 * {@code setMessageListener(Object)}.
 	 * @param messageListener the listener.
 	 * @since 2.0
+	 * @deprecated use {@link #setMessageListener(MessageListener)} since
+	 * {@link ChannelAwareMessageListener} now inherits {@link MessageListener}.
 	 */
+	@Deprecated
 	public void setChannelAwareMessageListener(ChannelAwareMessageListener messageListener) {
 		this.messageListener = messageListener;
 	}
@@ -1071,7 +1075,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	}
 
 	@Override
-	public void setupMessageListener(Object messageListener) {
+	public void setupMessageListener(MessageListener messageListener) {
 		setMessageListener(messageListener);
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -410,8 +410,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	}
 
 	/**
-	 * Set the {@link MessageListener}; strongly typed version of
-	 * {@code setMessageListener(Object)}.
+	 * Set the {@link MessageListener}.
 	 * @param messageListener the listener.
 	 * @since 2.0
 	 */
@@ -420,8 +419,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	}
 
 	/**
-	 * Set the {@link ChannelAwareMessageListener}; strongly typed version of
-	 * {@code setMessageListener(Object)}.
+	 * Set the {@link ChannelAwareMessageListener}.
 	 * @param messageListener the listener.
 	 * @since 2.0
 	 * @deprecated use {@link #setMessageListener(MessageListener)} since
@@ -435,15 +433,13 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	/**
 	 * Check the given message listener, throwing an exception if it does not correspond to a supported listener type.
 	 * <p>
-	 * By default, only a Spring {@link MessageListener} object or a Spring
-	 * {@link ChannelAwareMessageListener} object will be accepted.
+	 * Only a Spring {@link MessageListener} object will be accepted.
 	 * @param messageListener the message listener object to check
-	 * @throws IllegalArgumentException if the supplied listener is not a MessageListener or SessionAwareMessageListener
+	 * @throws IllegalArgumentException if the supplied listener is not a MessageListener
 	 * @see MessageListener
-	 * @see ChannelAwareMessageListener
 	 */
 	protected void checkMessageListener(Object messageListener) {
-		if (!(messageListener instanceof MessageListener || messageListener instanceof ChannelAwareMessageListener)) {
+		if (!(messageListener instanceof MessageListener)) {
 			throw new IllegalArgumentException("Message listener needs to be of type ["
 					+ MessageListener.class.getName() + "] or [" + ChannelAwareMessageListener.class.getName() + "]");
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
@@ -83,6 +83,7 @@ public class DirectReplyToMessageListenerContainer extends DirectMessageListener
 
 	@Override
 	@SuppressWarnings("deprecation")
+	@Deprecated
 	public void setMessageListener(Object messageListener) {
 		throw new UnsupportedOperationException(
 				"'messageListener' must be a 'MessageListener' or 'ChannelAwareMessageListener'");
@@ -90,6 +91,7 @@ public class DirectReplyToMessageListenerContainer extends DirectMessageListener
 
 	@Override
 	@SuppressWarnings("deprecation")
+	@Deprecated
 	public void setChannelAwareMessageListener(ChannelAwareMessageListener messageListener) {
 		setMessageListener(messageListener);
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
@@ -82,33 +82,40 @@ public class DirectReplyToMessageListenerContainer extends DirectMessageListener
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void setMessageListener(Object messageListener) {
 		throw new UnsupportedOperationException(
 				"'messageListener' must be a 'MessageListener' or 'ChannelAwareMessageListener'");
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void setChannelAwareMessageListener(ChannelAwareMessageListener messageListener) {
-		super.setChannelAwareMessageListener((message, channel) -> {
-			try {
-				messageListener.onMessage(message, channel);
-			}
-			finally {
-				this.inUseConsumerChannels.remove(channel);
-			}
-		});
+		setMessageListener(messageListener);
 	}
 
 	@Override
 	public void setMessageListener(MessageListener messageListener) {
-		super.setChannelAwareMessageListener((message, channel) -> {
-			try {
-				messageListener.onMessage(message);
-			}
-			finally {
-				this.inUseConsumerChannels.remove(channel);
-			}
-		});
+		if (messageListener instanceof ChannelAwareMessageListener) {
+			super.setMessageListener((ChannelAwareMessageListener) (message, channel) -> {
+				try {
+					((ChannelAwareMessageListener) messageListener).onMessage(message, channel);
+				}
+				finally {
+					this.inUseConsumerChannels.remove(channel);
+				}
+			});
+		}
+		else {
+			super.setMessageListener((ChannelAwareMessageListener) (message, channel) -> {
+				try {
+					messageListener.onMessage(message);
+				}
+				finally {
+					this.inUseConsumerChannels.remove(channel);
+				}
+			});
+		}
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.amqp.rabbit.listener;
 
+import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.SmartLifecycle;
 
@@ -33,7 +34,7 @@ public interface MessageListenerContainer extends SmartLifecycle {
 	 * if that message listener type is not supported.
 	 * @param messageListener the {@code object} to wrapped to the {@code MessageListener}.
 	 */
-	void setupMessageListener(Object messageListener);
+	void setupMessageListener(MessageListener messageListener);
 
 	/**
 	 * @return the {@link MessageConverter} that can be used to

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.amqp.rabbit.listener;
 
-
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.lang.Nullable;
 
 /**
- * Factory of {@link MessageListenerContainer} based on a
- * {@link RabbitListenerEndpoint} definition.
+ * Factory of {@link MessageListenerContainer}s.
  * @param <C> the container type.
  * @author Stephane Nicoll
  * @author Gary Russell
@@ -31,10 +31,21 @@ package org.springframework.amqp.rabbit.listener;
 public interface RabbitListenerContainerFactory<C extends MessageListenerContainer> {
 
 	/**
-	 * Create a {@link MessageListenerContainer} for the given {@link RabbitListenerEndpoint}.
-	 * @param endpoint the endpoint to configure
-	 * @return the created container
+	 * Create a {@link MessageListenerContainer} for the given
+	 * {@link RabbitListenerEndpoint}.
+	 * @param endpoint the endpoint to configure.
+	 * @return the created container.
 	 */
-	C createListenerContainer(RabbitListenerEndpoint endpoint);
+	C createListenerContainer(@Nullable RabbitListenerEndpoint endpoint);
+
+	/**
+	 * Create a {@link MessageListenerContainer} with no {@link MessageListener}
+	 * or queues; the listener must be added later before the container is started.
+	 * @return the created container.
+	 * @since 2.1.
+	 */
+	default C createListenerContainer() {
+		return createListenerContainer(null);
+	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -29,7 +29,6 @@ import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
-import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
 import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
 import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
 import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
@@ -58,10 +57,9 @@ import com.rabbitmq.client.Channel;
  *
  * @since 1.4
  *
- * @see MessageListener
  * @see ChannelAwareMessageListener
  */
-public abstract class AbstractAdaptableMessageListener implements MessageListener, ChannelAwareMessageListener {
+public abstract class AbstractAdaptableMessageListener implements ChannelAwareMessageListener {
 
 	private static final String DEFAULT_RESPONSE_ROUTING_KEY = "";
 
@@ -217,27 +215,6 @@ public abstract class AbstractAdaptableMessageListener implements MessageListene
 	 */
 	protected MessageConverter getMessageConverter() {
 		return this.messageConverter;
-	}
-
-	/**
-	 * Rabbit {@link MessageListener} entry point.
-	 * <p>
-	 * Delegates the message to the target listener method, with appropriate conversion of the message argument.
-	 * <p>
-	 * <b>Note:</b> Does not support sending response messages based on result objects returned from listener methods.
-	 * Use the {@link ChannelAwareMessageListener} entry point (typically through a Spring message listener container)
-	 * for handling result objects as well.
-	 * @param message the incoming Rabbit message
-	 * @see #onMessage(Message, com.rabbitmq.client.Channel)
-	 */
-	@Override
-	public void onMessage(Message message) {
-		try {
-			onMessage(message, null);
-		}
-		catch (Exception e) {
-			throw new ListenerExecutionFailedException("Listener threw exception", e, message);
-		}
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
@@ -269,16 +269,10 @@ public class MessageListenerAdapter extends AbstractAdaptableMessageListener {
 		Object delegate = getDelegate();
 		if (delegate != this) {
 			if (delegate instanceof ChannelAwareMessageListener) {
-				if (channel != null) {
-					((ChannelAwareMessageListener) delegate).onMessage(message, channel);
-					return;
-				}
-				else if (!(delegate instanceof MessageListener)) {
-					throw new AmqpIllegalStateException("MessageListenerAdapter cannot handle a "
-							+ "ChannelAwareMessageListener delegate if it hasn't been invoked with a Channel itself");
-				}
+				((ChannelAwareMessageListener) delegate).onMessage(message, channel);
+				return;
 			}
-			if (delegate instanceof MessageListener) {
+			else if (delegate instanceof MessageListener) {
 				((MessageListener) delegate).onMessage(message);
 				return;
 			}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/api/ChannelAwareMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/api/ChannelAwareMessageListener.java
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.listener.api;
 
 import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
 
 import com.rabbitmq.client.Channel;
 
@@ -27,7 +28,7 @@ import com.rabbitmq.client.Channel;
  * @author Gary Russell
  */
 @FunctionalInterface
-public interface ChannelAwareMessageListener {
+public interface ChannelAwareMessageListener extends MessageListener {
 
 	/**
 	 * Callback for processing a received Rabbit message.
@@ -38,5 +39,10 @@ public interface ChannelAwareMessageListener {
 	 * @throws Exception Any.
 	 */
 	void onMessage(Message message, Channel channel) throws Exception;
+
+	@Override
+	default void onMessage(Message message) {
+		throw new IllegalStateException("Should never be called for a ChannelAwareMessageListener");
+	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/ListenerContainerAware.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/ListenerContainerAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,9 @@ package org.springframework.amqp.rabbit.support;
 import java.util.Collection;
 
 import org.springframework.amqp.core.MessageListener;
-import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 
 /**
- * {@link MessageListener}s and {@link ChannelAwareMessageListener}s that also implement this
+ * {@link MessageListener}s that also implement this
  * interface can have configuration verified during initialization.
  *
  * @author Gary Russell

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MessageListenerTestContainer.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MessageListenerTestContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.amqp.rabbit.config;
 
+import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpoint;
 import org.springframework.amqp.support.converter.MessageConverter;
@@ -95,7 +96,7 @@ public class MessageListenerTestContainer
 	}
 
 	@Override
-	public void setupMessageListener(Object messageListener) {
+	public void setupMessageListener(MessageListener messageListener) {
 	}
 
 	@Override

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -278,7 +278,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		((DisposableBean) template.getConnectionFactory()).destroy();
 	}
 
-	public void doTest(int messageCount, ErrorHandler errorHandler, CountDownLatch latch, Object listener)
+	public void doTest(int messageCount, ErrorHandler errorHandler, CountDownLatch latch, MessageListener listener)
 			throws Exception {
 		this.errorsHandled = new CountDownLatch(messageCount);
 		int concurrentConsumers = 1;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegration2Tests.java
@@ -663,11 +663,11 @@ public class SimpleMessageListenerContainerIntegration2Tests {
 		return !this.container.isRunning();
 	}
 
-	private SimpleMessageListenerContainer createContainer(Object listener, String... queueNames) {
+	private SimpleMessageListenerContainer createContainer(MessageListener listener, String... queueNames) {
 		return createContainer(listener, true, queueNames);
 	}
 
-	private SimpleMessageListenerContainer createContainer(Object listener, boolean start, String... queueNames) {
+	private SimpleMessageListenerContainer createContainer(MessageListener listener, boolean start, String... queueNames) {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(template.getConnectionFactory());
 		if (listener != null) {
 			container.setMessageListener(listener);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerIntegrationTests.java
@@ -217,16 +217,16 @@ public class SimpleMessageListenerContainerIntegrationTests {
 	@Test
 	public void testNullQueue() throws Exception {
 		exception.expect(IllegalArgumentException.class);
-		container = createContainer((MessageListener) (m) -> { }, (Queue) null);
+		container = createContainer(m -> { }, (Queue) null);
 	}
 
 	@Test
 	public void testNullQueueName() throws Exception {
 		exception.expect(IllegalArgumentException.class);
-		container = createContainer((MessageListener) (m) -> { }, (String) null);
+		container = createContainer(m -> { }, (String) null);
 	}
 
-	private void doSunnyDayTest(CountDownLatch latch, Object listener) throws Exception {
+	private void doSunnyDayTest(CountDownLatch latch, MessageListener listener) throws Exception {
 		container = createContainer(listener);
 		for (int i = 0; i < messageCount; i++) {
 			template.convertAndSend(queue.getName(), i + "foo");
@@ -236,7 +236,7 @@ public class SimpleMessageListenerContainerIntegrationTests {
 		assertNull(template.receiveAndConvert(queue.getName()));
 	}
 
-	private void doListenerWithExceptionTest(CountDownLatch latch, Object listener) throws Exception {
+	private void doListenerWithExceptionTest(CountDownLatch latch, MessageListener listener) throws Exception {
 		container = createContainer(listener);
 		if (acknowledgeMode.isTransactionAllowed()) {
 			// Should only need one message if it is going to fail
@@ -264,26 +264,26 @@ public class SimpleMessageListenerContainerIntegrationTests {
 		}
 	}
 
-	private SimpleMessageListenerContainer createContainer(Object listener) {
+	private SimpleMessageListenerContainer createContainer(MessageListener listener) {
 		SimpleMessageListenerContainer container = createContainer(listener, queue.getName());
 		container.afterPropertiesSet();
 		container.start();
 		return container;
 	}
 
-	private SimpleMessageListenerContainer createContainer(Object listener, String queue) {
+	private SimpleMessageListenerContainer createContainer(MessageListener listener, String queue) {
 		SimpleMessageListenerContainer container = doCreateContainer(listener);
 		container.setQueueNames(queue);
 		return container;
 	}
 
-	private SimpleMessageListenerContainer createContainer(Object listener, Queue queue) {
+	private SimpleMessageListenerContainer createContainer(MessageListener listener, Queue queue) {
 		SimpleMessageListenerContainer container = doCreateContainer(listener);
 		container.setQueues(queue);
 		return container;
 	}
 
-	private SimpleMessageListenerContainer doCreateContainer(Object listener) {
+	private SimpleMessageListenerContainer doCreateContainer(MessageListener listener) {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(template.getConnectionFactory());
 		container.setMessageListener(listener);
 		container.setTxSize(txSize);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
@@ -64,7 +64,7 @@ public class MessageListenerAdapterTests {
 			}
 		}
 		this.adapter.setDelegate(new Delegate());
-		this.adapter.onMessage(new Message("foo".getBytes(), messageProperties));
+		this.adapter.onMessage(new Message("foo".getBytes(), messageProperties), null);
 		assertTrue(called.get());
 	}
 
@@ -79,7 +79,7 @@ public class MessageListenerAdapterTests {
 			}
 		}
 		this.adapter = new MessageListenerAdapter(new Delegate(), "myPojoMessageMethod");
-		this.adapter.onMessage(new Message("foo".getBytes(), messageProperties));
+		this.adapter.onMessage(new Message("foo".getBytes(), messageProperties), null);
 		assertTrue(called.get());
 	}
 
@@ -87,7 +87,7 @@ public class MessageListenerAdapterTests {
 	public void testExplicitListenerMethod() throws Exception {
 		this.adapter.setDefaultListenerMethod("handle");
 		this.adapter.setDelegate(this.simpleService);
-		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties));
+		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties), null);
 		assertEquals("handle", this.simpleService.called);
 	}
 
@@ -101,13 +101,13 @@ public class MessageListenerAdapterTests {
 		this.adapter.setDelegate(this.simpleService);
 		this.messageProperties.setConsumerQueue("foo");
 		this.messageProperties.setConsumerTag("bar");
-		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties));
+		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties), null);
 		assertEquals("handle", this.simpleService.called);
 		this.messageProperties.setConsumerQueue("junk");
-		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties));
+		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties), null);
 		assertEquals("notDefinedOnInterface", this.simpleService.called);
 		this.messageProperties.setConsumerTag("junk");
-		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties));
+		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties), null);
 		assertEquals("anotherHandle", this.simpleService.called);
 	}
 
@@ -117,7 +117,7 @@ public class MessageListenerAdapterTests {
 		ProxyFactory factory = new ProxyFactory(this.simpleService);
 		factory.setProxyTargetClass(true);
 		this.adapter.setDelegate(factory.getProxy());
-		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties));
+		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties), null);
 		assertEquals("notDefinedOnInterface", this.simpleService.called);
 	}
 
@@ -127,7 +127,7 @@ public class MessageListenerAdapterTests {
 		ProxyFactory factory = new ProxyFactory(this.simpleService);
 		factory.setProxyTargetClass(false);
 		this.adapter.setDelegate(factory.getProxy());
-		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties));
+		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties), null);
 		assertEquals("handle", this.simpleService.called);
 	}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2433,6 +2433,52 @@ Starting with _version 1.5_, you can now assign a `group` to the container on th
 This provides a mechanism to get a reference to a subset of containers; adding a `group` attribute causes a
 bean of type `Collection<MessageListenerContainer>` to be registered with the context with the group name.
 
+[[using-container-factories]]
+===== Using Container Factories
+
+Listener container factories were introduced to support the `@RabbitListener` and/or registering containers with the `RabbitListenerEndpointRegistry` as discussed in <<async-annotation-driven-registration>>.
+
+Starting with _version 2.1_, they can be used to create any listener container; even a container without a listener (such as for use in Spring Integration).
+Of course, a listener must be added before the container is started.
+
+There are two ways to create such containers:
+
+.use a SimpleRabbitListenerEndpoint
+[source, java]
+----
+@Bean
+public SimpleMessageListenerContainer factoryCreatedContainerSimpleListener(
+        SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory) {
+    SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+    endpoint.setQueueNames("queue.1");
+    endpoint.setMessageListener(message -> {
+        ...
+    });
+    return rabbitListenerContainerFactory.createListenerContainer(endpoint);
+}
+----
+
+.add the listener after creation
+[source, java]
+----
+@Bean
+public SimpleMessageListenerContainer factoryCreatedContainerNoListener(
+        SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory) {
+    SimpleMessageListenerContainer container = rabbitListenerContainerFactory.createListenerContainer();
+    container.setMessageListener(message -> {
+        ...
+    });
+    container.setQueueNames("test.no.listener.yet");
+    return container;
+}
+----
+
+In either case, the listener can also be a `ChannelAwareMessageListener`, since it is now a sub-interface of `MessageListener`.
+
+These techniques are useful if you wish to create several containers with similar properties and/or using a pre-configured container factory such as the one provided by Spring Boot auto configuration.
+
+IMPORTANT: Containers created this way are normal `@Bean` s and are not registered in the `RabbitListenerEndpointRegistry`.
+
 [[threading]]
 ===== Threading and Asynchronous Consumers
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -24,3 +24,11 @@ Two exceptions are `ChannelAwareMessageListener` and `RabbitListenerErrorHandler
 
 Channels enabled for publisher confirms are not returned to the cache while there are outstanding confirms.
 See <<template-confirms>> for more information.
+
+
+===== Listener Container Factory improvements
+
+The listener container factories can now be used to create any listener container, not just those for use with `@RabbitListener` s or the `@RabbitListenerEndpointRegistry`.
+See <<using-container-factories>> for more information.
+
+`ChannelAwareMessageListener` now inherits from `MesssageListener`.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-811

- `ChannelAwareMessageListener` now inherits from `MessageListener`
  - enables `SimpleRabbitListenerEndpoint` to be used with either
  - deprecate setters for CAML
- Support creating a container with no listener