### PR TITLE
GH-914: Honor AllowBeanDefOverriding = false

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,21 +140,25 @@ subprojects { subproject ->
 	[compileJava, compileTestJava]*.options*.compilerArgs = [xLintArg]
 
 	task checkTestConfigs {
+		inputs.files(
+				sourceSets.test.java.srcDirs.collect {
+					fileTree(it)
+							.include('**/*.xml')
+							.exclude('**/log4j2-test.xml')
+				})
+		outputs.dir('build/resources')
+		
 		doLast {
-			def configFiles = []
-			sourceSets.test.allSource.srcDirs.each {
-				fileTree(it).include('**/*.xml').exclude('**/log4j.xml').each { configFile ->
-					def configXml = new XmlParser(false, false).parse(configFile)
-
-					if (configXml.@'xsi:schemaLocation' ==~ /.*spring-[a-z-]*\d\.\d\.xsd.*/) {
-						configFiles << configFile
-					}
-				}
+			def wrongConfigs = inputs.files.filter {
+				new XmlParser(false, false)
+						.parse(it)
+						.@'xsi:schemaLocation' ==~ /.*spring-[a-z-]*\d\.\d\.xsd.*/
 			}
-			if (configFiles) {
+			if (!wrongConfigs.empty) {
 				throw new InvalidUserDataException('Hardcoded XSD version in the config files:\n' +
-						configFiles.collect {relativePath(it)}.join('\n') +
-						'\nPlease, use versionless schemaLocations for Spring XSDs to avoid issues with builds on different versions of dependencies.')
+						wrongConfigs.collect { relativePath(it) }.join('\n') +
+						'\nPlease, use versionless schemaLocations for Spring XSDs to avoid issues with builds ' +
+						'on different versions of dependencies.')
 			}
 		}
 	}
@@ -162,7 +166,7 @@ subprojects { subproject ->
 	task updateCopyrights {
 		onlyIf { !System.getenv('TRAVIS') && !System.getenv('bamboo_buildKey') }
 		inputs.files(modifiedFiles.filter { f -> f.path.contains(subproject.name) })
-		outputs.dir('build')
+		outputs.dir('build/classes')
 
 		doLast {
 			def now = Calendar.instance.get(Calendar.YEAR) as String

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/ExampleRabbitListenerCaptureTest.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/ExampleRabbitListenerCaptureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.test.RabbitListenerTestHarness.InvocationData;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.handler.annotation.Header;
@@ -46,14 +47,18 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.6
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader = ExampleRabbitListenerCaptureTest.NoBeansOverrideAnnotationConfigContextLoader.class)
+@RunWith(SpringRunner.class)
 @DirtiesContext
 public class ExampleRabbitListenerCaptureTest {
 
@@ -178,5 +183,17 @@ public class ExampleRabbitListenerCaptureTest {
 		}
 
 	}
+
+
+	public static class NoBeansOverrideAnnotationConfigContextLoader extends AnnotationConfigContextLoader {
+
+		@Override
+		protected void customizeBeanFactory(DefaultListableBeanFactory beanFactory) {
+			beanFactory.setAllowBeanDefinitionOverriding(false);
+		}
+
+	}
+
+}
 
 }

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/ExampleRabbitListenerCaptureTest.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/ExampleRabbitListenerCaptureTest.java
@@ -46,7 +46,6 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
@@ -196,4 +195,3 @@ public class ExampleRabbitListenerCaptureTest {
 
 }
 
-}

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/TestRabbitTemplateTests.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/TestRabbitTemplateTests.java
@@ -23,8 +23,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -45,6 +43,8 @@ import com.rabbitmq.client.Channel;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  *
  */
@@ -87,7 +87,7 @@ public class TestRabbitTemplateTests {
 		public String smlc1In = "smlc1:";
 
 		@Bean
-		public TestRabbitTemplate template() throws IOException {
+		public TestRabbitTemplate template() {
 			return new TestRabbitTemplate(connectionFactory());
 		}
 
@@ -103,7 +103,7 @@ public class TestRabbitTemplateTests {
 		}
 
 		@Bean
-		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() throws IOException {
+		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() {
 			SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
 			factory.setConnectionFactory(connectionFactory());
 			return factory;
@@ -125,7 +125,7 @@ public class TestRabbitTemplateTests {
 		}
 
 		@Bean
-		public SimpleMessageListenerContainer smlc1() throws IOException {
+		public SimpleMessageListenerContainer smlc1() {
 			SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory());
 			container.setQueueNames("foo", "bar");
 			container.setMessageListener(new MessageListenerAdapter(new Object() {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitBootstrapConfiguration.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,37 +18,44 @@ package org.springframework.amqp.rabbit.annotation;
 
 import org.springframework.amqp.rabbit.config.RabbitListenerConfigUtils;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
-import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Role;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.type.AnnotationMetadata;
 
 /**
- * {@code @Configuration} class that registers a {@link RabbitListenerAnnotationBeanPostProcessor}
- * bean capable of processing Spring's @{@link RabbitListener} annotation. Also register
- * a default {@link RabbitListenerEndpointRegistry}.
+ * An {@link ImportBeanDefinitionRegistrar} class that registers
+ * a {@link RabbitListenerAnnotationBeanPostProcessor} bean capable of processing
+ * Spring's @{@link RabbitListener} annotation.
+ * Also register a default {@link RabbitListenerEndpointRegistry}.
  *
  * <p>This configuration class is automatically imported when using the @{@link EnableRabbit}
- * annotation.  See {@link EnableRabbit} Javadoc for complete usage.
+ * annotation.
  *
  * @author Stephane Nicoll
+ * @author Artem Bilan
+ *
  * @since 1.4
+ *
  * @see RabbitListenerAnnotationBeanPostProcessor
  * @see RabbitListenerEndpointRegistry
  * @see EnableRabbit
  */
-@Configuration
-public class RabbitBootstrapConfiguration {
+public class RabbitBootstrapConfiguration implements ImportBeanDefinitionRegistrar {
 
-	@Bean(name = RabbitListenerConfigUtils.RABBIT_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME)
-	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-	public RabbitListenerAnnotationBeanPostProcessor rabbitListenerAnnotationProcessor() {
-		return new RabbitListenerAnnotationBeanPostProcessor();
-	}
+	@Override
+	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+		if (!registry.containsBeanDefinition(
+				RabbitListenerConfigUtils.RABBIT_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME)) {
 
-	@Bean(name = RabbitListenerConfigUtils.RABBIT_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)
-	public RabbitListenerEndpointRegistry defaultRabbitListenerEndpointRegistry() {
-		return new RabbitListenerEndpointRegistry();
+			registry.registerBeanDefinition(RabbitListenerConfigUtils.RABBIT_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME,
+					new RootBeanDefinition(RabbitListenerAnnotationBeanPostProcessor.class));
+		}
+
+		if (!registry.containsBeanDefinition(RabbitListenerConfigUtils.RABBIT_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)) {
+			registry.registerBeanDefinition(RabbitListenerConfigUtils.RABBIT_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME,
+					new RootBeanDefinition(RabbitListenerEndpointRegistry.class));
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/914

* Rework `RabbitBootstrapConfiguration` into the `ImportBeanDefinitionRegistrar`
and check for bean definitions presence it is going to register.
This way an override from the `RabbitListenerTestBootstrap` is going to
have a precedence and its `RabbitListenerTestHarness` won't allow a
regular `RabbitListenerAnnotationBeanPostProcessor` to be registered
* Rework `TestRabbitTemplate` to gather all the listener container
from the `ContextRefreshedEvent` instead of the `SmartInitializingSingleton`.
Looks like Spring doesn't care about their order, therefore we need to
be sure that `RabbitListenerAnnotationBeanPostProcessor` has populated
its `registry` with containers before.
* Demonstrate that `allowBeanDefinitionOverriding = false` works well
now in the `ExampleRabbitListenerCaptureTest`
* Optimize `checkTestConfigs` and `updateCopyrights` Gradle tasks for
their `inputs` and `outputs` for better `UP-TO-DATE` handling

**Cherry-pick to 2.1.x without `build.gradle` changes**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
