### PR TITLE
@SendTo: Add property-placeholders support

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
@@ -167,7 +167,7 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 	}
 
 	private String resolve(String value) {
-		if (getResolver() != null) {
+		if (getBeanFactory() != null) {
 			value = getBeanExpressionContext().getBeanFactory().resolveEmbeddedValue(value);
 			Object newValue = getResolver().evaluate(value, getBeanExpressionContext());
 			Assert.isInstanceOf(String.class, newValue, "Invalid @SendTo expression");

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  *
  * @author Stephane Nicoll
  * @author Artem Bilan
+ *
  * @since 1.4
  */
 public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint {
@@ -167,7 +168,8 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 
 	private String resolve(String value) {
 		if (getResolver() != null) {
-			Object newValue = this.getResolver().evaluate(value, getBeanExpressionContext());
+			value = getBeanExpressionContext().getBeanFactory().resolveEmbeddedValue(value);
+			Object newValue = getResolver().evaluate(value, getBeanExpressionContext());
 			Assert.isInstanceOf(String.class, newValue, "Invalid @SendTo expression");
 			return (String) newValue;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -145,7 +145,7 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 	 * that return result objects, which will be wrapped in
 	 * a response message and sent to a response destination.
 	 * <p>
-	 * Can be a string starting with "SpEL:" in which case the expression is
+	 * It can be a string surrounded by "!{...}" in which case the expression is
 	 * evaluated at runtime; see the reference manual for more information.
 	 * @param defaultReplyTo The exchange.
 	 * @since 1.6

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
@@ -180,11 +180,12 @@ public class DelegatingInvocableHandler {
 			}
 			replyTo = destinations.length == 1 ? resolve(destinations[0]) : null;
 		}
-		return this.beanExpressionContext.getBeanFactory().resolveEmbeddedValue(replyTo);
+		return replyTo;
 	}
 
 	private String resolve(String value) {
 		if (this.resolver != null) {
+			value = this.beanExpressionContext.getBeanFactory().resolveEmbeddedValue(value);
 			Object newValue = this.resolver.evaluate(value, this.beanExpressionContext);
 			Assert.isInstanceOf(String.class, newValue, "Invalid @SendTo expression");
 			return (String) newValue;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
@@ -51,6 +51,7 @@ import org.springframework.util.Assert;
  * Matches must be unambiguous.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 1.5
  *
@@ -162,7 +163,7 @@ public class DelegatingInvocableHandler {
 		}
 		if (replyTo == null) {
 			SendTo ann = AnnotationUtils.getAnnotation(this.bean.getClass(), SendTo.class);
-			replyTo = extractSendTo(this.getBean().getClass().getSimpleName(), ann);
+			replyTo = extractSendTo(getBean().getClass().getSimpleName(), ann);
 		}
 		if (replyTo != null) {
 			this.handlerSendTo.put(handler, PARSER.parseExpression(replyTo, PARSER_CONTEXT));
@@ -179,7 +180,7 @@ public class DelegatingInvocableHandler {
 			}
 			replyTo = destinations.length == 1 ? resolve(destinations[0]) : null;
 		}
-		return replyTo;
+		return this.beanExpressionContext.getBeanFactory().resolveEmbeddedValue(replyTo);
 	}
 
 	private String resolve(String value) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -957,7 +957,7 @@ public class EnableRabbitIntegrationTests {
 		}
 
 		@RabbitListener(queues = "test.sendTo")
-		@SendTo("test.sendTo.reply")
+		@SendTo("${foo.bar:test.sendTo.reply}")
 		public String capitalizeAndSendTo(String foo) {
 			return foo.toUpperCase();
 		}
@@ -1552,7 +1552,7 @@ public class EnableRabbitIntegrationTests {
 	static class MultiListenerBean {
 
 		@RabbitHandler
-		@SendTo("#{sendToRepliesBean}")
+		@SendTo("${foo.bar:#{sendToRepliesBean}}")
 		public String bar(@NonNull Bar bar) {
 			return "BAR: " + bar.field;
 		}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2235,8 +2235,6 @@ public OrderStatus processOrder(Order order) {
 }
 ----
 
-NOTE: Starting with version 2.0.6, the `@SendTo` value can be as a property placeholder, e.g. `@SendTo("${some.reply.queue.name}")`.
-
 If you need to set additional headers in a transport-independent manner, you could return a `Message` instead, something like:
 
 [source,java]
@@ -2324,6 +2322,20 @@ In summary, `#{...}` is evaluated once during initialization, with the `#root` o
 beans are referenced by their names.
 `!{...}` is evaluated at runtime for each message with the root object having the properties above and beans are
 referenced with their names, prefixed by `@`.
+
+Starting with version 2.1, simple property placeholders are also supported `${some.reply.to}`.
+With earlier versions, the following can be used as a work around:
+====
+[source, java]
+----
+@RabbitListener(queues = "foo")
+@SendTo("#{environment['my.send.to']}")
+public String listen(Message in) {
+    ...
+    return ...
+}
+----
+====
 
 [[annotation-method-selection]]
 ====== Multi-Method Listeners

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2235,6 +2235,8 @@ public OrderStatus processOrder(Order order) {
 }
 ----
 
+NOTE: Starting with version 2.0.6, the `@SendTo` value can be as a property placeholder, e.g. `@SendTo("${some.reply.queue.name}")`.
+
 If you need to set additional headers in a transport-independent manner, you could return a `Message` instead, something like:
 
 [source,java]


### PR DESCRIPTION
Add property-placeholders resolution for the `@SendTo` processors for
consistency with all other Spring AMQP annotations support

External request on the matter: https://stackoverflow.com/questions/51620793/use-property-placeholder-with-spring-amqp-sendto-annotation