### PR TITLE
AMQP-846 Polishing

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -509,12 +509,12 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	 * @param adviceChain the advice chain to set
 	 */
 	public void setAdviceChain(Advice... adviceChain) {
+		Assert.notNull(adviceChain, "'adviceChain' cannot be null");
 		this.adviceChain = Arrays.copyOf(adviceChain, adviceChain.length);
 	}
 
-	@Nullable
 	protected Advice[] getAdviceChain() {
-		return this.adviceChain == null ? null : Arrays.copyOf(this.adviceChain, this.adviceChain.length);
+		return this.adviceChain; // NOSONAR direct access
 	}
 
 	/**
@@ -1122,7 +1122,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	}
 
 	protected void initializeProxy(Object delegate) {
-		if (this.getAdviceChain().length == 0) {
+		if (getAdviceChain().length == 0) {
 			return;
 		}
 		ProxyFactory factory = new ProxyFactory();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-846

Sonar detected a new potential NPE after the change.
Revert the container change; the problem really only existed in
the container factory.

Also, the getter on the container itself is protected, so it's
ok to return a hard reference to the array.