### PR TITLE
AMQP-847: Close channel in RabbitTemplate.receive

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -137,6 +137,7 @@ import com.rabbitmq.client.ShutdownListener;
  * @author Artem Bilan
  * @author Ernest Sadykov
  * @author Mark Norkin
+ *
  * @since 1.0
  */
 public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, RabbitOperations, MessageListener,
@@ -1269,7 +1270,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			Thread.currentThread().interrupt();
 		}
 		catch (TimeoutException e) {
-			// no result in time
+			RabbitUtils.setPhysicalCloseRequired(channel, true);
 		}
 		finally {
 			if (!(exception instanceof ConsumerCancelledException) && channel.isOpen()) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -48,6 +48,7 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
@@ -395,6 +396,14 @@ public class RabbitTemplateIntegrationTests {
 		catch (ConsumeOkNotReceivedException e) {
 			// we're expecting no result, this could happen, depending on timing.
 		}
+	}
+
+	@Test
+	public void testReceiveTimeoutRequeue() {
+		assertNull(this.template.receiveAndConvert(ROUTE, 1));
+		assertEquals(0,
+				TestUtils.getPropertyValue(this.connectionFactory, "cachedChannelsNonTransactional", List.class)
+						.size());
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-847

To avoid unacked messages race condition when client timeouts, but at
this moment the message becomes available in queue, physically close
a receive channel on the `TimeoutException` from the `Future.get()`

**Cherry-pick to 2.0.x & 1.7.x**