### PR TITLE
Add getter for RabbitTemplate on AsyncTemplate

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -348,6 +348,15 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 		return this.template.getMessageConverter();
 	}
 
+	/**
+	 * Return the underlying RabbitTemplate used for sending.
+	 * @return the template.
+	 * @since 2.2
+	 */
+	protected RabbitTemplate getRabbitTemplateTemplate() {
+		return this.template;
+	}
+
 	@Override
 	public RabbitMessageFuture sendAndReceive(Message message) {
 		return sendAndReceive(this.template.getExchange(), this.template.getRoutingKey(), message);


### PR DESCRIPTION
For https://github.com/spring-projects/spring-integration/issues/2797

We need to access the `getUnconfirmed()` method but might as well expose
the entire template in case other situations arise.

