### PR TITLE
AMQP-838: Deprecate container.setMessageConverter

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
@@ -328,6 +328,7 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 		this.recoveryCallback = recoveryCallback;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public C createListenerContainer(RabbitListenerEndpoint endpoint) {
 		C instance = createContainerInstance();
@@ -339,7 +340,10 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 			instance.setErrorHandler(this.errorHandler);
 		}
 		if (this.messageConverter != null) {
-			instance.setMessageConverter(this.messageConverter);
+			endpoint.setMessageConverter(this.messageConverter);
+			if (endpoint.getMessageConverter() == null) {
+				instance.setMessageConverter(this.messageConverter);
+			}
 		}
 		if (this.acknowledgeMode != null) {
 			instance.setAcknowledgeMode(this.acknowledgeMode);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
@@ -220,6 +220,21 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 		this.errorHandler = errorHandler;
 	}
 
+	/*
+	 * Unlikely this FB is used for a RabbitListener (it's only used by the
+	 * XML parser and this property is never set). We could probably just
+	 * remove this, but deprecating, just in case.
+	 */
+	/**
+	 * Set the {@link MessageConverter} strategy for converting AMQP Messages.
+	 * @param messageConverter the message converter to use
+	 * @deprecated - this converter is not used by the container; it was only
+	 * used to configure the converter for a {@code @RabbitListener} adapter.
+	 * That is now handled differently. If you are manually creating a listener
+	 * container, the converter must be configured in a listener adapter (if
+	 * present).
+	 */
+	@Deprecated
 	public void setMessageConverter(MessageConverter messageConverter) {
 		this.messageConverter = messageConverter;
 	}
