### PR TITLE
GH-846: Fix send and receive with confirms

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1769,8 +1769,11 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 		}
 		ChannelHolder channelHolder = container.getChannelHolder();
 		try {
-			return doSendAndReceiveAsListener(exchange, routingKey, message, correlationData,
-					channelHolder.getChannel());
+			Channel channel = channelHolder.getChannel();
+			if (this.confirmsOrReturnsCapable) {
+				addListener(channel);
+			}
+			return doSendAndReceiveAsListener(exchange, routingKey, message, correlationData, channel);
 		}
 		catch (Exception e) {
 			container.releaseConsumerFor(channelHolder, false, null);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/846

Send and receive with a direct container (the default) fails on the second
operation because the remplate is not registered as a listener with the
callback channel.

`doSendAndReceiveWithDirect` does not invoke `doSendAndReceiveAsListener`
within `execute` because the channel is obtained from the container.

The first send and receive succeeds because `execute` is invoked once in the
`useDirectReplyTo` which determines whether the broker supports direct
reply-to.

`addListener()` is called from `execute()` after a channel has been received
from the cache.

Fix is to call `addListener()` from `doSendAndReceiveWithDirect`.

**cherry-pick to 2.0.x**