### PR TITLE
AMQP-848: RT with DRTMLC - always release consumer

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1797,8 +1797,10 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 			return doSendAndReceiveAsListener(exchange, routingKey, message, correlationData, channel);
 		}
 		catch (Exception e) {
-			container.releaseConsumerFor(channelHolder, false, null);
 			throw RabbitExceptionTranslator.convertRabbitAccessException(e);
+		}
+		finally {
+			container.releaseConsumerFor(channelHolder, false, null);
 		}
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -157,7 +157,7 @@ public class RabbitTemplateIntegrationTests {
 
 	private static final Log logger = LogFactory.getLog(RabbitTemplateIntegrationTests.class);
 
-	private static final String ROUTE = "test.queue";
+	protected static final String ROUTE = "test.queue";
 
 	private static final Queue REPLY_QUEUE = new Queue("test.reply.queue");
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3328,6 +3328,7 @@ The following are examples of how to manually wire up the beans.
     <property name="routingKey" value="foo" />
     <property name="replyQueue" ref="replyQ" />
     <property name="replyTimeout" value="600000" />
+    <property name="useDirectReplyToContainer" value="false" />
 </bean>
 
 <bean class="org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer">
@@ -3347,6 +3348,7 @@ The following are examples of how to manually wire up the beans.
         rabbitTemplate.setMessageConverter(msgConv());
         rabbitTemplate.setReplyQueue(replyQueue());
         rabbitTemplate.setReplyTimeout(60000);
+        rabbitTemplate.setUseDirectReplyToContainer(false);
         return rabbitTemplate;
     }
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/AMQP-848

When using a `DirectReplyToMessageListenerContainer` the consumer was released
for reuse after a normal `onMessage` or if an exception is thrown.

Neither of these occur when the reply times out.

Move the release to a `finally` block - it is idempotent so won't affect the
normal `onMessage` case.

**cherry-pick to 2.0.x**