### PR TITLE
GH-935: Handle all exceptions in handleDelivery

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -42,8 +42,10 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.Level;
 import org.junit.Rule;
@@ -302,7 +304,7 @@ public class BlockingQueueConsumerTests {
 	}
 
 	@Test
-	public void testDrainAndReject() throws IOException {
+	public void testDrainAndReject() throws IOException, TimeoutException {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		Connection connection = mock(Connection.class);
 		ChannelProxy channel = mock(ChannelProxy.class);
@@ -315,12 +317,18 @@ public class BlockingQueueConsumerTests {
 		doReturn(isOpen.get()).when(channel).isOpen();
 		when(channel.queueDeclarePassive(anyString()))
 				.then(invocation -> mock(AMQP.Queue.DeclareOk.class));
-		doAnswer(i -> {
-			((Consumer) i.getArgument(6)).handleConsumeOk("consumerTag");
+		AtomicReference<Consumer> theConsumer = new AtomicReference<>();
+		doAnswer(inv -> {
+			Consumer consumer = inv.getArgument(6);
+			consumer.handleConsumeOk("consumerTag");
+			theConsumer.set(consumer);
 			return "consumerTag";
 		}).when(channel).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
 				anyMap(), any(Consumer.class));
-
+		doAnswer(inv -> {
+			theConsumer.get().handleCancelOk("consumerTag");
+			return null;
+		}).when(channel).basicCancel("consumerTag");
 		BlockingQueueConsumer blockingQueueConsumer = new BlockingQueueConsumer(connectionFactory,
 				new DefaultMessagePropertiesConverter(), new ActiveObjectCounter<BlockingQueueConsumer>(),
 				AcknowledgeMode.AUTO, true, 2, "test");
@@ -346,9 +354,7 @@ public class BlockingQueueConsumerTests {
 		envelope = new Envelope(3, false, "foo", "bar");
 		consumer.handleDelivery("consumerTag", envelope, props, new byte[0]);
 		assertThat(TestUtils.getPropertyValue(blockingQueueConsumer, "queue", BlockingQueue.class).size(), equalTo(0));
-		verify(channel).basicNack(3, true, true);
-		verify(channel, times(2)).basicCancel("consumerTag");
+		verify(channel, times(1)).basicCancel("consumerTag");
 	}
-
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/935

- Don't call basicCancel if already canceled
- Catch all `Exception`s

**cherry-pick to all supported** (may need a separate PR, especially for 1.7.x)