### PR TITLE
Add @NonNullApi where appropriate

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJackson2MessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJackson2MessageConverter.java
@@ -26,6 +26,7 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.MimeType;
@@ -43,6 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Andreas Asplund
  * @author Artem Bilan
  * @author Mohammad Hewedy
+ * @author Gary Russell
  *
  * @since 2.1
  */
@@ -98,7 +100,7 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 	 * Message body content. If not specified, the charset will be "UTF-8".
 	 * @param defaultCharset The default charset.
 	 */
-	public void setDefaultCharset(String defaultCharset) {
+	public void setDefaultCharset(@Nullable String defaultCharset) {
 		this.defaultCharset = (defaultCharset != null) ? defaultCharset
 				: DEFAULT_CHARSET;
 	}
@@ -124,6 +126,7 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 	}
 
 	public void setJavaTypeMapper(Jackson2JavaTypeMapper javaTypeMapper) {
+		Assert.notNull(javaTypeMapper, "'javaTypeMapper' cannot be null");
 		this.javaTypeMapper = javaTypeMapper;
 		this.typeMapperSet = true;
 	}
@@ -175,7 +178,7 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 	 * @param conversionHint The conversionHint must be a {@link ParameterizedTypeReference}.
 	 */
 	@Override
-	public Object fromMessage(Message message, Object conversionHint) throws MessageConversionException {
+	public Object fromMessage(Message message, @Nullable Object conversionHint) throws MessageConversionException {
 		Object content = null;
 		MessageProperties properties = message.getMessageProperties();
 		if (properties != null) {
@@ -240,7 +243,8 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 	}
 
 	@Override
-	protected Message createMessage(Object objectToConvert, MessageProperties messageProperties, Type genericType)
+	protected Message createMessage(Object objectToConvert, MessageProperties messageProperties,
+				@Nullable Type genericType)
 			throws MessageConversionException {
 
 		byte[] bytes;

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractMessageConverter.java
@@ -59,7 +59,7 @@ public abstract class AbstractMessageConverter implements MessageConverter {
 	}
 
 	@Override
-	public final Message toMessage(Object object, MessageProperties messageProperties, @Nullable Type genericType)
+	public final Message toMessage(Object object, @Nullable MessageProperties messageProperties, @Nullable Type genericType)
 			throws MessageConversionException {
 
 		if (messageProperties == null) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultClassMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultClassMapper.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -72,6 +73,7 @@ public class DefaultClassMapper implements ClassMapper, InitializingBean {
 	 * @param defaultType the defaultType to set.
 	 */
 	public void setDefaultType(Class<?> defaultType) {
+		Assert.notNull(defaultType, "'defaultType' cannot be null");
 		this.defaultType = defaultType;
 	}
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.amqp.core.MessageProperties;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -91,7 +92,7 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 	 * @param trustedPackages the trusted Java packages for deserialization
 	 * @since 1.6.11
 	 */
-	public void setTrustedPackages(String... trustedPackages) {
+	public void setTrustedPackages(@Nullable String... trustedPackages) {
 		if (trustedPackages != null) {
 			for (String whiteListClass : trustedPackages) {
 				if ("*".equals(whiteListClass)) {
@@ -106,7 +107,7 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 	}
 
 	@Override
-	public void addTrustedPackages(String... packages) {
+	public void addTrustedPackages(@Nullable String... packages) {
 		setTrustedPackages(packages);
 	}
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MarshallingMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MarshallingMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import javax.xml.transform.stream.StreamSource;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.lang.Nullable;
 import org.springframework.oxm.Marshaller;
 import org.springframework.oxm.Unmarshaller;
 import org.springframework.oxm.XmlMappingException;
@@ -101,7 +102,7 @@ public class MarshallingMessageConverter extends AbstractMessageConverter implem
 	 *
 	 * @param contentType The content type.
 	 */
-	public void setContentType(String contentType) {
+	public void setContentType(@Nullable String contentType) {
 		this.contentType = contentType;
 	}
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/package-info.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes for supporting message conversion.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.amqp.support.converter;

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/DefaultClassMapperTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/DefaultClassMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ import org.springframework.amqp.core.MessageProperties;
 public class DefaultClassMapperTests {
 
 	@Spy
-	private DefaultClassMapper classMapper = new DefaultClassMapper();
+	private final DefaultClassMapper classMapper = new DefaultClassMapper();
 
 	private final MessageProperties props = new MessageProperties();
 
@@ -130,7 +130,7 @@ public class DefaultClassMapperTests {
 		Class<Foo> clazz = (Class<Foo>) classMapper.toClass(props);
 
 		assertSame(Foo.class, clazz);
-		classMapper.setDefaultType(null);
+		classMapper.setDefaultType(LinkedHashMap.class);
 	}
 
 	private Map<String, Class<?>> map(String string, Class<?> class1) {

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests.java
@@ -131,8 +131,6 @@ public class Jackson2JsonMessageConverterTests {
 		Message message = converter.toMessage(trade, new MessageProperties());
 
 		converter.setClassMapper(new DefaultClassMapper());
-		converter.setJavaTypeMapper(null);
-
 
 		((DefaultClassMapper) this.converter.getClassMapper()).setTrustedPackages(TRUSTED_PACKAGE);
 
@@ -146,7 +144,6 @@ public class Jackson2JsonMessageConverterTests {
 		classMapper.setTrustedPackages(TRUSTED_PACKAGE);
 
 		converter.setClassMapper(classMapper);
-		converter.setJavaTypeMapper(null);
 		Message message = converter.toMessage(trade, new MessageProperties());
 
 		SimpleTrade marshalledTrade = (SimpleTrade) converter.fromMessage(message);

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/Jackson2XmlMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/Jackson2XmlMessageConverterTests.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 /**
  * @author Mohammad Hewedy
+ * @author Gary Russell
  *
  * @since 2.1
  */
@@ -123,7 +124,6 @@ public class Jackson2XmlMessageConverterTests {
 		Message message = converter.toMessage(trade, new MessageProperties());
 
 		converter.setClassMapper(new DefaultClassMapper());
-		converter.setJavaTypeMapper(null);
 
 		((DefaultClassMapper) this.converter.getClassMapper()).setTrustedPackages(TRUSTED_PACKAGE);
 
@@ -137,7 +137,6 @@ public class Jackson2XmlMessageConverterTests {
 		classMapper.setTrustedPackages(TRUSTED_PACKAGE);
 
 		converter.setClassMapper(classMapper);
-		converter.setJavaTypeMapper(null);
 		Message message = converter.toMessage(trade, new MessageProperties());
 
 		SimpleTrade marshalledTrade = (SimpleTrade) converter.fromMessage(message);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/package-info.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes related to connections.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.amqp.rabbit.connection;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/package-info.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides core classes for Spring Rabbit.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.amqp.rabbit.core;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/package-info.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes for message listener containers.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.amqp.rabbit.listener;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/package-info.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides support classes for Spring Rabbit.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.amqp.rabbit.support;


### PR DESCRIPTION
Packages with `@Nullable` annotations need to have `@NonNulApi` at the package level.

There may be classes in these packages that have nullable arguments/returns that are
not currently marked as `@nullable`. These will be fixed over time. Some fixes are
included here.