### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -34,7 +34,7 @@ Signing the CLA does not grant anyone commit rights to the main repository, but 
 
 1. Go to https://github.com/spring-projects/spring-amqp[https://github.com/spring-projects/spring-amqp]
 2. Hit the "fork" button and choose your own github account as the target
-3. For more detail see http://help.github.com/fork-a-repo/[Fork A Repo].
+3. For more detail see https://help.github.com/fork-a-repo/[Fork A Repo].
 
 == Setup your Local Development Environment
 
@@ -54,7 +54,7 @@ _you should see branches on origin as well as upstream, including 'master' and '
 * _Always_ work on topic branches (Typically use the HitHub (or JIRA) issue ID as the branch name).
   - For example, to create and switch to a new branch for issue #123: `git checkout -b GH-123`
 * You might be working on several different topic branches at any given time, but when at a stopping point for one of those branches, commit (a local operation).
-* Please follow the "Commit Guidelines" described in http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project[this chapter of Pro Git].
+* Please follow the "Commit Guidelines" described in https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project[this chapter of Pro Git].
 * Then to begin working on another issue (say AMQP-101): `git checkout AMQP-101`. The _-b_ flag is not needed if that branch already exists in your local repository.
 * When ready to resolve an issue or to collaborate with others, you can push your branch to origin (your fork),
 e.g.: `git push origin GH-123`
@@ -66,7 +66,7 @@ Alternatively, they can use `git fetch --all` to sync their local state with all
 * A prerequisite for any pull request is that it will be cleanly merge-able with the upstream master's current state.
 **This is the responsibility of any contributor.**
 If your pull request cannot be applied cleanly, the project lead will most likely add a comment requesting that you make it merge-able.
-For a full explanation, see http://git-scm.com/book/en/Git-Branching-Rebasing[the Pro Git section on rebasing].
+For a full explanation, see https://git-scm.com/book/en/Git-Branching-Rebasing[the Pro Git section on rebasing].
 As stated there: _"> Often, you’ll do this to make sure your commits apply cleanly on a remote branch — perhaps in a project to which you’re trying to contribute but that you don’t maintain."_
 
 == Keeping your Local Code in Sync
@@ -80,7 +80,7 @@ As stated there: _"> Often, you’ll do this to make sure your commits apply cle
     - Then: `git pull upstream master`
     - Switch back to the topic branch: `git checkout AMQP-123` (no -b needed since the branch already exists)
     - Rebase the topic branch to minimize the distance between it and your recently synched master branch: `git rebase master`
