### PR TITLE
GH-905: Fix @RabbitListener Thread Names

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1197,8 +1197,8 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 			if (!this.isExposeListenerChannel() && this.transactionManager != null) {
 				logger.warn("exposeListenerChannel=false is ignored when using a TransactionManager");
 			}
-			if (!this.taskExecutorSet && StringUtils.hasText(this.getBeanName())) {
-				this.taskExecutor = new SimpleAsyncTaskExecutor(this.getBeanName() + "-");
+			if (!this.taskExecutorSet && StringUtils.hasText(getListenerId())) {
+				this.taskExecutor = new SimpleAsyncTaskExecutor(getListenerId() + "-");
 				this.taskExecutorSet = true;
 			}
 			if (this.transactionManager != null && !isChannelTransacted()) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitIntegrationTests.java
@@ -240,7 +240,7 @@ public class EnableRabbitIntegrationTests {
 
 	@Test
 	public void autoDeclare() {
-		assertEquals("FOO", rabbitTemplate.convertSendAndReceive("auto.exch", "auto.rk", "foo"));
+		assertEquals("FOOthreadNamer-1", rabbitTemplate.convertSendAndReceive("auto.exch", "auto.rk", "foo"));
 		assertThat(this.myService.channelBoundOk).isTrue();
 	}
 
@@ -909,7 +909,7 @@ public class EnableRabbitIntegrationTests {
 			this.txRabbitTemplate = txRabbitTemplate;
 		}
 
-		@RabbitListener(bindings = @QueueBinding(
+		@RabbitListener(id = "threadNamer", bindings = @QueueBinding(
 				value = @Queue(value = "auto.declare", autoDelete = "true", admins = "rabbitAdmin"),
 				exchange = @Exchange(value = "auto.exch", autoDelete = "true"),
 				key = "auto.rk"), containerFactory = "txListenerContainerFactory"
@@ -918,7 +918,7 @@ public class EnableRabbitIntegrationTests {
 			this.channelBoundOk = this.txRabbitTemplate.execute(c -> {
 				return c.equals(channel);
 			});
-			return foo.toUpperCase();
+			return foo.toUpperCase() + Thread.currentThread().getName();
 		}
 
 		@RabbitListener(queuesToDeclare = @Queue(name = "${jjjj:test.simple.declare}", durable = "true"))


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/905

Default container thread names are based on the bean name. `@RabbitListener`
containers are not beans; use `getListenerId()` instead (which falls back
to bean name for other containers).

**cherry-pick to all supported branches**
