### PR TITLE
Upgrade/Fix config for asciidoctor plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'io.spring.gradle:docbook-reference-plugin:0.3.1'
-		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
+		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.8'
 		classpath 'me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 		classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
@@ -339,16 +339,16 @@ asciidoctor {
 	logDocuments = true
 	options = [
 		doctype: 'book',
-		attributes: [
-			docinfo: '',
-			toc2: '',
-			'compat-mode': '',
-			imagesdir: '',
-			stylesdir: "stylesheets/",
-			stylesheet: 'golo.css',
-			'spring-amqp-version': "$version",
-			'source-highlighter': 'highlightjs'
-		]
+	]
+	attributes = [
+		docinfo: '',
+		toc2: '',
+		'compat-mode': '',
+		imagesdir: '',
+		stylesdir: "stylesheets/",
+		stylesheet: 'golo.css',
+		'spring-amqp-version': "$version",
+		'source-highlighter': 'highlightjs'
 	]
 }
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3012,7 +3012,8 @@ You can use it the same way as `Jackson2JsonMessageConverter`, except it support
 
 [source,xml]
 ----
-<bean id="xmlConverterWithDefaultType" class="org.springframework.amqp.support.converter.Jackson2XmlMessageConverter">
+<bean id="xmlConverterWithDefaultType"
+        class="org.springframework.amqp.support.converter.Jackson2XmlMessageConverter">
     <property name="classMapper">
         <bean class="org.springframework.amqp.support.converter.DefaultClassMapper">
             <property name="defaultType" value="foo.PurchaseOrder"/>
@@ -4769,8 +4770,11 @@ You can also use a properties bean to set the property globally for all containe
 
 [source,xml]
 ----
-<util:properties id="spring.amqp.global.properties">
-    <prop key="mlc.missing.queues.fatal">false</prop>
+<util:properties
+        id="spring.amqp.global.properties">
+    <prop key="mlc.missing.queues.fatal">
+        false
+    </prop>
 </util:properties>
 ----
 
@@ -4799,11 +4803,12 @@ You can also use a properties bean to set the property globally for all containe
 
 [source,xml]
 ----
-<util:properties id="spring.amqp.global.properties">
-    <prop
-     key="mlc.possible.authentication.failure.fatal">
+<util:properties
+    id="spring.amqp.global.properties">
+  <prop
+    key="mlc.possible.authentication.failure.fatal">
      false
-    </prop>
+  </prop>
 </util:properties>
 ----
 

--- a/src/reference/asciidoc/logging.adoc
+++ b/src/reference/asciidoc/logging.adoc
@@ -78,7 +78,8 @@ Retries are delayed like: `N ^ log(N)`, where `N` is the retry number.
 | null
 | The SSL algorithm to use.
 
-| sslPropertiesLocation
+| sslProperties
+Location
 | null
 | Location of the SSL properties file.
 


### PR DESCRIPTION
Avoid:

>Attributes found in options. Existing attributes will be replaced due to assignment. Please use 'attributes' method instead as current behaviour will be removed in future

Also some minor doc fixes (PDF overflows).