### PR TITLE
Fix race in test

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -400,7 +400,12 @@ public class RabbitTemplateIntegrationTests {
 
 	@Test
 	public void testReceiveTimeoutRequeue() {
-		assertNull(this.template.receiveAndConvert(ROUTE, 1));
+		try {
+			assertNull(this.template.receiveAndConvert(ROUTE, 10));
+		}
+		catch (ConsumeOkNotReceivedException e) {
+			// empty - race for consumeOk
+		}
 		assertEquals(0,
 				TestUtils.getPropertyValue(this.connectionFactory, "cachedChannelsNonTransactional", List.class)
 						.size());


### PR DESCRIPTION
https://build.spring.io/browse/AMQP-SONAR-2481/

With a short timeout, the consumer might not receive the `consumeOk` in time.

```
org.springframework.amqp.rabbit.core.ConsumeOkNotReceivedException: Blocking receive, consumer failed to consume: TemplateConsumer [channel=Cached Rabbit Channel: PublisherCallbackChannelImpl: AMQChannel(amqp://guest@127.0.0.1:5672/,1), conn: Proxy@374f01d1 Shared Rabbit Connection: SimpleConnection@b347172 [delegate=amqp://guest@127.0.0.1:5672/, localPort= 60288], consumerTag=amq.ctag-Ss7YrnvpFtQfF00vlzQ1qQ]
	at org.springframework.amqp.rabbit.core.RabbitTemplate.createConsumer(RabbitTemplate.java:2584)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.consumeDelivery(RabbitTemplate.java:1341)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.lambda$receive$5(RabbitTemplate.java:1155)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.invokeAction(RabbitTemplate.java:2121)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.doExecute(RabbitTemplate.java:2080)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.execute(RabbitTemplate.java:2033)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.execute(RabbitTemplate.java:2013)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.receive(RabbitTemplate.java:1154)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.receiveAndConvert(RabbitTemplate.java:1199)
	at org.springframework.amqp.rabbit.core.RabbitTemplateIntegrationTests.testReceiveTimeoutRequeue(RabbitTemplateIntegrationTests.java:403)
```

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
