### PR TITLE
GH-865: Restart DirMLC for any consume exception

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -660,7 +660,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		catch (AmqpApplicationContextClosedException e) {
 			throw new AmqpConnectException(e);
 		}
-		catch (IOException | AmqpConnectException e) {
+		catch (Exception e) {
 			RabbitUtils.closeChannel(channel);
 			RabbitUtils.closeConnection(connection);
 
@@ -876,7 +876,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 
 		@Override
 		public void handleDelivery(String consumerTag, Envelope envelope,
-				BasicProperties properties, byte[] body) throws IOException {
+				BasicProperties properties, byte[] body) {
 			MessageProperties messageProperties =
 					getMessagePropertiesConverter().toMessageProperties(properties, envelope, "UTF-8");
 			messageProperties.setConsumerTag(consumerTag);
@@ -939,7 +939,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			}
 		}
 
-		private void callExecuteListener(Message message, long deliveryTag) throws Exception {
+		private void callExecuteListener(Message message, long deliveryTag) {
 			boolean channelLocallyTransacted = isChannelLocallyTransacted();
 			try {
 				executeListener(getChannel(), message);


### PR DESCRIPTION
Fixes spring-projects/spring-amqp#865

**Cherry-pick to 2.0.x**