### PR TITLE
GH-923: Fix start delay for @Lazy @RabbitListener

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,5 +48,16 @@ public interface MessageListenerContainer extends SmartLifecycle {
 	 */
 	@Deprecated
 	MessageConverter getMessageConverter();
+
+	/**
+	 * Do not check for missing or mismatched queues during startup. Used for lazily
+	 * loaded message listener containers to avoid a deadlock when starting such
+	 * containers. Applications lazily loading containers should verify the queue
+	 * configuration before loading the container bean.
+	 * @since 2.1.5
+	 */
+	default void lazyLoad() {
+		// no-op
+	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,6 +163,9 @@ public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLife
 					this.applicationContext.getBeanFactory().registerSingleton(endpoint.getGroup(), containerGroup);
 				}
 				containerGroup.add(container);
+			}
+			if (this.contextRefreshed) {
+				container.lazyLoad();
 			}
 			if (startImmediately) {
 				startIfNecessary(container);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/LazyContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/LazyContainerTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Gary Russell
+ * @since 2.1.5
+ *
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@RabbitAvailable(queues = "test.lazy")
+public class LazyContainerTests {
+
+	@Autowired
+	private ConfigurableApplicationContext context;
+
+	@Autowired
+	private ObjectProvider<LazyListener> lazyListenerProvider;
+
+	@Autowired
+	private  RabbitTemplate rabbitTemplate;
+
+	@Test
+	void lazy() {
+		this.context.getBeanFactory().registerSingleton("clearTheByTypeCache", "foo");
+		long t1 = System.currentTimeMillis();
+		this.lazyListenerProvider.getIfAvailable();
+		assertThat(System.currentTimeMillis() - t1).isLessThan(30_000L);
+		Object reply = this.rabbitTemplate.convertSendAndReceive("test.lazy", "lazy");
+		assertThat(reply).isNotNull();
+		assertThat(reply).isEqualTo("LAZY");
+	}
+
+	@Configuration
+	@EnableRabbit
+	public static class Config {
+		@Bean
+		public CachingConnectionFactory cf() {
+			return new CachingConnectionFactory(RabbitAvailableCondition.getBrokerRunning()
+					.getConnectionFactory());
+		}
+
+		@Bean
+		public RabbitTemplate template() {
+			return new RabbitTemplate(cf());
+		}
+
+		@Bean
+		public RabbitAdmin admin() {
+			return new RabbitAdmin(template());
+		}
+
+		@Bean
+		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() {
+			SimpleRabbitListenerContainerFactory cf = new SimpleRabbitListenerContainerFactory();
+			cf.setConnectionFactory(cf());
+			return cf;
+		}
+
+		@Bean
+		public Queue queue() {
+			return new Queue("test.lazy");
+		}
+
+		@Bean
+		@Lazy
+		public LazyListener listener() {
+			return new LazyListener();
+		}
+
+		@RabbitListener(queues = "test.lazy")
+		public String listen(String in) {
+			return in.toUpperCase();
+		}
+
+	}
+
+	public static class LazyListener {
+
+		@RabbitListener(queues = "test.lazy", concurrency = "2")
+		public String listenLazily(String in) {
+			return in.toUpperCase();
+		}
+
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BrokerDeclaredQueueNameTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BrokerDeclaredQueueNameTests.java
@@ -114,12 +114,13 @@ public class BrokerDeclaredQueueNameTests {
 	}
 
 	private void testBrokerNamedQueue(AbstractMessageListenerContainer container,
-			CountDownLatch latch1, CountDownLatch latch2, Queue queue) throws Exception {
+			CountDownLatch firstLatch, CountDownLatch secondLatch, Queue queue) throws Exception {
+
 		container.start();
 		String firstActualName = queue.getActualName();
 		this.message.set(null);
 		this.template.convertAndSend(firstActualName, "foo");
-		assertThat(latch1.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(firstLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.message.get().getBody()).isEqualTo("foo".getBytes());
 		final CountDownLatch newConnectionLatch = new CountDownLatch(2);
 		this.cf.addConnectionListener(c -> newConnectionLatch.countDown());
@@ -129,7 +130,7 @@ public class BrokerDeclaredQueueNameTests {
 		assertThat(secondActualName).isNotEqualTo(firstActualName);
 		this.message.set(null);
 		this.template.convertAndSend(secondActualName, "bar");
-		assertThat(latch2.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(secondLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.message.get().getBody()).isEqualTo("bar".getBytes());
 		container.stop();
 	}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -5167,6 +5167,10 @@ This global property is not applied to any containers that have an explicit `mis
 
 The default retry properties (three retries at five-second intervals) can be overridden by setting the properties below.
 
+IMPORTANT: Missing queue detection is disabled while starting a container for a `@RabbitListener` in a bean that is marked `@Lazy`.
+This is to avoid a potential deadlock which can delay the start of such containers for up to 60 seconds.
+Applications using lazy listener beans should check the queue(s) before getting a reference to the lazy bean.
+
 a| image::images/tickmark.png[]
 a| image::images/tickmark.png[]
 
@@ -5220,6 +5224,10 @@ NOTE: If the broker is not available during initial startup, the container start
 IMPORTANT: The check is done against all queues in the context, not just the queues that a particular listener is configured to use.
 If you wish to limit the checks to just those queues used by a container, you should configure a separate `RabbitAdmin` for the container, and provide a reference to it using the `rabbitAdmin` property.
 See <<conditional-declaration>> for more information.
+
+IMPORTANT: Mismatched queue argument detection is disabled while starting a container for a `@RabbitListener` in a bean that is marked `@Lazy`.
+This is to avoid a potential deadlock which can delay the start of such containers for up to 60 seconds.
+Applications using lazy listener beans should check the queue arguments before getting a reference to the lazy bean.
 
 a| image::images/tickmark.png[]
 a| image::images/tickmark.png[]


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/923

While checking for missing or mis-matched queues, a lazily-loaded
listener container can deadlock for 60 seconds.

This occurs if the `allBeanNamesByType` cache does not currently have
an entry for `Queue` (e.g. cleared by registering a singleton).
When lazy beans are referenced, the `RabbitListenerEndpointRegistry`
starts the container and `start()` waits for the consumers to start.
Getting a reference to the lazy bean holds the `singletonObjects`
lock, which is required by the consumer(s) to get the `Queue` beans
to check.

Add a test case to demonstrate the issue.

Disable the redeclaration logic during the initial start of such a
container.

**cherry-pick to 2.1.x**

