### PR TITLE
AMQP-828: No Exception on normal close

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1203,7 +1203,11 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 		Delivery delivery = null;
 		RuntimeException exception = null;
 		CompletableFuture<Delivery> future = new CompletableFuture<>();
-		ShutdownListener shutdownListener = c -> future.completeExceptionally(c);
+		ShutdownListener shutdownListener = c -> {
+			if (!RabbitUtils.isNormalChannelClose(c)) {
+				future.completeExceptionally(c);
+			}
+		};
 		channel.addShutdownListener(shutdownListener);
 		ClosingRecoveryListener.addRecoveryListenerIfNecessary(channel);
 		DefaultConsumer consumer = createConsumer(queueName, channel, future,
@@ -1599,7 +1603,11 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 
 			};
 			ClosingRecoveryListener.addRecoveryListenerIfNecessary(channel);
-			ShutdownListener shutdownListener = c -> pendingReply.completeExceptionally(c);
+			ShutdownListener shutdownListener = c -> {
+				if (!RabbitUtils.isNormalChannelClose(c)) {
+					pendingReply.completeExceptionally(c);
+				}
+			};
 			channel.addShutdownListener(shutdownListener);
 			channel.basicConsume(replyTo, true, consumerTag, this.noLocalReplyConsumer, true, null, consumer);
 			Message reply = null;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-828
JIRA: https://jira.spring.io/browse/AMQP-829

When a channel is closed normally (e.g. due to a timeout), the shutdown listener
completed the future with the `ShutdownSignalException`.

2018-08-28 05:09:18,261 ERROR org.springframework.amqp.rabbit.core.RabbitTemplate [Test worker] : Consumer failed to receive message: TemplateConsumer [channel=Cached Rabbit Channel: PublisherCallbackChannelImpl: AMQChannel(amqp://guest@127.0.0.1:5672/,1), conn: Proxy@39754e71 Shared Rabbit Connection: SimpleConnection@1a81c806 [delegate=amqp://guest@127.0.0.1:5672/, localPort= 59780], consumerTag=null]
com.rabbitmq.client.ShutdownSignalException: clean channel shutdown; protocol method: #method<channel.close>(reply-code=200, reply-text=OK, class-id=0, method-id=0)

This preempts the `ConsumeOkNotReceivedException` in some tests, since the future is already complete.

**cherry-pick to 1.7.x** Will submit a separate PR for master since there's another future there.