### PR TITLE
GH-829: Add connection name to log apenders

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -72,6 +72,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.retry.RetryPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.StringUtils;
 
 import com.rabbitmq.client.ConnectionFactory;
 
@@ -172,6 +173,7 @@ public class AmqpAppender extends AbstractAppender {
 			@PluginAttribute("autoDelete") boolean autoDelete,
 			@PluginAttribute("contentType") String contentType,
 			@PluginAttribute("contentEncoding") String contentEncoding,
+			@PluginAttribute("connectionName") String connectionName,
 			@PluginAttribute("clientConnectionProperties") String clientConnectionProperties,
 			@PluginAttribute("async") boolean async,
 			@PluginAttribute("charset") String charset,
@@ -214,6 +216,7 @@ public class AmqpAppender extends AbstractAppender {
 		manager.autoDelete = autoDelete;
 		manager.contentType = contentType;
 		manager.contentEncoding = contentEncoding;
+		manager.connectionName = connectionName;
 		manager.clientConnectionProperties = clientConnectionProperties;
 		manager.charset = charset;
 		manager.async = async;
@@ -571,6 +574,11 @@ public class AmqpAppender extends AbstractAppender {
 		private boolean declareExchange = false;
 
 		/**
+		 * A name for the connection (appears on the RabbitMQ Admin UI).
+		 */
+		private String connectionName;
+
+		/**
 		 * Additional client connection properties to be added to the rabbit connection,
 		 * with the form {@code key:value[,key:value]...}.
 		 */
@@ -617,7 +625,10 @@ public class AmqpAppender extends AbstractAppender {
 						.withAlwaysWriteExceptions(false)
 						.withNoConsoleNoAnsi(true)
 						.build();
-				this.connectionFactory = new CachingConnectionFactory(createRabbitConnectionFactory());
+				this.connectionFactory = new CachingConnectionFactory(rabbitConnectionFactory);
+				if (StringUtils.hasText(this.connectionName)) {
+					this.connectionFactory.setConnectionNameStrategy(cf -> this.connectionName);
+				}
 				if (this.addresses != null) {
 					this.connectionFactory.setAddresses(this.addresses);
 				}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -51,6 +51,7 @@ import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.util.StringUtils;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.PatternLayout;
@@ -175,6 +176,11 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	 * RabbitMQ ConnectionFactory.
 	 */
 	private AbstractConnectionFactory connectionFactory;
+
+	/**
+	 * A name for the connection (appears on the RabbitMQ Admin UI).
+	 */
+	private String connectionName;
 
 	/**
 	 * Additional client connection properties added to the rabbit connection, with the form
@@ -570,6 +576,15 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	}
 
 	/**
+	 * Set a name for the connection which will appear on the RabbitMQ Admin UI.
+	 * @param connectionName the connection name.
+	 * @since 2.1.1
+	 */
+	public void setConnectionName(String connectionName) {
+		this.connectionName = connectionName;
+	}
+
+	/**
 	 * Set additional client connection properties to be added to the rabbit connection,
 	 * with the form {@code key:value[,key:value]...}.
 	 *
@@ -609,6 +624,9 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 			this.locationLayout.setContext(getContext());
 			this.locationLayout.start();
 			this.connectionFactory = new CachingConnectionFactory(rabbitConnectionFactory);
+			if (StringUtils.hasText(this.connectionName)) {
+				this.connectionFactory.setConnectionNameStrategy(cf -> this.connectionName);
+			}
 			if (this.addresses != null) {
 				this.connectionFactory.setAddresses(this.addresses);
 			}

--- a/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
+++ b/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
@@ -11,6 +11,7 @@
 				  applicationId="testAppId" routingKeyPattern="%X{applicationId}.%c.%p"
 				  contentType="text/plain" contentEncoding="UTF-8" generateId="true" deliveryMode="NON_PERSISTENT"
 				  charset="UTF-8"
+				  connectionName="log4j2Appender"
 				  clientConnectionProperties="foo:bar,baz:qux"
 				  async="false"
 				  senderPoolSize="3" maxSenderRetries="5"

--- a/spring-rabbit/src/test/resources/logback-test.xml
+++ b/spring-rabbit/src/test/resources/logback-test.xml
@@ -21,6 +21,7 @@
 		<durable>false</durable>
 		<deliveryMode>NON_PERSISTENT</deliveryMode>
 		<declareExchange>true</declareExchange>
+		<connectionName>logbackAppender</connectionName>
 		<clientConnectionProperties>foo:bar,baz:qux</clientConnectionProperties>
 		<foo>bar</foo>
 	</appender>


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/829

Allow setting the RabbitMQ connection name in the log appenders.