-(Again, for more detail see http://git-scm.com/book/en/Git-Branching-Rebasing[the Pro Git section on rebasing]).
+(Again, for more detail see https://git-scm.com/book/en/Git-Branching-Rebasing[the Pro Git section on rebasing]).
 * **Note** While it is generally recommended to __not__ re-write history by using `push --force`, and we do not do this on `master` (and release) branches in the main repo, we require topic branches for pull requests to be rebased before merging, in order to maintain a clean timeline and avoid "merge" commits.
 * If, while rebasing for the merge, we find significant conflicts, we may ask you to rebase and `push --force` to your topic branch after resolving the conflicts.
 * Assuming your pull request is merged into the 'upstream' master, you will actually end up pulling that change into

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Spring AMQP [<img src="https://build.spring.io/plugins/servlet/wittified/build-status/AMQP-MASTER">](https://build.spring.io/browse/AMQP-MASTER) [![Join the chat at https://gitter.im/spring-projects/spring-amqp](https://badges.gitter.im/spring-projects/spring-amqp.svg)](https://gitter.im/spring-projects/spring-amqp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 ===========
 
-This project provides support for using Spring and Java with [AMQP 0.9.1](https://www.rabbitmq.com/amqp-0-9-1-reference.html), and in particular [RabbitMQ](http://www.rabbitmq.com/).
+This project provides support for using Spring and Java with [AMQP 0.9.1](https://www.rabbitmq.com/amqp-0-9-1-reference.html), and in particular [RabbitMQ](https://www.rabbitmq.com/).
 
 # Checking out and Building
 
-To check out the project from [GitHub](https://github.com/SpringSource/spring-amqp) and build from source using [Gradle](http://gradle.org/), do the following:
+To check out the project from [GitHub](https://github.com/SpringSource/spring-amqp) and build from source using [Gradle](https://gradle.org/), do the following:
 
 	git clone git://github.com/SpringSource/spring-amqp.git
 	cd spring-amqp
@@ -31,7 +31,7 @@ To build complete distribution including `-dist`, `-docs`, and `-schema` zip fil
 
 	./gradlew dist
 
-To analyze and gather metrics using [Sonar](http://www.sonarsource.org/):
+To analyze and gather metrics using [Sonar](https://www.sonarqube.org/):
 
 	./gradlew clean build sonar
 
@@ -52,7 +52,7 @@ Browse to the *'spring-amqp'* root directory. All projects should import free of
 
 # Using SpringSource Tool Suite™ (STS)
 
-Using the STS Gradle Support, you can directly import Gradle projects, without having to generate Eclipse metadata first (since STS 2.7.M1). Please make sure you have the Gradle STS Extension installed - Please see the [installation  instructions](http://static.springsource.org/sts/docs/latest/reference/html/gradle/installation.html) for details.
+Using the STS Gradle Support, you can directly import Gradle projects, without having to generate Eclipse metadata first (since STS 2.7.M1). Please make sure you have the Gradle STS Extension installed - Please see the [installation  instructions](https://docs.spring.io/sts/docs/latest/reference/html/gradle/installation.html) for details.
 
 1. Select *File -> Import -> Gradle Project*
 2. Browse to the Spring AMQP Root Folder
@@ -89,20 +89,20 @@ Lists of issues addressed per release can be found in [JIRA](https://jira.spring
 
 ## Additional Resources
 
-* [Spring AMQP Homepage](http://www.springsource.org/spring-amqp)
-* [Spring AMQP Source](http://github.com/SpringSource/spring-amqp)
-* [Spring AMQP Samples](http://github.com/SpringSource/spring-amqp-samples)
-* [Spring AMQP Forum](http://forum.springsource.org/forumdisplay.php?f=74)
-* [StackOverflow](http://stackoverflow.com/questions/tagged/spring-amqp)
+* [Spring AMQP Homepage](https://www.springsource.org/spring-amqp)
+* [Spring AMQP Source](https://github.com/SpringSource/spring-amqp)
+* [Spring AMQP Samples](https://github.com/SpringSource/spring-amqp-samples)
+* [Spring AMQP Forum](https://forum.spring.io/)
+* [StackOverflow](https://stackoverflow.com/questions/tagged/spring-amqp)
 
 # Contributing to Spring AMQP
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [forum](http://forum.springsource.org/forumdisplay.php?f=74) by responding to questions and joining the debate.
+* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [forum](https://forum.spring.io/) by responding to questions and joining the debate.
 * Create [JIRA](https://jira.spring.io/browse/AMQP) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://www.springsource.org/node/feed) to springframework.org
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by [subscribing](https://www.springsource.org/node/feed) to springframework.org
 
 Before we accept a non-trivial patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_committer_signup).  Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. Active contributors might be asked to join the core team, and given the ability to merge pull requests.
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/client/AmqpClientInterceptor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/client/AmqpClientInterceptor.java
@@ -84,7 +84,7 @@ public class AmqpClientInterceptor extends RemoteAccessor implements MethodInter
 	/**
 	 * The AMQP template to be used for sending messages and receiving results. This class is using "Request/Reply" for
 	 * sending messages as described <a href=
-	 * "http://static.springsource.org/spring-amqp/reference/html/amqp.html#request-reply" >in the Spring-AMQP
+	 * "https://docs.spring.io/spring-amqp/reference/html/amqp.html#request-reply" >in the Spring-AMQP
 	 * documentation</a>.
 	 *
 	 * @param amqpTemplate The amqp template.

--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/service/AmqpInvokerServiceExporter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/service/AmqpInvokerServiceExporter.java
@@ -47,7 +47,7 @@ import org.springframework.remoting.support.RemoteInvocationResult;
  *
  * <p>
  * This listener responds to "Request/Reply"-style messages as described <a href=
- * "http://static.springsource.org/spring-amqp/reference/html/amqp.html#request-reply" >here</a>.
+ * "https://docs.spring.io/spring-amqp/reference/html/amqp.html#request-reply" >here</a>.
  *
  * @author David Bilge
  * @author Gary Russell

--- a/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningTests.java
+++ b/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningTests.java
@@ -44,7 +44,7 @@ public class BrokerRunningTests {
 		brokerRunning.setPort(1234);
 		brokerRunning.setUser("fiz");
 
-		assertEquals("http://baz:15672/api/", brokerRunning.getAdminUri());
+		assertEquals("https://baz:15672/api/", brokerRunning.getAdminUri());
 		ConnectionFactory connectionFactory = brokerRunning.getConnectionFactory();
 		assertEquals("baz", connectionFactory.getHost());
 		assertEquals(1234, connectionFactory.getPort());
@@ -56,7 +56,7 @@ public class BrokerRunningTests {
 	public void testEnvironmentVars() {
 		Map<String, String> vars = new HashMap<>();
 		vars.put("RABBITMQ_TEST_ADMIN_PASSWORD", "FOO");
-		vars.put("RABBITMQ_TEST_ADMIN_URI", "http://foo/bar");
+		vars.put("RABBITMQ_TEST_ADMIN_URI", "https://foo/bar");
 		vars.put("RABBITMQ_TEST_ADMIN_USER", "BAR");
 		vars.put("RABBITMQ_TEST_HOSTNAME", "BAZ");
 		vars.put("RABBITMQ_TEST_PASSWORD", "QUX");
@@ -65,7 +65,7 @@ public class BrokerRunningTests {
 		BrokerRunning.setEnvironmentVariableOverrides(vars);
 		BrokerRunning brokerRunning = BrokerRunning.isBrokerAndManagementRunning();
 
-		assertEquals("http://foo/bar", brokerRunning.getAdminUri());
+		assertEquals("https://foo/bar", brokerRunning.getAdminUri());
 		ConnectionFactory connectionFactory = brokerRunning.getConnectionFactory();
 		assertEquals("BAZ", connectionFactory.getHost());
 		assertEquals(2345, connectionFactory.getPort());

--- a/spring-rabbit/README.adoc
+++ b/spring-rabbit/README.adoc
@@ -6,7 +6,7 @@ Many of the integration tests here require a running RabbitMQ server - they
 will be skipped if the broker is not detected.
 
 If RabbitMQ is not installed on your system, refer to the instructions for your
-particular OS here: [http://www.rabbitmq.com/install.html]
+particular OS here: [https://www.rabbitmq.com/install.html]
 
 Start the server. For example, and a *nix-based system where RabbitMQ has been
 installed within `/opt/rabbitmq`, issue the following command:

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactory.java
@@ -88,7 +88,7 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 	 * @param defaultConnectionFactory the fallback connection factory to use if the queue
 	 * can't be located.
 	 * @param nodeToAddress a Map of node to address: (rabbit@server1 : server1:5672)
-	 * @param adminUris the rabbitmq admin addresses (http://host:port, ...) must be the
+	 * @param adminUris the rabbitmq admin addresses (https://host:port, ...) must be the
 	 * same length as addresses.
 	 * @param vhost the virtual host.
 	 * @param username the user name.
@@ -107,7 +107,7 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 	/**
 	 * @param defaultConnectionFactory the fallback connection factory to use if the queue can't be located.
 	 * @param nodeToAddress a Map of node to address: (rabbit@server1 : server1:5672)
-	 * @param adminUris the rabbitmq admin addresses (http://host:port, ...) must be the same length
+	 * @param adminUris the rabbitmq admin addresses (https://host:port, ...) must be the same length
 	 * as addresses.
 	 * @param vhost the virtual host.
 	 * @param username the user name.
@@ -131,7 +131,7 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 	 * @param defaultConnectionFactory the fallback connection factory to use if the queue
 	 * can't be located.
 	 * @param addresses the rabbitmq server addresses (host:port, ...).
-	 * @param adminUris the rabbitmq admin addresses (http://host:port, ...)
+	 * @param adminUris the rabbitmq admin addresses (https://host:port, ...)
 	 * @param nodes the rabbitmq nodes corresponding to addresses (rabbit@server1, ...)
 	 * must be the same length as addresses.
 	 * @param vhost the virtual host.
@@ -151,7 +151,7 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 	/**
 	 * @param defaultConnectionFactory the fallback connection factory to use if the queue can't be located.
 	 * @param addresses the rabbitmq server addresses (host:port, ...).
-	 * @param adminUris the rabbitmq admin addresses (http://host:port, ...).
+	 * @param adminUris the rabbitmq admin addresses (https://host:port, ...).
 	 * @param nodes the rabbitmq nodes corresponding to addresses (rabbit@server1, ...)  must be the same length
 	 * as addresses.
 	 * @param vhost the virtual host.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -362,7 +362,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 	/**
 	 * An address for replies; if not provided, a temporary exclusive, auto-delete queue will
 	 * be used for each reply, unless RabbitMQ supports 'amq.rabbitmq.reply-to' - see
-	 * http://www.rabbitmq.com/direct-reply-to.html
+	 * https://www.rabbitmq.com/direct-reply-to.html
 	 * <p>The address can be a simple queue name (in which case the reply will be routed via the default
 	 * exchange), or with the form {@code exchange/routingKey} to route the reply using an explicit
 	 * exchange and routing key.

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.2.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit-2.2.xsd
@@ -1226,7 +1226,7 @@
 					<xsd:documentation><![CDATA[
 	When 'true', instructs the template to use a temporary, exclusive, auto-delete queue for
 	each 'sendAndReceive'. By default, when there is no 'reply-address', the template will
-	use Direct reply-to ('http://www.rabbitmq.com/direct-reply-to.html') when the broker supports it.
+	use Direct reply-to ('https://www.rabbitmq.com/direct-reply-to.html') when the broker supports it.
 	This flag overrides that behavior; it is ignored if a 'reply-address' is provided.
 	Defaults to 'false'.
 					]]></xsd:documentation>

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -1,13 +1,13 @@
 <html>
 <body>
 	This document is the API specification for <a
-				href="http://projects.spring.io/spring-amqp/"
+				href="https://projects.spring.io/spring-amqp/"
 				target="_top">Spring AMQP</a>
 	<hr />
 	<div id="overviewBody">
 		<p>
 			For further API reference and developer documentation, see the <a
-				href="http://docs.spring.io/spring-amqp/reference/"
+				href="https://docs.spring.io/spring-amqp/reference/"
 				target="_top">Spring AMQP reference documentation</a>. That
 			documentation contains more detailed, developer-targeted
 			descriptions, with conceptual overviews, definitions of terms,
@@ -17,8 +17,8 @@
 		<p>
 			If you are interested in commercial training, consultancy, and
 			support for Spring AMQP, please visit <a
-				href="http://www.spring.io" target="_top">
-				http://www.spring.io</a>
+				href="https://www.spring.io" target="_top">
+				https://www.spring.io</a>
 		</p>
 	</div>
 </body>

--- a/src/dist/README.md
+++ b/src/dist/README.md
@@ -1,11 +1,11 @@
 Spring AMQP
 ===========
 
-This project provides support for using Spring and Java with [AMQP](http://www.amqp.org/), and in particular [RabbitMQ](http://www.rabbitmq.com/).
+This project provides support for using Spring and Java with [AMQP](https://www.amqp.org/), and in particular [RabbitMQ](https://www.rabbitmq.com/).
 
 # Checking out and Building
 
-To check out the project from [GitHub](https://github.com/spring-projects/spring-amqp) and build from source using [Gradle](http://gradle.org/), do the following:
+To check out the project from [GitHub](https://github.com/spring-projects/spring-amqp) and build from source using [Gradle](https://gradle.org/), do the following:
 
 	git clone git://github.com/spring-projects/spring-amqp.git
 	cd spring-amqp
@@ -31,7 +31,7 @@ To build complete distribution including `-dist`, `-docs`, and `-schema` zip fil
 
 	./gradlew dist
 
-To analyze and gather metrics using [Sonar](http://www.sonarsource.org/):
+To analyze and gather metrics using [Sonar](https://www.sonarqube.org/):
 
 	./gradlew clean build sonar
 
@@ -52,7 +52,7 @@ Browse to the *'spring-amqp'* root directory. All projects should import free of
 
 # Using SpringSource Tool Suite™ (STS)
 
-Using the STS Gradle Support, you can directly import Gradle projects, without having to generate Eclipse metadata first (since STS 2.7.M1). Please make sure you have the Gradle STS Extension installed - Please see the [installation  instructions](http://static.springsource.org/sts/docs/latest/reference/html/gradle/installation.html) for details.
+Using the STS Gradle Support, you can directly import Gradle projects, without having to generate Eclipse metadata first (since STS 2.7.M1). Please make sure you have the Gradle STS Extension installed - Please see the [installation  instructions](https://docs.spring.io/sts/docs/latest/reference/html/gradle/installation.html) for details.
 
 1. Select *File -> Import -> Gradle Project*
 2. Browse to the Spring AMQP Root Folder
@@ -89,19 +89,19 @@ Lists of issues addressed per release can be found in [JIRA](https://jira.spring
 
 ## Additional Resources
 
-* [Spring AMQP Homepage](http://www.spring.io/spring-amqp)
-* [Spring AMQP Source](http://github.com/spring-projects/spring-amqp)
-* [Spring AMQP Samples](http://github.com/spring-projects/spring-amqp-samples)
-* [StackOverflow](http://stackoverflow.com/questions/tagged/spring-amqp)
+* [Spring AMQP Homepage](https://www.spring.io/spring-amqp)
+* [Spring AMQP Source](https://github.com/spring-projects/spring-amqp)
+* [Spring AMQP Samples](https://github.com/spring-projects/spring-amqp-samples)
+* [StackOverflow](https://stackoverflow.com/questions/tagged/spring-amqp)
 
 # Contributing to Spring AMQP
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [StackOverflow](http://stackoverflow.com/questions/tagged/spring-amqp) by responding to questions and joining the debate.
+* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [StackOverflow](https://stackoverflow.com/questions/tagged/spring-amqp) by responding to questions and joining the debate.
 * Create [JIRA](https://jira.spring.io/browse/AMQP) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://www.springsource.org/node/feed) to springframework.org
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by [subscribing](https://www.springsource.org/node/feed) to springframework.org
 
 Before we accept a non-trivial patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_committer_signup).  Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. Active contributors might be asked to join the core team, and given the ability to merge pull requests.
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -617,7 +617,7 @@ The following example configuration shows how to use Spring Boot's RabbitPropert
 @Autowired
 private RabbitProperties props;
 
-private final String[] adminUris = { "http://host1:15672", "http://host2:15672" };
+private final String[] adminUris = { "https://host1:15672", "https://host2:15672" };
 
 private final String[] nodes = { "rabbit@host1", "rabbit@host2" };
 
@@ -659,7 +659,7 @@ These features are explained further in the following sections.
 
 See also `simplePublisherConfirms` in <<scoped-operations>>.
 
-TIP: For some more background information, see the blog post by the RabbitMQ team titled http://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/[Introducing Publisher Confirms].
+TIP: For some more background information, see the blog post by the RabbitMQ team titled https://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/[Introducing Publisher Confirms].
 
 [[connection-channel-listeners]]
 ===== Connection and Channel Listeners
@@ -1339,7 +1339,7 @@ Message message = MessageBuilder.withBody("foo".getBytes())
 ----
 ====
 
-Each of the properties defined on the http://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html[`MessageProperties`] can be set.
+Each of the properties defined on the https://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html[`MessageProperties`] can be set.
 Other methods include `setHeader(String key, String value)`, `removeHeader(String key)`, `removeHeaders()`, and `copyProperties(MessageProperties properties)`.
 Each property setting method has a `set*IfAbsent()` variant.
 In the cases where a default initial value exists, the method is named `set*IfAbsentOrDefault()`.
@@ -1795,7 +1795,7 @@ public class ExampleAmqpConfiguration {
 [[consumer-priority]]
 ====== Consumer Priority
 
-Starting with RabbitMQ Version 3.2, the broker now supports consumer priority (see http://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/[Using Consumer Priorities with RabbitMQ]).
+Starting with RabbitMQ Version 3.2, the broker now supports consumer priority (see https://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/[Using Consumer Priorities with RabbitMQ]).
 This is enabled by setting the `x-priority` argument on the consumer.
 The `SimpleMessageListenerContainer` now supports setting consumer arguments, as the following example shows:
 
@@ -1825,7 +1825,7 @@ See <<listener-queues>>.
 [[lc-auto-delete]]
 ====== `auto-delete` Queues
 
-When a container is configured to listen to `auto-delete` queues, the queue has an `x-expires` option, or the http://www.rabbitmq.com/ttl.html[Time-To-Live] policy is configured on the Broker, the queue is removed by the broker when the container is stopped (that is, when the last consumer is cancelled).
+When a container is configured to listen to `auto-delete` queues, the queue has an `x-expires` option, or the https://www.rabbitmq.com/ttl.html[Time-To-Live] policy is configured on the Broker, the queue is removed by the broker when the container is stopped (that is, when the last consumer is cancelled).
 Before version 1.3, the container could not be restarted because the queue was missing.
 The `RabbitAdmin` only automatically redeclares queues and so on when the connection is closed or when it opens, which does not happen when the container is stopped and started.
 
@@ -3266,7 +3266,7 @@ It has been replaced by `AbstractJackson2MessageConverter`.
 
 Yet another option is the `MarshallingMessageConverter`.
 It delegates to the Spring OXM library's implementations of the `Marshaller` and `Unmarshaller` strategy interfaces.
-You can read more about that library http://docs.spring.io/spring/docs/current/spring-framework-reference/html/oxm.html[here].
+You can read more about that library https://docs.spring.io/spring/docs/current/spring-framework-reference/html/oxm.html[here].
 In terms of configuration, it is most common to provide only the constructor argument, since most implementations of `Marshaller` also implement `Unmarshaller`.
 The following example shows how to configure a `MarshallingMessageConverter`:
 
@@ -3484,7 +3484,7 @@ The exception passed in is a `ListenerExecutionFailedException`, which has a `fa
 [[direct-reply-to]]
 ===== RabbitMQ Direct reply-to
 
-IMPORTANT: Starting with version 3.4.0, the RabbitMQ server supports http://www.rabbitmq.com/direct-reply-to.html[direct reply-to].
+IMPORTANT: Starting with version 3.4.0, the RabbitMQ server supports https://www.rabbitmq.com/direct-reply-to.html[direct reply-to].
 This eliminates the main reason for a fixed reply queue (to avoid the need to create a temporary queue for each request).
 Starting with Spring AMQP version 1.4.1 direct reply-to is used by default (if supported by the server) instead of creating temporary reply queues.
 When no `replyQueue` is provided (or it is set with a name of `amq.rabbitmq.reply-to`), the `RabbitTemplate` automatically detects whether direct reply-to is supported and either uses it or falls back to using a temporary reply queue.
@@ -3510,7 +3510,7 @@ It always used a `DirectReplyToContainer` for replies when direct reply-to is us
 ===== Message Correlation With A Reply Queue
 
 When using a fixed reply queue (other than `amq.rabbitmq.reply-to`), you must provide correlation data so that replies can be correlated to requests.
-See http://www.rabbitmq.com/tutorials/tutorial-six-java.html[RabbitMQ Remote Procedure Call (RPC)].
+See https://www.rabbitmq.com/tutorials/tutorial-six-java.html[RabbitMQ Remote Procedure Call (RPC)].
 By default, the standard `correlationId` property is used to hold the correlation data.
 However, if you wish to use a custom property to hold correlation data, you can set the `correlation-key` attribute on the <rabbit-template/>.
 Explicitly setting the attribute to `correlationId` is the same as omitting the attribute.
@@ -3745,7 +3745,7 @@ See <<json-complex>> for more information.
 [[remoting]]
 ===== Spring Remoting with AMQP
 
-The Spring Framework has a general remoting capability, allowing http://static.springsource.org/spring/docs/current/spring-framework-reference/html/remoting.html[Remote Procedure Calls (RPC)] that use various transports.
+The Spring Framework has a general remoting capability, allowing https://docs.spring.io/spring/docs/current/spring-framework-reference/html/remoting.html[Remote Procedure Calls (RPC)] that use various transports.
 Spring-AMQP supports a similar mechanism with a `AmqpProxyFactoryBean` on the client and a `AmqpInvokerServiceExporter` on the server.
 This provides RPC over AMQP.
 On the client side, a `RabbitTemplate` is used as described <<reply-listener,earlier>>.
@@ -4577,7 +4577,7 @@ When the management plugin is enabled, the RabbitMQ server exposes a REST API to
 A https://github.com/rabbitmq/hop[Java Binding for the API] is now provided.
 The `com.rabbitmq.http.client.Client` is a standard, immediate, and, therefore, blocking API.
 It is based on the https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#spring-web[Spring Web] module and its `RestTemplate` implementation.
-On the other hand, the `com.rabbitmq.http.client.ReactorNettyClient` is a reactive, non-blocking implementation based on the http://projectreactor.io/docs/netty/release/reference/docs/index.html[Reactor Netty] project.
+On the other hand, the `com.rabbitmq.http.client.ReactorNettyClient` is a reactive, non-blocking implementation based on the https://projectreactor.io/docs/netty/release/reference/docs/index.html[Reactor Netty] project.
 
 The hop dependency (`com.rabbitmq:http-client`) is now also `optional`.
 
@@ -4699,7 +4699,7 @@ If the `channelTransacted` flag was set to `false` (the default) in the precedin
 Prior to version 1.6.6, adding a rollback rule to a container's `transactionAttribute` when using an external transaction manager (such as JDBC) had no effect.
 Exceptions always rolled back the transaction.
 
-Also, when using a http://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/transaction.html#transaction-declarative[transaction advice] in the container's advice chain, conditional rollback was not very usefulm, because all listener exceptions are wrapped in a `ListenerExecutionFailedException`.
+Also, when using a https://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/transaction.html#transaction-declarative[transaction advice] in the container's advice chain, conditional rollback was not very usefulm, because all listener exceptions are wrapped in a `ListenerExecutionFailedException`.
 
 The first problem has been corrected, and the rules are now applied properly.
 Further, the `ListenerFailedRuleBasedTransactionAttribute` is now provided.
@@ -4733,7 +4733,7 @@ Consequently, when there is a rollback of a Spring transaction and a message has
 The action taken on message rejection is independent of transactions and depends on the `defaultRequeueRejected` property (default: `true`).
 For more information about rejecting failed messages, see <<async-listeners>>.
 
-For more information about RabbitMQ transactions and their limitations, see http://www.rabbitmq.com/semantics.html[RabbitMQ Broker Semantics].
+For more information about RabbitMQ transactions and their limitations, see https://www.rabbitmq.com/semantics.html[RabbitMQ Broker Semantics].
 
 NOTE: Prior to RabbitMQ 2.7.0, such messages (and any that are unacked when a channel is closed or aborts) went to the back of the queue on a Rabbit broker.
 Since 2.7.0, rejected messages go to the front of the queue, in a similar manner to JMS rolled back messages.
@@ -4747,13 +4747,13 @@ See <<containerAttributes>>.
 
 ===== Using `RabbitTransactionManager`
 
-The http://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html[RabbitTransactionManager] is an alternative to executing Rabbit operations within, and synchronized with, external transactions.
-This transaction manager is an implementation of the http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html[`PlatformTransactionManager`] interface and should be used with a single Rabbit `ConnectionFactory`.
+The https://docs.spring.io/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html[RabbitTransactionManager] is an alternative to executing Rabbit operations within, and synchronized with, external transactions.
+This transaction manager is an implementation of the https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html[`PlatformTransactionManager`] interface and should be used with a single Rabbit `ConnectionFactory`.
 
 IMPORTANT: This strategy is not able to provide XA transactions -- for example, in order to share transactions between messaging and database access.
 
 Application code is required to retrieve the transactional Rabbit resources through `ConnectionFactoryUtils.getTransactionalResourceHolder(ConnectionFactory, boolean)` instead of a standard `Connection.createChannel()` call with subsequent channel creation.
-When using Spring AMQP's http://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html[RabbitTemplate], it will autodetect a thread-bound Channel and automatically participate in its transaction.
+When using Spring AMQP's https://docs.spring.io/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html[RabbitTemplate], it will autodetect a thread-bound Channel and automatically participate in its transaction.
 
 With Java Configuration, you can setup a new RabbitTransactionManager by using the following bean:
 
@@ -5512,7 +5512,7 @@ public StatefulRetryOperationsInterceptor interceptor() {
 
 Only a subset of retry capabilities can be configured this way.
 More advanced features would need the configuration of a `RetryTemplate` as a Spring bean.
-See the http://static.springsource.org/spring-retry/docs/api/current/[Spring Retry Javadoc] for complete information about available policies and their configuration.
+See the https://docs.spring.io/spring-retry/docs/api/current/[Spring Retry Javadoc] for complete information about available policies and their configuration.
 
 [[async-listeners]]
 ===== Message Listeners and the Asynchronous Case

--- a/src/reference/asciidoc/further-reading.adoc
+++ b/src/reference/asciidoc/further-reading.adoc
@@ -1,10 +1,10 @@
 [[further-reading]]
 === Further Reading
 
-For those who are not familiar with AMQP, the http://www.amqp.org/resources/download[specification] is actually quite readable.
+For those who are not familiar with AMQP, the https://www.amqp.org/resources/download[specification] is actually quite readable.
 It is, of course, the authoritative source of information, and the Spring AMQP code should be easy to understand for anyone who is familiar with the spec.
 Our current implementation of the RabbitMQ support is based on their 2.8.x version, and it officially supports AMQP 0.8 and 0.9.1.
 We recommend reading the 0.9.1 document.
 
-There are many great articles, presentations, and blogs available on the RabbitMQ http://www.rabbitmq.com/how.html[Getting Started] page.
+There are many great articles, presentations, and blogs available on the RabbitMQ https://www.rabbitmq.com/how.html[Getting Started] page.
 Since that is currently the only supported implementation for Spring AMQP, we also recommend that as a general starting point for all broker-related concerns.

--- a/src/reference/asciidoc/preface.adoc
+++ b/src/reference/asciidoc/preface.adoc
@@ -4,4 +4,4 @@ We provide a "`template`" as a high-level abstraction for sending and receiving 
 We also provide support for message-driven POJOs.
 These libraries facilitate management of AMQP resources while promoting the use of dependency injection and declarative configuration.
 In all of these cases, you can see similarities to the JMS support in the Spring Framework.
-For other project-related information, visit the Spring AMQP project http://projects.spring.io/spring-amqp/[homepage].
+For other project-related information, visit the Spring AMQP project https://projects.spring.io/spring-amqp/[homepage].

--- a/src/reference/asciidoc/quick-tour.adoc
+++ b/src/reference/asciidoc/quick-tour.adoc
@@ -5,7 +5,7 @@
 
 This is the five-minute tour to get started with Spring AMQP.
 
-Prerequisites: Install and run the RabbitMQ broker (http://www.rabbitmq.com/download.html[http://www.rabbitmq.com/download.html]).
+Prerequisites: Install and run the RabbitMQ broker (https://www.rabbitmq.com/download.html[https://www.rabbitmq.com/download.html]).
 Then grab the spring-rabbit JAR and all its dependencies - the easiest way to do so is to declare a dependency in your build tool.
 For example, for Maven, you can do something resembling the following:
 
@@ -95,9 +95,9 @@ String foo = (String) template.receiveAndConvert("myqueue");
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:rabbit="http://www.springframework.org/schema/rabbit"
        xsi:schemaLocation="http://www.springframework.org/schema/rabbit
-           http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+           https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans.xsd">
+           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <rabbit:connection-factory id="connectionFactory"/>
 

--- a/src/reference/asciidoc/sample-apps.adoc
+++ b/src/reference/asciidoc/sample-apps.adoc
@@ -6,7 +6,7 @@ The first is a simple "`Hello World`" example that demonstrates both synchronous
 It provides an excellent starting point for acquiring an understanding of the essential components.
 The second sample is based on a stock-trading use case to demonstrate the types of interaction that would be common in real world applications.
 In this chapter, we provide a quick walk-through of each sample so that you can focus on the most important components.
-The samples are both Maven-based, so you should be able to import them directly into any Maven-aware IDE (such as http://www.springsource.org/sts[SpringSource Tool Suite]).
+The samples are both Maven-based, so you should be able to import them directly into any Maven-aware IDE (such as https://www.springsource.org/sts[SpringSource Tool Suite]).
 
 [[hello-world-sample]]
 ==== The "`Hello World`" Sample
@@ -20,7 +20,7 @@ You can import the `spring-rabbit-helloworld` sample into the IDE and then follo
 Within the `src/main/java` directory, navigate to the `org.springframework.amqp.helloworld` package.
 Open the `HelloWorldConfiguration` class and notice that it contains the `@Configuration` annotation at the class level and notice some `@Bean` annotations at method-level.
 This is an example of Spring's Java-based configuration.
-You can read more about that http://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html#beans-java[here].
+You can read more about that https://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html#beans-java[here].
 
 The following listing shows how the connection factory is created:
 
@@ -156,7 +156,7 @@ static class ScheduledProducer {
 ====
 
 You do not need to understand all of the details, since the real focus should be on the receiving side (which we cover next).
-However, if you are not yet familiar with Spring task scheduling support, you can learn more http://docs.spring.io/spring/docs/current/spring-framework-reference/html/scheduling.html#scheduling-annotation-support[here].
+However, if you are not yet familiar with Spring task scheduling support, you can learn more https://docs.spring.io/spring/docs/current/spring-framework-reference/html/scheduling.html#scheduling-annotation-support[here].
 The short story is that the `postProcessor` bean in the `ProducerConfiguration` registers the task with a scheduler.
 
 Now we can turn to the receiving side.
@@ -380,4 +380,4 @@ Spring applications, when sending JSON, set the `__TypeId__` header to the fully
 
 The `spring-rabbit-json` sample explores several techniques to convert the JSON from a non-Spring application.
 
-See also <<json-message-converter>> as well as the http://docs.spring.io/spring-amqp/docs/current/api/index.html?org/springframework/amqp/support/converter/DefaultClassMapper.html[Javadoc for the `DefaultClassMapper`].
+See also <<json-message-converter>> as well as the https://docs.spring.io/spring-amqp/docs/current/api/index.html?org/springframework/amqp/support/converter/DefaultClassMapper.html[Javadoc for the `DefaultClassMapper`].

--- a/src/reference/asciidoc/si-amqp.adoc
+++ b/src/reference/asciidoc/si-amqp.adoc
@@ -6,7 +6,7 @@ This brief chapter covers the relationship between the Spring Integration and th
 [[spring-integration-amqp-introduction]]
 ==== Introduction
 
-The http://www.springsource.org/spring-integration[Spring Integration] project includes AMQP Channel Adapters and Gateways that build upon the Spring AMQP project.
+The https://www.springsource.org/spring-integration[Spring Integration] project includes AMQP Channel Adapters and Gateways that build upon the Spring AMQP project.
 Those adapters are developed and released in the Spring Integration project.
 In Spring Integration, "`Channel Adapters`" are unidirectional (one-way), whereas "`Gateways`" are bidirectional (request-reply).
 We provide an inbound-channel-adapter, an outbound-channel-adapter, an inbound-gateway, and an outbound-gateway.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://baz:15672/api/ (UnknownHostException) with 1 occurrences migrated to:  
  https://baz:15672/api/ ([https](https://baz:15672/api/) result UnknownHostException).
* [ ] http://foo/bar (UnknownHostException) with 2 occurrences migrated to:  
  https://foo/bar ([https](https://foo/bar) result UnknownHostException).
* [ ] http://host1:15672 (UnknownHostException) with 1 occurrences migrated to:  
  https://host1:15672 ([https](https://host1:15672) result UnknownHostException).
* [ ] http://host2:15672 (UnknownHostException) with 1 occurrences migrated to:  
  https://host2:15672 ([https](https://host2:15672) result UnknownHostException).
* [ ] http://host:port (UnknownHostException) with 4 occurrences migrated to:  
  https://host:port ([https](https://host:port) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project ([https](https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project) result 200).
* [ ] http://git-scm.com/book/en/Git-Branching-Rebasing with 2 occurrences migrated to:  
  https://git-scm.com/book/en/Git-Branching-Rebasing ([https](https://git-scm.com/book/en/Git-Branching-Rebasing) result 200).
* [ ] http://github.com/SpringSource/spring-amqp with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-amqp ([https](https://github.com/SpringSource/spring-amqp) result 200).
* [ ] http://github.com/SpringSource/spring-amqp-samples with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-amqp-samples ([https](https://github.com/SpringSource/spring-amqp-samples) result 200).
* [ ] http://github.com/spring-projects/spring-amqp with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-amqp ([https](https://github.com/spring-projects/spring-amqp) result 200).
* [ ] http://github.com/spring-projects/spring-amqp-samples with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-amqp-samples ([https](https://github.com/spring-projects/spring-amqp-samples) result 200).
* [ ] http://gradle.org/ with 2 occurrences migrated to:  
  https://gradle.org/ ([https](https://gradle.org/) result 200).
* [ ] http://projects.spring.io/spring-amqp/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-amqp/ ([https](https://projects.spring.io/spring-amqp/) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-amqp with 3 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-amqp ([https](https://stackoverflow.com/questions/tagged/spring-amqp) result 200).
* [ ] http://www.amqp.org/ with 1 occurrences migrated to:  
  https://www.amqp.org/ ([https](https://www.amqp.org/) result 200).
* [ ] http://www.amqp.org/resources/download with 1 occurrences migrated to:  
  https://www.amqp.org/resources/download ([https](https://www.amqp.org/resources/download) result 200).
* [ ] http://www.rabbitmq.com/ with 2 occurrences migrated to:  
  https://www.rabbitmq.com/ ([https](https://www.rabbitmq.com/) result 200).
* [ ] http://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/ ([https](https://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/) result 200).
* [ ] http://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/ ([https](https://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/) result 200).
* [ ] http://www.rabbitmq.com/direct-reply-to.html with 3 occurrences migrated to:  
  https://www.rabbitmq.com/direct-reply-to.html ([https](https://www.rabbitmq.com/direct-reply-to.html) result 200).
* [ ] http://www.rabbitmq.com/download.html with 2 occurrences migrated to:  
  https://www.rabbitmq.com/download.html ([https](https://www.rabbitmq.com/download.html) result 200).
* [ ] http://www.rabbitmq.com/how.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/how.html ([https](https://www.rabbitmq.com/how.html) result 200).
* [ ] http://www.rabbitmq.com/install.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/install.html ([https](https://www.rabbitmq.com/install.html) result 200).
* [ ] http://www.rabbitmq.com/semantics.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/semantics.html ([https](https://www.rabbitmq.com/semantics.html) result 200).
* [ ] http://www.rabbitmq.com/ttl.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/ttl.html ([https](https://www.rabbitmq.com/ttl.html) result 200).
* [ ] http://www.rabbitmq.com/tutorials/tutorial-six-java.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/tutorials/tutorial-six-java.html ([https](https://www.rabbitmq.com/tutorials/tutorial-six-java.html) result 200).
* [ ] http://www.sonarsource.org/ (301) with 2 occurrences migrated to:  
  https://www.sonarqube.org/ ([https](https://www.sonarsource.org/) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-amqp/docs/current/api/index.html?org/springframework/amqp/support/converter/DefaultClassMapper.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/docs/current/api/index.html?org/springframework/amqp/support/converter/DefaultClassMapper.html ([https](https://docs.spring.io/spring-amqp/docs/current/api/index.html?org/springframework/amqp/support/converter/DefaultClassMapper.html) result 301).
* [ ] http://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html ([https](https://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html) result 301).
* [ ] http://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html ([https](https://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html) result 301).
* [ ] http://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html ([https](https://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html) result 301).
* [ ] http://docs.spring.io/spring-amqp/reference/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/reference/ ([https](https://docs.spring.io/spring-amqp/reference/) result 301).
* [ ] http://static.springsource.org/spring-amqp/reference/html/amqp.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/reference/html/amqp.html ([https](https://static.springsource.org/spring-amqp/reference/html/amqp.html) result 301).
* [ ] http://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/transaction.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/transaction.html ([https](https://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/transaction.html) result 301).
* [ ] http://static.springsource.org/spring-retry/docs/api/current/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-retry/docs/api/current/ ([https](https://static.springsource.org/spring-retry/docs/api/current/) result 301).
* [ ] http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html ([https](https://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/oxm.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/oxm.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/oxm.html) result 301).
* [ ] http://static.springsource.org/spring/docs/current/spring-framework-reference/html/remoting.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/remoting.html ([https](https://static.springsource.org/spring/docs/current/spring-framework-reference/html/remoting.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/scheduling.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/scheduling.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/scheduling.html) result 301).
* [ ] http://static.springsource.org/sts/docs/latest/reference/html/gradle/installation.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/sts/docs/latest/reference/html/gradle/installation.html ([https](https://static.springsource.org/sts/docs/latest/reference/html/gradle/installation.html) result 301).
* [ ] http://forum.springsource.org/forumdisplay.php?f=74 (301) with 2 occurrences migrated to:  
  https://forum.spring.io/ ([https](https://forum.springsource.org/forumdisplay.php?f=74) result 301).
* [ ] http://help.github.com/fork-a-repo/ with 1 occurrences migrated to:  
  https://help.github.com/fork-a-repo/ ([https](https://help.github.com/fork-a-repo/) result 301).
* [ ] http://help.github.com/forking/ with 2 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://www.spring.io with 2 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* [ ] http://www.spring.io/spring-amqp with 1 occurrences migrated to:  
  https://www.spring.io/spring-amqp ([https](https://www.spring.io/spring-amqp) result 301).
* [ ] http://www.springframework.org/schema/rabbit/spring-rabbit.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/rabbit/spring-rabbit.xsd ([https](https://www.springframework.org/schema/rabbit/spring-rabbit.xsd) result 301).
* [ ] http://www.springsource.org/spring-amqp with 1 occurrences migrated to:  
  https://www.springsource.org/spring-amqp ([https](https://www.springsource.org/spring-amqp) result 301).
* [ ] http://www.springsource.org/spring-integration with 1 occurrences migrated to:  
  https://www.springsource.org/spring-integration ([https](https://www.springsource.org/spring-integration) result 301).
* [ ] http://www.springsource.org/sts with 1 occurrences migrated to:  
  https://www.springsource.org/sts ([https](https://www.springsource.org/sts) result 301).
* [ ] http://projectreactor.io/docs/netty/release/reference/docs/index.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/netty/release/reference/docs/index.html ([https](https://projectreactor.io/docs/netty/release/reference/docs/index.html) result 302).
* [ ] http://www.springsource.org/node/feed with 2 occurrences migrated to:  
  https://www.springsource.org/node/feed ([https](https://www.springsource.org/node/feed) result 302).

# Ignored
These URLs were intentionally ignored.

* http://guest:guest@localhost:15672/api with 1 occurrences
* http://guest:guest@localhost:15672/api/ with 1 occurrences
* http://localhost:11235 with 2 occurrences
* http://localhost:11236 with 2 occurrences
* http://localhost:15672 with 2 occurrences
* http://localhost:15672/api/ with 6 occurrences
* http://www.springframework.org/schema/beans with 4 occurrences
* http://www.springframework.org/schema/rabbit with 6 occurrences
* http://www.springframework.org/schema/tool with 2 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 2 occurrences