@@ -389,6 +404,7 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 		return this.container == null ? AbstractMessageListenerContainer.class : this.container.getClass();
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	protected AbstractMessageListenerContainer createInstance() throws Exception {
 		if (this.container == null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -465,12 +465,21 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	/**
 	 * Set the {@link MessageConverter} strategy for converting AMQP Messages.
 	 * @param messageConverter the message converter to use
+	 * @deprecated - this converter is not used by the container; it was only
+	 * used to configure the converter for a {@code @RabbitListener} adapter.
+	 * That is now handled differently. If you are manually creating a listener
+	 * container, the converter must be configured in a listener adapter (if
+	 * present).
 	 */
+	@Deprecated
 	public void setMessageConverter(MessageConverter messageConverter) {
+		this.logger.warn("It is preferred to configure the message converter via the endpoint. "
+				+ "See RabbitListenerEndpoint.setMessageConverter");
 		this.messageConverter = messageConverter;
 	}
 
 	@Override
+	@Deprecated
 	public MessageConverter getMessageConverter() {
 		return this.messageConverter;
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
@@ -27,6 +27,7 @@ import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -76,6 +77,8 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 	private String group;
 
 	private Boolean autoStartup;
+
+	private MessageConverter messageConverter;
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
@@ -247,6 +250,16 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 	@Override
 	public Boolean getAutoStartup() {
 		return this.autoStartup;
+	}
+
+	@Override
+	public MessageConverter getMessageConverter() {
+		return this.messageConverter;
+	}
+
+	@Override
+	public void setMessageConverter(MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
@@ -25,6 +25,7 @@ import org.springframework.context.SmartLifecycle;
  * listener container. Not meant to be implemented externally.
  *
  * @author Stephane Nicoll
+ * @author Gary Russell
  * @since 1.4
  */
 public interface MessageListenerContainer extends SmartLifecycle {
@@ -39,7 +40,13 @@ public interface MessageListenerContainer extends SmartLifecycle {
 	/**
 	 * @return the {@link MessageConverter} that can be used to
 	 * convert {@link org.springframework.amqp.core.Message}, if any.
+	 * @deprecated - this converter is not used by the container; it was only
+	 * used to configure the converter for a {@code @RabbitListener} adapter.
+	 * That is now handled differently. If you are manually creating a listener
+	 * container, the converter must be configured in a listener adapter (if
+	 * present).
 	 */
+	@Deprecated
 	MessageConverter getMessageConverter();
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpoint.java
@@ -111,6 +111,7 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 		return this.messageHandlerMethodFactory;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	protected MessagingMessageListenerAdapter createMessageListener(MessageListenerContainer container) {
 		Assert.state(this.messageHandlerMethodFactory != null,
@@ -121,7 +122,10 @@ public class MethodRabbitListenerEndpoint extends AbstractRabbitListenerEndpoint
 		if (replyToAddress != null) {
 			messageListener.setResponseAddress(replyToAddress);
 		}
-		MessageConverter messageConverter = container.getMessageConverter();
+		MessageConverter messageConverter = getMessageConverter();
+		if (messageConverter == null) {
+			messageConverter = container.getMessageConverter();
+		}
 		if (messageConverter != null) {
 			messageListener.setMessageConverter(messageConverter);
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.amqp.rabbit.listener;
 
+import org.springframework.amqp.support.converter.MessageConverter;
 
 /**
  * Model for a Rabbit listener endpoint. Can be used against a
@@ -66,5 +67,28 @@ public interface RabbitListenerEndpoint {
 	 * @param listenerContainer the listener container to configure
 	 */
 	void setupListenerContainer(MessageListenerContainer listenerContainer);
+
+	/**
+	 * The preferred way for a container factory to pass a message converter
+	 * to the endpoint's adapter.
+	 * @param converter the converter.
+	 * @since 2.0.8
+	 */
+	default void setMessageConverter(MessageConverter converter) {
+		// NOSONAR
+	}
+
+	/**
+	 * Used by the container factory to check if this endpoint supports the
+	 * preferred way for a container factory to pass a message converter
+	 * to the endpoint's adapter. If null is returned, the factory will
+	 * fall back to the legacy method of passing the converter via the
+	 * container.
+	 * @return the converter.
+	 * @since 2.0.8
+	 */
+	default MessageConverter getMessageConverter() {
+		return null;
+	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MessageListenerTestContainer.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/MessageListenerTestContainer.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.InitializingBean;
 
 /**
  * @author Stephane Nicoll
+ * @author Gary Russell
  */
 public class MessageListenerTestContainer
 		implements MessageListenerContainer, InitializingBean, DisposableBean {
@@ -100,6 +101,7 @@ public class MessageListenerTestContainer
 	}
 
 	@Override
+	@Deprecated
 	public MessageConverter getMessageConverter() {
 		return null;
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import org.springframework.amqp.core.AcknowledgeMode;
-import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
@@ -51,6 +50,7 @@ import org.springframework.util.backoff.ExponentialBackOff;
  * @author Stephane Nicoll
  * @author Artem Bilan
  * @author Joris Kuipers
+ * @author Gary Russell
  *
  */
 public class RabbitListenerContainerFactoryTests {
@@ -68,7 +68,7 @@ public class RabbitListenerContainerFactoryTests {
 
 	private final MessageConverter messageConverter = new SimpleMessageConverter();
 
-	private final MessageListener messageListener = new MessageListenerAdapter();
+	private final MessageListenerAdapter messageListener = new MessageListenerAdapter();
 
 	@Test
 	public void createSimpleContainer() {
@@ -200,7 +200,7 @@ public class RabbitListenerContainerFactoryTests {
 	private void setBasicConfig(AbstractRabbitListenerContainerFactory<?> factory) {
 		factory.setConnectionFactory(this.connectionFactory);
 		factory.setErrorHandler(this.errorHandler);
-		factory.setMessageConverter(this.messageConverter);
+		this.messageListener.setMessageConverter(this.messageConverter);
 		factory.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 		factory.setChannelTransacted(true);
 		factory.setAutoStartup(false);
@@ -211,7 +211,7 @@ public class RabbitListenerContainerFactoryTests {
 		DirectFieldAccessor fieldAccessor = new DirectFieldAccessor(container);
 		assertSame(connectionFactory, container.getConnectionFactory());
 		assertSame(errorHandler, fieldAccessor.getPropertyValue("errorHandler"));
-		assertSame(messageConverter, container.getMessageConverter());
+		assertSame(messageConverter, fieldAccessor.getPropertyValue("messageListener.messageConverter"));
 		assertEquals(AcknowledgeMode.MANUAL, container.getAcknowledgeMode());
 		assertEquals(true, container.isChannelTransacted());
 		assertEquals(false, container.isAutoStartup());


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-838

The `setMessageConverter()` on the listener container was only used
to convey the converter from the container factory to the listener
adapter. This is confusing to users hand-wiring a container since
there is an implication it is used by the container itself.

Deprecate the method, and use the endpoint (by default) to convey
the converter to the endpoint's adapter.

**cherry-pick to 2.0.x**