### PR TITLE
GH-777: declareCollections to false by default

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitAdmin.java
@@ -125,7 +125,7 @@ public class RabbitAdmin implements AmqpAdmin, ApplicationContextAware, Applicat
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
-	private boolean declareCollections = true;
+	private boolean declareCollections = false;
 
 	private TaskExecutor taskExecutor = new SimpleAsyncTaskExecutor();
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3968,6 +3968,11 @@ public static class Config {
 }
 -----
 
+IMPORTANT: In versions prior to 2.1, you could declare multiple `Declarable` s by defining beans of type `Collection<Declarable>`.
+This can cause undesirable side effects in some cases, because the admin has to iterate over all `Collection<?>` beans.
+This feature is now disabled in favor of `Declarables` as discussed above.
+You can revert to the previous behavior by setting the `RabbitAdmin` property `declareCollections` to `true`.
+
 [[conditional-declaration]]
 ===== Conditional Declaration
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -40,6 +40,7 @@ See <<broker-events>> for more information.
 
 The `RabbitAdmin` will discover beans of type `Declarables` (which is a container for `Declarable` - `Queue`, `Exchange`, `Binding` objects) and declare the contained objects on the broker.
 Users are discouraged from using the old mechanism of declaring `<Collection<Queue>>` etc and should use `Declarables` beans instead.
+By default, the old mechanism is disabled.
 See <<collection-declaration>> for more information.
 
 ===== RabbitTemplate Changes


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/777

Disable declaring collections by default now that `Declarables` is supported.
This is so that Boot 2.1 apps will not have issues without additional configuration
of the `RabbitAdmin`.