### PR TITLE
URL Cleanup

### DIFF
--- a/spring-amqp/src/test/resources/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests-context.xml
+++ b/spring-amqp/src/test/resources/org/springframework/amqp/support/converter/Jackson2JsonMessageConverterTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="jsonConverterWithDefaultType" class="org.springframework.amqp.support.converter.Jackson2JsonMessageConverter">
 		<property name="classMapper">

--- a/spring-rabbit-test/src/test/resources/org/springframework/amqp/rabbit/repeatable/annotation-driven-no-rabbit-admin-repeatable-config.xml
+++ b/spring-rabbit-test/src/test/resources/org/springframework/amqp/rabbit/repeatable/annotation-driven-no-rabbit-admin-repeatable-config.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:annotation-driven/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-container-factory.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-container-factory.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:annotation-driven container-factory="simpleFactory"/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-handler-method-factory.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-handler-method-factory.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:annotation-driven handler-method-factory="customMessageHandlerMethodFactory"/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-registry.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-custom-registry.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 
 	<rabbit:annotation-driven registry="customRegistry"/>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-default-container-factory.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-default-container-factory.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:annotation-driven/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-full-config.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-full-config.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:annotation-driven/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-full-configurable-config.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-full-configurable-config.xml
@@ -4,11 +4,11 @@
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
 	   http://www.springframework.org/schema/context
-	   http://www.springframework.org/schema/context/spring-context.xsd">
+	   https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<rabbit:annotation-driven/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-no-rabbit-admin-config.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-no-rabbit-admin-config.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:annotation-driven/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-no-rabbit-admin-listeners-config.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-no-rabbit-admin-listeners-config.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:annotation-driven/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-sample-config.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/annotation-driven-sample-config.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   http://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/rabbit
-	   http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	   https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:annotation-driven/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-0-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-0-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:connection-factory id="connectionFactory"  host="localhost" />
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-1-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-1-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<!-- One of 'rabbit-template' or 'rabbit-connection-factory' attributes
 		must be set - context load should fail -->

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-2-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/AdminParserTests-2-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:connection-factory id="connectionFactory"  host="localhost" />
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:task="http://www.springframework.org/schema/task"
-	xsi:schemaLocation="http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:connection-factory id="kitchenSink" host="foo" virtual-host="/bar"
 		channel-cache-size="10" port="6888" username="user" password="password"

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ExchangeParserIntegrationTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ExchangeParserIntegrationTests-context.xml
@@ -2,8 +2,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/rabbit"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<direct-exchange name="directTest" auto-delete="true">
 		<bindings>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ExchangeParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ExchangeParserTests-context.xml
@@ -4,9 +4,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 
 	<rabbit:direct-exchange name="direct" auto-declare="false" declared-by="admin1, admin2">

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-context.xml
@@ -4,10 +4,10 @@
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:task="http://www.springframework.org/schema/task"
-	xsi:schemaLocation="http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<rabbit:queue name="foo" />
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-fail-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerParserTests-fail-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<rabbit:queue name="foo" />
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<property name="properties">

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/MismatchedQueueDeclarationTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/MismatchedQueueDeclarationTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:connection-factory id="connectionFactory" host="localhost" />
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueArgumentsParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueArgumentsParserTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:queue-arguments id="args">
 		<entry key="foo" value="bar" />

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserIllegalAnonymousTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserIllegalAnonymousTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:queue id="anonymous" durable="true" auto-delete="true" exclusive="true"/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserIntegrationTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserIntegrationTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:queue name="arguments">
 		<rabbit:queue-arguments value-type="java.lang.Long">

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserPlaceholderTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserPlaceholderTests-context.xml
@@ -4,9 +4,9 @@
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<property name="properties">

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/QueueParserTests-context.xml
@@ -4,9 +4,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<rabbit:queue name="foo" />
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/RabbitNamespaceHandlerTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/RabbitNamespaceHandlerTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<direct-exchange name="direct-test"
 		xmlns="http://www.springframework.org/schema/rabbit">

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	   xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<rabbit:template id="template" connection-factory="connectionFactory"/>
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:template id="routingTemplate"
 		connection-factory="rcf"

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/ListenFromAutoDeleteQueueTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
 	<rabbit:connection-factory id="rabbitConnectionFactory" host="localhost" />
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/StopStartIntegrationTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/listener/StopStartIntegrationTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <rabbit:connection-factory id="connectionFactory" host="localhost" />
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/remoting/RemotingTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/remoting/RemotingTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="client" class="org.springframework.amqp.remoting.client.AmqpProxyFactoryBean">
 		<property name="amqpTemplate" ref="template" />

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/retry/retry-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/retry/retry-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit.xsd">
 
     <rabbit:connection-factory id="connectionFactory" host="localhost" />
 

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files="package-info\.java" checks=".*" />
 	<suppress files="[\\/]test[\\/]" checks="RequireThis" />

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "https://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
 
 	<module name="SuppressionFilter">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.puppycrawl.com/dtds/configuration_1_2.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_2.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_2.dtd) result 404).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 33 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/rabbit/spring-rabbit.xsd with 32 occurrences migrated to:  
  https://www.springframework.org/schema/rabbit/spring-rabbit.xsd ([https](https://www.springframework.org/schema/rabbit/spring-rabbit.xsd) result 200).
* [ ] http://www.springframework.org/schema/task/spring-task.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 75 occurrences
* http://www.springframework.org/schema/context with 2 occurrences
* http://www.springframework.org/schema/rabbit with 71 occurrences
* http://www.springframework.org/schema/task with 4 occurrences
* http://www.springframework.org/schema/util with 10 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 33 occurrences