### PR TITLE
AMQP-808: Add Declarables for declaring collection

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Declarables.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Declarables.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.core;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * A collection of {@link Declarable} objects; used to declare multiple objects on the
+ * broker using a single bean declaration for the collection.
+ *
+ * @author Gary Russell
+ * @since 2.1
+ */
+public class Declarables {
+
+	private final Collection<Declarable> declarables = new ArrayList<>();
+
+	public Declarables(Collection<Declarable> declarables) {
+		this.declarables.addAll(declarables);
+	}
+
+	public Collection<Declarable> getDeclarables() {
+		return this.declarables;
+	}
+
+	@Override
+	public String toString() {
+		return "Declarables [declarables=" + this.declarables + "]";
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Declarables.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Declarables.java
@@ -17,7 +17,11 @@
 package org.springframework.amqp.core;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * A collection of {@link Declarable} objects; used to declare multiple objects on the
@@ -30,7 +34,14 @@ public class Declarables {
 
 	private final Collection<Declarable> declarables = new ArrayList<>();
 
+	public Declarables(Declarable... declarables) {
+		if (!ObjectUtils.isEmpty(declarables)) {
+			this.declarables.addAll(Arrays.asList(declarables));
+		}
+	}
+
 	public Declarables(Collection<Declarable> declarables) {
+		Assert.notNull(declarables, "declarables cannot be null");
 		this.declarables.addAll(declarables);
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
@@ -43,7 +43,6 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -410,43 +409,37 @@ public class RabbitAdminTests {
 
 		@Bean
 		public Declarables es() {
-			return new Declarables(Arrays.asList(
+			return new Declarables(
 					new DirectExchange("e2", false, true),
-					new DirectExchange("e3", false, true)
-			));
+					new DirectExchange("e3", false, true));
 		}
 
 		@Bean
 		public Declarables qs() {
-			return new Declarables(Arrays.asList(
+			return new Declarables(
 					new Queue("q2", false, false, true),
-					new Queue("q3", false, false, true)
-			));
+					new Queue("q3", false, false, true));
 		}
 
 		@Bean
 		@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 		public Declarables prototypes() {
-			return new Declarables(Arrays.asList(
-					new Queue(this.prototypeQueueName, false, false, true)
-			));
+			return new Declarables(new Queue(this.prototypeQueueName, false, false, true));
 		}
 
 		@Bean
 		public Declarables bs() {
-			return new Declarables(Arrays.asList(
+			return new Declarables(
 					new Binding("q2", DestinationType.QUEUE, "e2", "k2", null),
-					new Binding("q3", DestinationType.QUEUE, "e3", "k3", null)
-			));
+					new Binding("q3", DestinationType.QUEUE, "e3", "k3", null));
 		}
 
 		@Bean
 		public Declarables ds() {
-			return new Declarables(Arrays.asList(
+			return new Declarables(
 					new DirectExchange("e4", false, true),
 					new Queue("q4", false, false, true),
-					new Binding("q4", DestinationType.QUEUE, "e4", "k4", null)
-			));
+					new Binding("q4", DestinationType.QUEUE, "e4", "k4", null));
 		}
 
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
@@ -65,7 +65,7 @@ import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Binding.DestinationType;
 import org.springframework.amqp.core.BindingBuilder;
-import org.springframework.amqp.core.Declarable;
+import org.springframework.amqp.core.Declarables;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Exchange;
 import org.springframework.amqp.core.Queue;
@@ -269,19 +269,6 @@ public class RabbitAdminTests {
 	}
 
 	@Test
-	public void testMultiEntitiesSuppressed() {
-		ConfigurableApplicationContext ctx = new AnnotationConfigApplicationContext(Config1.class);
-		RabbitAdmin admin = ctx.getBean(RabbitAdmin.class);
-		assertNotNull(admin.getQueueProperties("q1"));
-		assertNull(admin.getQueueProperties("q2"));
-		assertNull(admin.getQueueProperties("q3"));
-		assertNull(admin.getQueueProperties("q4"));
-		admin.deleteQueue("q1");
-		admin.deleteExchange("e1");
-		ctx.close();
-	}
-
-	@Test
 	public void testAvoidHangAMQP_508() {
 		CachingConnectionFactory cf = new CachingConnectionFactory("localhost");
 		RabbitAdmin admin = new RabbitAdmin(cf);
@@ -422,56 +409,44 @@ public class RabbitAdminTests {
 		}
 
 		@Bean
-		public List<Exchange> es() {
-			return Arrays.<Exchange>asList(
+		public Declarables es() {
+			return new Declarables(Arrays.asList(
 					new DirectExchange("e2", false, true),
 					new DirectExchange("e3", false, true)
-			);
+			));
 		}
 
 		@Bean
-		public List<Queue> qs() {
-			return Arrays.asList(
+		public Declarables qs() {
+			return new Declarables(Arrays.asList(
 					new Queue("q2", false, false, true),
 					new Queue("q3", false, false, true)
-			);
+			));
 		}
 
 		@Bean
 		@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-		public List<Queue> prototypes() {
-			return Arrays.asList(
+		public Declarables prototypes() {
+			return new Declarables(Arrays.asList(
 					new Queue(this.prototypeQueueName, false, false, true)
-			);
+			));
 		}
 
 		@Bean
-		public List<Binding> bs() {
-			return Arrays.asList(
+		public Declarables bs() {
+			return new Declarables(Arrays.asList(
 					new Binding("q2", DestinationType.QUEUE, "e2", "k2", null),
 					new Binding("q3", DestinationType.QUEUE, "e3", "k3", null)
-			);
+			));
 		}
 
 		@Bean
-		public List<Declarable> ds() {
-			return Arrays.<Declarable>asList(
+		public Declarables ds() {
+			return new Declarables(Arrays.asList(
 					new DirectExchange("e4", false, true),
 					new Queue("q4", false, false, true),
 					new Binding("q4", DestinationType.QUEUE, "e4", "k4", null)
-			);
-		}
-
-	}
-
-	@Configuration
-	public static class Config1 extends Config {
-
-		@Override
-		public RabbitAdmin admin(ConnectionFactory cf) {
-			RabbitAdmin admin = super.admin(cf);
-			admin.setDeclareCollections(false);
-			return admin;
+			));
 		}
 
 	}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3783,9 +3783,8 @@ The `durable()` method with no parameter is no longer provided.
 [[collection-declaration]]
 ===== Declaring Collections of Exchanges, Queues, Bindings
 
-Starting with _version 1.5_, it is now possible to declare multiple entities with one `@Bean`, by returning a collection.
-
-Only collections where the first element is a `Declarable` are considered, and only `Declarable` elements from such collections are processed.
+You can wrap collections of declarable objects (`Queue`, `Exchange`, `Binding`) in `Declarables` objects.
+The `RabbitAdmin` will detect such beans in the application context and declare the contained objects on the broker.
 
 [source, java]
 -----
@@ -3818,43 +3817,40 @@ public static class Config {
     }
 
     @Bean
-    public List<Exchange> es() {
-    	return Arrays.<Exchange>asList(
-    			new DirectExchange("e2", false, true),
-    			new DirectExchange("e3", false, true)
-    	);
+    public Declarables es() {
+        return new Declarables(Arrays.asList(
+                new DirectExchange("e2", false, true),
+                new DirectExchange("e3", false, true)
+        ));
     }
 
     @Bean
-    public List<Queue> qs() {
-    	return Arrays.asList(
-    			new Queue("q2", false, false, true),
-    			new Queue("q3", false, false, true)
-    	);
+    public Declarables qs() {
+        return new Declarables(Arrays.asList(
+                new Queue("q2", false, false, true),
+                new Queue("q3", false, false, true)
+        ));
     }
 
     @Bean
-    public List<Binding> bs() {
-    	return Arrays.asList(
-    			new Binding("q2", DestinationType.QUEUE, "e2", "k2", null),
-    			new Binding("q3", DestinationType.QUEUE, "e3", "k3", null)
-    	);
+    public Declarables bs() {
+        return new Declarables(Arrays.asList(
+                new Binding("q2", DestinationType.QUEUE, "e2", "k2", null),
+                new Binding("q3", DestinationType.QUEUE, "e3", "k3", null)
+        ));
     }
 
     @Bean
-    public List<Declarable> ds() {
-    	return Arrays.<Declarable>asList(
-    			new DirectExchange("e4", false, true),
-    			new Queue("q4", false, false, true),
-    			new Binding("q4", DestinationType.QUEUE, "e4", "k4", null)
-    	);
+    public Declarables ds() {
+        return new Declarables(Arrays.asList(
+                new DirectExchange("e4", false, true),
+                new Queue("q4", false, false, true),
+                new Binding("q4", DestinationType.QUEUE, "e4", "k4", null)
+        ));
     }
 
 }
 -----
-
-IMPORTANT: This feature can cause undesirable side effects in some cases, because the admin has to iterate over all `Collection<?>` beans.
-Starting with _versions 1.7.7, 2.0.4_, this feature can be disabled by setting the admin property `declareCollections` to `false`.
 
 [[conditional-declaration]]
 ===== Conditional Declaration

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3818,35 +3818,37 @@ public static class Config {
 
     @Bean
     public Declarables es() {
-        return new Declarables(Arrays.asList(
+        return new Declarables(
                 new DirectExchange("e2", false, true),
-                new DirectExchange("e3", false, true)
-        ));
+                new DirectExchange("e3", false, true));
     }
 
     @Bean
     public Declarables qs() {
-        return new Declarables(Arrays.asList(
+        return new Declarables(
                 new Queue("q2", false, false, true),
-                new Queue("q3", false, false, true)
-        ));
+                new Queue("q3", false, false, true));
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public Declarables prototypes() {
+        return new Declarables(new Queue(this.prototypeQueueName, false, false, true));
     }
 
     @Bean
     public Declarables bs() {
-        return new Declarables(Arrays.asList(
+        return new Declarables(
                 new Binding("q2", DestinationType.QUEUE, "e2", "k2", null),
-                new Binding("q3", DestinationType.QUEUE, "e3", "k3", null)
-        ));
+                new Binding("q3", DestinationType.QUEUE, "e3", "k3", null));
     }
 
     @Bean
     public Declarables ds() {
-        return new Declarables(Arrays.asList(
+        return new Declarables(
                 new DirectExchange("e4", false, true),
                 new Queue("q4", false, false, true),
-                new Binding("q4", DestinationType.QUEUE, "e4", "k4", null)
-        ));
+                new Binding("q4", DestinationType.QUEUE, "e4", "k4", null));
     }
 
 }

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -26,9 +26,15 @@ Channels enabled for publisher confirms are not returned to the cache while ther
 See <<template-confirms>> for more information.
 
 
-===== Listener Container Factory improvements
+===== Listener Container Factory Improvements
 
 The listener container factories can now be used to create any listener container, not just those for use with `@RabbitListener` s or the `@RabbitListenerEndpointRegistry`.
 See <<using-container-factories>> for more information.
 
 `ChannelAwareMessageListener` now inherits from `MesssageListener`.
+
+===== RabbitAdmin Changes
+
+The `RabbitAdmin` will discover of type `Declarables`, which is a container for `Declarable` (`Queue`, `Exchange`, `Binding`) objects, and declare the objects on the broker.
+Users are discouraged from using the old mechanism of declaring `<Collection<Queue>>` etc and should use `Declarables` beans instead.
+See <<collection-declaration>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-808

Deprecate the use of `Collection<Declarable>` in favor of a dedicated
`Declarables` container object to avoid unexpected side-effects when
getting all `Collection` beans from the application context.