### PR TITLE
Close auto-recovering connection

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -467,6 +467,26 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 			}
 
 			Connection connection = new SimpleConnection(rabbitConnection, this.closeTimeout);
+			if (rabbitConnection instanceof AutorecoveringConnection) {
+				((AutorecoveringConnection) rabbitConnection).addRecoveryListener(new RecoveryListener() {
+
+					@Override
+					public void handleRecoveryStarted(Recoverable recoverable) {
+						handleRecovery(recoverable);
+					}
+
+					@Override
+					public void handleRecovery(Recoverable recoverable) {
+						try {
+							connection.close();
+						}
+						catch (Exception e) {
+							AbstractConnectionFactory.this.logger.error("Failed to close auto-recover connection", e);
+						}
+					}
+
+				});
+			}
 			if (this.logger.isInfoEnabled()) {
 				this.logger.info("Created new connection: " + connectionName + "/" + connection);
 			}


### PR DESCRIPTION
When a connection is auto-recovered, the `RabbitAdmin` is not
invoked to re-declare auto-delete queues because the connection
listeners are not invoked.

Close an auto-recovered connection before it is recovered.

Tested with a stand-alone spring-cloud-bus application.

**Cherry-pick to 2.0.x, 1.7.x**