### PR TITLE
doInitialize be called twice

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1068,6 +1068,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 						+ "transactional channel. Either use a different AcknowledgeMode or make sure channelTransacted=false");
 		validateConfiguration();
 		initialize();
+		this.initialized = true;
 	}
 
 	@Override


### PR DESCRIPTION
configue AbstractMessageListenerContainer's Derived class as a Bean, and "doInitialize()" will be called twice, from **create bean -> afterPropertiesSet** and from **start -> afterPropertiesSet**