### PR TITLE
AMQP-833: DLQ and Expiry - Discard

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -514,6 +515,20 @@ public class MessageProperties implements Serializable {
 	 */
 	public void setTargetBean(Object targetBean) {
 		this.targetBean = targetBean;
+	}
+
+	/**
+	 * Return the x-death header.
+	 * @return the header.
+	 */
+	@SuppressWarnings("unchecked")
+	public List<Map<String, ?>> getXDeathHeader() {
+		try {
+			return (List<Map<String, ?>>) this.headers.get("x-death");
+		}
+		catch (Exception e) {
+			return null;
+		}
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
@@ -16,10 +16,15 @@
 
 package org.springframework.amqp.rabbit.listener;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.ImmediateAcknowledgeAmqpException;
+import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
 import org.springframework.amqp.support.converter.MessageConversionException;
 import org.springframework.messaging.MessagingException;
@@ -54,6 +59,8 @@ public class ConditionalRejectingErrorHandler implements ErrorHandler {
 
 	private final FatalExceptionStrategy exceptionStrategy;
 
+	private boolean discardFatalsWithXDeath = true;
+
 	/**
 	 * Create a handler with the {@link ConditionalRejectingErrorHandler.DefaultExceptionStrategy}.
 	 */
@@ -69,10 +76,33 @@ public class ConditionalRejectingErrorHandler implements ErrorHandler {
 		this.exceptionStrategy = exceptionStrategy;
 	}
 
+	/**
+	 * Set to false to disable the, now, default behavior of logging and discarding
+	 * messages that cause fatal exceptions and have an `x-death` header; which
+	 * usually means that the message has been republished after previously being
+	 * sent to a DLQ.
+	 * @param discardFatalsWithXDeath false to disable.
+	 * @since 2.1
+	 */
+	public void setDiscardFatalsWithXDeath(boolean discardFatalsWithXDeath) {
+		this.discardFatalsWithXDeath = discardFatalsWithXDeath;
+	}
+
 	@Override
 	public void handleError(Throwable t) {
 		log(t);
 		if (!this.causeChainContainsARADRE(t) && this.exceptionStrategy.isFatal(t)) {
+			if (this.discardFatalsWithXDeath && t instanceof ListenerExecutionFailedException) {
+				Message failed = ((ListenerExecutionFailedException) t).getFailedMessage();
+				if (failed != null) {
+					List<Map<String, ?>> xDeath = failed.getMessageProperties().getXDeathHeader();
+					if (xDeath != null && xDeath.size() > 0) {
+						this.logger.error("x-death header detected on a message with a fatal exception; "
+								+ "perhaps requeued from a DLQ? - discarding: " + failed);
+						throw new ImmediateAcknowledgeAmqpException("Fatal and x-death present");
+					}
+				}
+			}
 			throw new AmqpRejectAndDontRequeueException("Error Handler converted exception to fatal", t);
 		}
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DlqExpiryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DlqExpiryTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
+import org.springframework.amqp.support.converter.MessageConversionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+@RabbitAvailable
+@SpringJUnitConfig
+public class DlqExpiryTests {
+
+	@Autowired
+	private Config config;
+
+	@Test
+	public void testExpiredDies() throws Exception {
+		this.config.template().convertAndSend("test.expiry.main", "foo");
+		assertThat(this.config.latch.await(10, TimeUnit.SECONDS)).isTrue();
+		Thread.sleep(300);
+		assertThat(this.config.counter).isEqualTo(2);
+		this.config.admin().deleteQueue("test.expiry.dlq");
+	}
+
+	@Configuration
+	@EnableRabbit
+	public static class Config {
+
+		private int counter;
+
+		private final CountDownLatch latch = new CountDownLatch(2);
+
+		@Bean
+		public CachingConnectionFactory ccf() {
+			return new CachingConnectionFactory(RabbitAvailableCondition.getBrokerRunning().getConnectionFactory());
+		}
+
+		@Bean
+		public RabbitAdmin admin() {
+			return new RabbitAdmin(ccf());
+		}
+
+		@Bean
+		public RabbitTemplate template() {
+			return new RabbitTemplate(ccf());
+		}
+
+		@Bean
+		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() {
+			SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+			factory.setConnectionFactory(ccf());
+			return factory;
+		}
+
+		@Bean
+		public Queue main() {
+			return QueueBuilder.nonDurable("test.expiry.main").autoDelete()
+					.withArgument("x-dead-letter-exchange", "")
+					.withArgument("x-dead-letter-routing-key", "test.expiry.dlq")
+					.build();
+		}
+
+		@Bean
+		public Queue dlq() {
+			return QueueBuilder.nonDurable("test.expiry.dlq").autoDelete()
+					.withArgument("x-dead-letter-exchange", "")
+					.withArgument("x-dead-letter-routing-key", "test.expiry.main")
+					.withArgument("x-message-ttl", 100)
+					.build();
+		}
+
+		@RabbitListener(queues = "test.expiry.main")
+		public void listen(Message in) {
+			this.latch.countDown();
+			this.counter++;
+			throw new MessageConversionException("test.expiry");
+		}
+
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ErrorHandlerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ErrorHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,11 +54,11 @@ public class ErrorHandlerTests {
 		willDoNothing().given(logger).warn(anyString(), any(Throwable.class));
 		new DirectFieldAccessor(handler).setPropertyValue("logger", logger);
 		handler.handleError(new ListenerExecutionFailedException("intended", new RuntimeException(),
-				mock(org.springframework.amqp.core.Message.class)));
+				new org.springframework.amqp.core.Message("".getBytes(), new MessageProperties())));
 
 		try {
 			handler.handleError(new ListenerExecutionFailedException("intended", new MessageConversionException(""),
-					mock(org.springframework.amqp.core.Message.class)));
+					new org.springframework.amqp.core.Message("".getBytes(), new MessageProperties())));
 			fail("Expected exception");
 		}
 		catch (AmqpRejectAndDontRequeueException e) {
@@ -67,7 +67,7 @@ public class ErrorHandlerTests {
 		try {
 			handler.handleError(new ListenerExecutionFailedException("intended",
 					new org.springframework.messaging.converter.MessageConversionException(""),
-					mock(org.springframework.amqp.core.Message.class)));
+					new org.springframework.amqp.core.Message("".getBytes(), new MessageProperties())));
 			fail("Expected exception");
 		}
 		catch (AmqpRejectAndDontRequeueException e) {
@@ -78,7 +78,7 @@ public class ErrorHandlerTests {
 		try {
 			handler.handleError(new ListenerExecutionFailedException("intended",
 					new MethodArgumentNotValidException(message, mp),
-					mock(org.springframework.amqp.core.Message.class)));
+					new org.springframework.amqp.core.Message("".getBytes(), new MessageProperties())));
 			fail("Expected exception");
 		}
 		catch (AmqpRejectAndDontRequeueException e) {
@@ -87,7 +87,7 @@ public class ErrorHandlerTests {
 		try {
 			handler.handleError(new ListenerExecutionFailedException("intended",
 					new MethodArgumentTypeMismatchException(message, mp, ""),
-					mock(org.springframework.amqp.core.Message.class)));
+					new org.springframework.amqp.core.Message("".getBytes(), new MessageProperties())));
 			fail("Expected exception");
 		}
 		catch (AmqpRejectAndDontRequeueException e) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -51,6 +51,7 @@ import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageBuilder;
 import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
@@ -264,7 +265,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		container.stop();
 
 		Exception e = new ListenerExecutionFailedException("foo", new MessageConversionException("bar"),
-				mock(Message.class));
+				new Message("".getBytes(), new MessageProperties()));
 		try {
 			eh.handleError(e);
 			fail("expected exception");

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4280,6 +4280,10 @@ The default `FatalExceptionStrategy` logs a warning message when an exception is
 
 Since _version 1.6.3_ a convenient way to add user exceptions to the fatal list is to subclass `ConditionalRejectingErrorHandler.DefaultExceptionStrategy` and override the method `isUserCauseFatal(Throwable cause)` to return true for fatal exceptions.
 
+A common pattern for handling DLQ messages is to set a time-to-live on those messages as well as additional DLQ configuration such that these messages expire and are routed back to the main queue for retry.
+The problem with this technique is that messages that cause fatal exceptions will loop forever.
+Starting with version 2.1, the the `ConditionalRejectingErrorHandler` detects an `x-death` header on a message that causes a fatal exception to be thrown, the message will be logged and discarded.
+
 [[transactions]]
 ==== Transactions
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -74,3 +74,8 @@ See <<async-return>> for more information.
 ===== Connection Factory Bean Changes
 
 The `RabbitConnectionFactoryBean` now calls `enableHostnameVerification()` by default; to revert to the previous behavior, set the `enabaleHostnameVerification` property to `false`.
+
+===== Listener Container Changes
+
+The default `ConditionalRejectingErrorHandler` will now completely discard messages that cause fatal errors if an `x-death` header is present.
+See <<>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-833

A common pattern is to add time-to-live to a DLQ and route
expired messages back to the main queue.

If a message fails with a fatal exception, such messages will
cycle around for ever; the application has no mechanism to
look at the `x-death` header.

Add logic to the `ConditionalRejectingErrorHandler` to look for
an `x-death` header and discard the message completely by throwing
an `ImmediateAcknowledgeAmqpException`.

Add a property to the error handler to revert to the previous
behavior.