### PR TITLE
AMQP-813: Requeue after retry exhausted option

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/ImmediateRequeueAmqpException.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/ImmediateRequeueAmqpException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp;
+
+/**
+ * The special {@link AmqpException} to be thrown from the listener (e.g. retry recoverer callback)
+ * to {@code requeue) failed message.
+ *
+ * @author Artem Bilan
+ *
+ * @since 2.1
+ */
+@SuppressWarnings("serial")
+public class ImmediateRequeueAmqpException extends AmqpException {
+
+	public ImmediateRequeueAmqpException(String message) {
+		super(message);
+	}
+
+	public ImmediateRequeueAmqpException(Throwable cause) {
+		super(cause);
+	}
+
+	public ImmediateRequeueAmqpException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ContainerUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ContainerUtils.java
@@ -19,11 +19,13 @@ package org.springframework.amqp.rabbit.listener;
 import org.apache.commons.logging.Log;
 
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.ImmediateRequeueAmqpException;
 
 /**
  * Utility methods for listener containers.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 2.1
  *
@@ -45,7 +47,8 @@ public final class ContainerUtils {
 	 */
 	public static boolean shouldRequeue(boolean defaultRequeueRejected, Throwable throwable, Log logger) {
 		boolean shouldRequeue = defaultRequeueRejected ||
-				throwable instanceof MessageRejectedWhileStoppingException;
+				throwable instanceof MessageRejectedWhileStoppingException ||
+				throwable instanceof ImmediateRequeueAmqpException;
 		Throwable t = throwable;
 		while (shouldRequeue && t != null) {
 			if (t instanceof AmqpRejectAndDontRequeueException) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/ImmediateRequeueMessageRecoverer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/ImmediateRequeueMessageRecoverer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.retry;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.amqp.ImmediateRequeueAmqpException;
+import org.springframework.amqp.core.Message;
+
+/**
+ * The {@link MessageRecoverer} implementation to throw an {@link ImmediateRequeueAmqpException}
+ * for subsequent requeuing in the listener container.
+ *
+ * @author Artem Bilan
+ *
+ * @since 2.1
+ */
+public class ImmediateRequeueMessageRecoverer implements MessageRecoverer {
+
+	protected Log logger = LogFactory.getLog(ImmediateRequeueMessageRecoverer.class);
+
+	@Override
+	public void recover(Message message, Throwable cause) {
+		if (this.logger.isWarnEnabled()) {
+			this.logger.warn("Retries exhausted for message " + message + "; requeuing...", cause);
+		}
+		throw new ImmediateRequeueAmqpException(cause);
+	}
+
+}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -5231,6 +5231,8 @@ RepublishMessageRecoverer recoverer = new RepublishMessageRecoverer(amqpTemplate
 };
 ----
 
+Starting with version 2.1, an `ImmediateRequeueMessageRecoverer` is  added to throw an `ImmediateRequeueAmqpException` which notifies a listener container to requeue the current failed message.
+
 ===== Exception Classification for Retry
 
 Spring Retry has a great deal of flexibility for determining which exceptions can invoke retry.

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4256,21 +4256,16 @@ For example, there are a lot of cases where IOExceptions may be thrown.
 The RabbitTemplate, SimpleMessageListenerContainer, and other Spring AMQP components will catch those Exceptions and convert into one of the Exceptions within our runtime hierarchy.
 Those are defined in the 'org.springframework.amqp' package, and AmqpException is the base of the hierarchy.
 
-When a listener throws an exception, it is wrapped in a `ListenerExecutionFailedException` and, normally the message is
-rejected and requeued by the broker.
+When a listener throws an exception, it is wrapped in a `ListenerExecutionFailedException` and, normally the message is rejected and requeued by the broker.
 Setting `defaultRequeueRejected` to false will cause messages to be discarded (or routed to a dead letter exchange).
-As discussed in <<async-listeners>>, the listener can throw an `AmqpRejectAndDontRequeueException` to conditionally
-control this behavior.
+As discussed in <<async-listeners>>, the listener can throw an `AmqpRejectAndDontRequeueException` (or `ImmediateRequeueAmqpException`) to conditionally control this behavior.
 
 However, there is a class of errors where the listener cannot control the behavior.
-When a message that cannot be converted is encountered (for example an invalid `content_encoding` header), some
-exceptions are thrown before the message reaches user code.
-With `defaultRequeueRejected` set to `true` (default), such messages would be redelivered over and over.
-Before _version 1.3.2_, users needed to write a custom `ErrorHandler`, as discussed in <<exception-handling>> to avoid
-this situation.
+When a message that cannot be converted is encountered (for example an invalid `content_encoding` header), some exceptions are thrown before the message reaches user code.
+With `defaultRequeueRejected` set to `true` (default) (or throwing an `ImmediateRequeueAmqpException`), such messages would be redelivered over and over.
+Before _version 1.3.2_, users needed to write a custom `ErrorHandler`, as discussed in <<exception-handling>> to avoid this situation.
 
-Starting with _version 1.3.2_, the default `ErrorHandler` is now a `ConditionalRejectingErrorHandler` which will reject
-(and not requeue) messages that fail with an irrecoverable error:
+Starting with _version 1.3.2_, the default `ErrorHandler` is now a `ConditionalRejectingErrorHandler` which will reject (and not requeue) messages that fail with an irrecoverable error:
 
 - `o.s.amqp...MessageConversionException`
 - `o.s.messaging...MessageConversionException`
@@ -4280,17 +4275,14 @@ Starting with _version 1.3.2_, the default `ErrorHandler` is now a `ConditionalR
 - `java.lang.ClassCastException`
 
 The first can be thrown when converting the incoming message payload using a `MessageConverter`.
-The second may be thrown by the conversion service if additional conversion is required when mapping to a
-`@RabbitListener` method.
+The second may be thrown by the conversion service if additional conversion is required when mapping to a `@RabbitListener` method.
 The third may be thrown if validation (e.g. `@Valid`) is used in the listener and the validation fails.
 The fourth may be thrown if the inbound message was converted to a type that is not correct for the target method.
 For example, the parameter is declared as `Message<Foo>` but `Message<Bar>` is received.
 
 The fifth and sixth were added in _version 1.6.3_.
 
-An instance of this error handler can be configured with a `FatalExceptionStrategy` so users can provide their own rules
-for conditional message rejection, e.g.
-a delegate implementation to the `BinaryExceptionClassifier` from Spring Retry (<<async-listeners>>).
+An instance of this error handler can be configured with a `FatalExceptionStrategy` so users can provide their own rules for conditional message rejection, e.g. a delegate implementation to the `BinaryExceptionClassifier` from Spring Retry (<<async-listeners>>).
 In addition, the `ListenerExecutionFailedException` now has a `failedMessage` property which can be used in the decision.
 If the `FatalExceptionStrategy.isFatal()` method returns `true`, the error handler throws an `AmqpRejectAndDontRequeueException`.
 The default `FatalExceptionStrategy` logs a warning message when an exception is determined to be fatal.
@@ -5187,6 +5179,8 @@ This causes all failed messages to be discarded.
 When using RabbitMQ 2.8.x or higher, this also facilitates delivering the message to a Dead Letter Exchange.
 
 Or, you can throw a `AmqpRejectAndDontRequeueException`; this prevents message requeuing, regardless of the setting of the `defaultRequeueRejected` property.
+
+Starting with version 2.1, an `ImmediateRequeueAmqpException` is introduced to perform exactly opposite logic: the message will be required regardless of the setting of the `defaultRequeueRejected` property.
 
 Often, a combination of both techniques will be used.
 Use a `StatefulRetryOperationsInterceptor` in the advice chain, with a `MessageRecoverer` that throws an `AmqpRejectAndDontRequeueException`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -55,7 +55,7 @@ See <<request-reply>> for more information.
 When returns and confirms are enabled, the correlation data, if provided, is populated with the returned message.
 See <<template-confirms>> for more information.
 
-===== Message Convertion
+===== Message Conversion
 
 A new `Jackson2XmlMessageConverter` is introduced to support converting messages from/to XML format.
 See <<Jackson2XmlMessageConverter>> for more information.
@@ -91,3 +91,10 @@ Use a separate RabbitMQ `ConnectionFactory` if you need auto recovery connection
 
 The default `ConditionalRejectingErrorHandler` will now completely discard messages that cause fatal errors if an `x-death` header is present.
 See <<exception-handling>> for more information.
+
+===== Immediate requeue
+
+A new `ImmediateRequeueAmqpException` is introduced to notify a listener container that the message has to be requeued.
+To utilize this feature a new `ImmediateRequeueMessageRecoverer` implementation is added.
+
+See <<async-listeners>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-813

* Add `ImmediateRequeueAmqpException` to let `ContainerUtils.shouldRequeue()`
to return `true` immediately and requeue the message in the container
* Add `ImmediateRequeueMessageRecoverer` to throw a mentioned above
`ImmediateRequeueAmqpException`
* Refactor `RetryInterceptorBuilder` to avoid duplicated code
* Mention changes in the Docs