### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Spring AMQP <img src="https://build.spring.io/plugins/servlet/buildStatusImage/AMQP-MASTER">
 ===========
 
-This project provides support for using Spring and Java with [AMQP](http://www.amqp.org/), and in particular [RabbitMQ](http://www.rabbitmq.com/).
+This project provides support for using Spring and Java with [AMQP](https://www.amqp.org/), and in particular [RabbitMQ](https://www.rabbitmq.com/).
 
 # Checking out and Building
 
-To check out the project from [GitHub](https://github.com/SpringSource/spring-amqp) and build from source using [Gradle](http://gradle.org/), do the following:
+To check out the project from [GitHub](https://github.com/SpringSource/spring-amqp) and build from source using [Gradle](https://gradle.org/), do the following:
 
 	git clone git://github.com/SpringSource/spring-amqp.git
 	cd spring-amqp
@@ -31,7 +31,7 @@ To build complete distribution including `-dist`, `-docs`, and `-schema` zip fil
 
 	./gradlew dist
 
-To analyze and gather metrics using [Sonar](http://www.sonarsource.org/):
+To analyze and gather metrics using [Sonar](https://www.sonarqube.org/):
 
 	./gradlew clean build sonar
 
@@ -52,7 +52,7 @@ Browse to the *'spring-amqp'* root directory. All projects should import free of
 
 # Using SpringSource Tool Suite™ (STS)
 
-Using the STS Gradle Support, you can directly import Gradle projects, without having to generate Eclipse metadata first (since STS 2.7.M1). Please make sure you have the Gradle STS Extension installed - Please see the [installation  instructions](http://static.springsource.org/sts/docs/latest/reference/html/gradle/installation.html) for details.
+Using the STS Gradle Support, you can directly import Gradle projects, without having to generate Eclipse metadata first (since STS 2.7.M1). Please make sure you have the Gradle STS Extension installed - Please see the [installation  instructions](https://docs.spring.io/sts/docs/latest/reference/html/gradle/installation.html) for details.
 
 1. Select *File -> Import -> Gradle Project*
 2. Browse to the Spring AMQP Root Folder
@@ -89,20 +89,20 @@ Lists of issues addressed per release can be found in [JIRA](https://jira.spring
 
 ## Additional Resources
 
-* [Spring AMQP Homepage](http://www.springsource.org/spring-amqp)
-* [Spring AMQP Source](http://github.com/SpringSource/spring-amqp)
-* [Spring AMQP Samples](http://github.com/SpringSource/spring-amqp-samples)
-* [Spring AMQP Forum](http://forum.springsource.org/forumdisplay.php?f=74)
-* [StackOverflow](http://stackoverflow.com/questions/tagged/spring-amqp)
+* [Spring AMQP Homepage](https://www.springsource.org/spring-amqp)
+* [Spring AMQP Source](https://github.com/SpringSource/spring-amqp)
+* [Spring AMQP Samples](https://github.com/SpringSource/spring-amqp-samples)
+* [Spring AMQP Forum](https://forum.spring.io/forumdisplay.php?f=74)
+* [StackOverflow](https://stackoverflow.com/questions/tagged/spring-amqp)
 
 # Contributing to Spring AMQP
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [forum](http://forum.springsource.org/forumdisplay.php?f=74) by responding to questions and joining the debate.
+* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [forum](https://forum.spring.io/forumdisplay.php?f=74) by responding to questions and joining the debate.
 * Create [JIRA](https://jira.springsource.org/browse/AMQP) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://www.springsource.org/node/feed) to springframework.org
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by [subscribing](https://www.springsource.org/node/feed) to springframework.org
 
 Before we accept a non-trivial patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_committer_signup).  Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. Active contributors might be asked to join the core team, and given the ability to merge pull requests.
 

--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/client/AmqpClientInterceptor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/client/AmqpClientInterceptor.java
@@ -82,7 +82,7 @@ public class AmqpClientInterceptor extends RemoteAccessor implements MethodInter
 	/**
 	 * The AMQP template to be used for sending messages and receiving results. This class is using "Request/Reply" for
 	 * sending messages as described <a href=
-	 * "http://static.springsource.org/spring-amqp/reference/html/amqp.html#request-reply" >in the Spring-AMQP
+	 * "https://docs.spring.io/spring-amqp/reference/html/amqp.html#request-reply" >in the Spring-AMQP
 	 * documentation</a>.
 	 *
 	 * @param amqpTemplate The amqp template.

--- a/spring-amqp/src/main/java/org/springframework/amqp/remoting/service/AmqpInvokerServiceExporter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/remoting/service/AmqpInvokerServiceExporter.java
@@ -45,7 +45,7 @@ import org.springframework.remoting.support.RemoteInvocationResult;
  *
  * <p>
  * This listener responds to "Request/Reply"-style messages as described <a href=
- * "http://static.springsource.org/spring-amqp/reference/html/amqp.html#request-reply" >here</a>.
+ * "https://docs.spring.io/spring-amqp/reference/html/amqp.html#request-reply" >here</a>.
  *
  * @author David Bilge
  * @author Gary Russell

--- a/spring-rabbit/README.md
+++ b/spring-rabbit/README.md
@@ -2,7 +2,7 @@ Many of the "integration" tests here require a running RabbitMQ server - they
 will be skipped if the broker is not detected.
 
 If RabbitMQ is not installed on your system, refer to the instructions for your
-particular OS here: [http://www.rabbitmq.com/install.html]
+particular OS here: [https://www.rabbitmq.com/install.html]
 
 Start the server. For example, and a *nix-based system where RabbitMQ has been
 installed within `/opt/rabbitmq`, issue the following command:

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -272,7 +272,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	/**
 	 * A queue for replies; if not provided, a temporary exclusive, auto-delete queue will
 	 * be used for each reply, unless RabbitMQ supports 'amq.rabbitmq.reply-to' - see
-	 * http://www.rabbitmq.com/direct-reply-to.html
+	 * https://www.rabbitmq.com/direct-reply-to.html
 	 * @deprecated - use #setReplyAddress(String replyAddress)
 	 * @param replyQueue the replyQueue to set
 	 */
@@ -284,7 +284,7 @@ public class RabbitTemplate extends RabbitAccessor implements BeanFactoryAware, 
 	/**
 	 * An address for replies; if not provided, a temporary exclusive, auto-delete queue will
 	 * be used for each reply, unless RabbitMQ supports 'amq.rabbitmq.reply-to' - see
-	 * http://www.rabbitmq.com/direct-reply-to.html
+	 * https://www.rabbitmq.com/direct-reply-to.html
 	 * <p>The address can be a simple queue name (in which case the reply will be routed via the default
 	 * exchange), or with the form {@code exchange/routingKey} to route the reply using an explicit
 	 * exchange and routing key.

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/MulticastMain.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/MulticastMain.java
@@ -1,7 +1,7 @@
 // The contents of this file are subject to the Mozilla Public License
 // Version 1.1 (the "License"); you may not use this file except in
 // compliance with the License. You may obtain a copy of the License at
-// http://www.mozilla.org/MPL/
+// https://www.mozilla.org/MPL/
 //
 // Software distributed under the License is distributed on an "AS IS"
 // basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/Log4jLevelAdjuster.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/test/Log4jLevelAdjuster.java
@@ -47,7 +47,7 @@ public class Log4jLevelAdjuster implements MethodRule {
 				}
 				finally {
 					logger.debug("Restoring log level setting for: " + Arrays.asList(classes));
-					// raw Class type used to avoid http://bugs.sun.com/view_bug.do?bug_id=6682380
+					// raw Class type used to avoid https://bugs.java.com/view_bug.do?bug_id=6682380
 					for (@SuppressWarnings("rawtypes") Class cls : classes) {
 						LogManager.getLogger(cls).setLevel(oldLevels.get(cls));
 					}

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -1,13 +1,13 @@
 <html>
 <body>
 	This document is the API specification for <a
-				href="http://projects.spring.io/spring-amqp/"
+				href="https://projects.spring.io/spring-amqp/"
 				target="_top">Spring AMQP</a>
 	<hr />
 	<div id="overviewBody">
 		<p>
 			For further API reference and developer documentation, see the <a
-				href="http://docs.spring.io/spring-amqp/reference/"
+				href="https://docs.spring.io/spring-amqp/reference/"
 				target="_top">Spring AMQP reference documentation</a>. That
 			documentation contains more detailed, developer-targeted
 			descriptions, with conceptual overviews, definitions of terms,
@@ -17,8 +17,8 @@
 		<p>
 			If you are interested in commercial training, consultancy, and
 			support for Spring AMQP, please visit <a
-				href="http://www.spring.io" target="_top">
-				http://www.spring.io</a>
+				href="https://www.spring.io" target="_top">
+				https://www.spring.io</a>
 		</p>
 	</div>
 </body>

--- a/src/dist/README.md
+++ b/src/dist/README.md
@@ -1,11 +1,11 @@
 Spring AMQP
 ===========
 
-This project provides support for using Spring and Java with [AMQP](http://www.amqp.org/), and in particular [RabbitMQ](http://www.rabbitmq.com/).
+This project provides support for using Spring and Java with [AMQP](https://www.amqp.org/), and in particular [RabbitMQ](https://www.rabbitmq.com/).
 
 # Checking out and Building
 
-To check out the project from [GitHub](https://github.com/spring-projects/spring-amqp) and build from source using [Gradle](http://gradle.org/), do the following:
+To check out the project from [GitHub](https://github.com/spring-projects/spring-amqp) and build from source using [Gradle](https://gradle.org/), do the following:
 
 	git clone git://github.com/spring-projects/spring-amqp.git
 	cd spring-amqp
@@ -31,7 +31,7 @@ To build complete distribution including `-dist`, `-docs`, and `-schema` zip fil
 
 	./gradlew dist
 
-To analyze and gather metrics using [Sonar](http://www.sonarsource.org/):
+To analyze and gather metrics using [Sonar](https://www.sonarqube.org/):
 
 	./gradlew clean build sonar
 
@@ -52,7 +52,7 @@ Browse to the *'spring-amqp'* root directory. All projects should import free of
 
 # Using SpringSource Tool Suite™ (STS)
 
-Using the STS Gradle Support, you can directly import Gradle projects, without having to generate Eclipse metadata first (since STS 2.7.M1). Please make sure you have the Gradle STS Extension installed - Please see the [installation  instructions](http://static.springsource.org/sts/docs/latest/reference/html/gradle/installation.html) for details.
+Using the STS Gradle Support, you can directly import Gradle projects, without having to generate Eclipse metadata first (since STS 2.7.M1). Please make sure you have the Gradle STS Extension installed - Please see the [installation  instructions](https://docs.spring.io/sts/docs/latest/reference/html/gradle/installation.html) for details.
 
 1. Select *File -> Import -> Gradle Project*
 2. Browse to the Spring AMQP Root Folder
@@ -89,19 +89,19 @@ Lists of issues addressed per release can be found in [JIRA](https://jira.spring
 
 ## Additional Resources
 
-* [Spring AMQP Homepage](http://www.spring.io/spring-amqp)
-* [Spring AMQP Source](http://github.com/spring-projects/spring-amqp)
-* [Spring AMQP Samples](http://github.com/spring-projects/spring-amqp-samples)
-* [StackOverflow](http://stackoverflow.com/questions/tagged/spring-amqp)
+* [Spring AMQP Homepage](https://www.spring.io/spring-amqp)
+* [Spring AMQP Source](https://github.com/spring-projects/spring-amqp)
+* [Spring AMQP Samples](https://github.com/spring-projects/spring-amqp-samples)
+* [StackOverflow](https://stackoverflow.com/questions/tagged/spring-amqp)
 
 # Contributing to Spring AMQP
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [StackOverflow](http://stackoverflow.com/questions/tagged/spring-amqp) by responding to questions and joining the debate.
+* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [StackOverflow](https://stackoverflow.com/questions/tagged/spring-amqp) by responding to questions and joining the debate.
 * Create [JIRA](https://jira.spring.io/browse/AMQP) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://www.springsource.org/node/feed) to springframework.org
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by [subscribing](https://www.springsource.org/node/feed) to springframework.org
 
 Before we accept a non-trivial patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_committer_signup).  Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. Active contributors might be asked to join the core team, and given the ability to merge pull requests.
 

--- a/src/dist/epl-license.txt
+++ b/src/dist/epl-license.txt
@@ -273,7 +273,7 @@ EXHIBIT A.
 ``The contents of this file are subject to the Erlang Public License,
 Version 1.0, (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the License at
-http://www.eddieware.org/EPL
+http://www.eddieware.org/EPL/
 
 Software distributed under the License is distributed on an "AS IS"
 basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/dist/notice.txt
+++ b/src/dist/notice.txt
@@ -4,13 +4,13 @@
    ========================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.spring.io)."
+      Project (https://www.spring.io)."
 
    Alternatively, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -511,7 +511,7 @@ When such a channel is obtained, the client can register a `PublisherCallbackCha
 The `PublisherCallbackChannel` implementation contains logic to route a confirm/return to the appropriate listener.
 These features are explained further in the following sections.
 
-TIP: For some more background information, please see the following blog post by the RabbitMQ team titled http://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/[Introducing Publisher Confirms].
+TIP: For some more background information, please see the following blog post by the RabbitMQ team titled https://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/[Introducing Publisher Confirms].
 
 [[channel-close-logging]]
 ===== Logging Channel Close Events
@@ -775,7 +775,7 @@ Message message = MessageBuilder.withBody("foo".getBytes())
 
 ----
 
-Each of the properties defined on the http://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html[MessageProperies] can be set.
+Each of the properties defined on the https://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html[MessageProperies] can be set.
 Other methods include `setHeader(String key, String value)`, `removeHeader(String key)`, `removeHeaders()`, and `copyProperties(MessageProperties properties)`.
 Each property setting method has a `set*IfAbsent()` variant.
 In the cases where a default initial value exists, the method is named `set*IfAbsentOrDefault()`.
@@ -1079,7 +1079,7 @@ public class ExampleAmqpConfiguration {
 ----
 
 [[consumer-priority]]
-Starting with *RabbitMQ Version 3.2*, the broker now supports consumer priority (see http://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/[Using Consumer Priorities with RabbitMQ]).
+Starting with *RabbitMQ Version 3.2*, the broker now supports consumer priority (see https://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/[Using Consumer Priorities with RabbitMQ]).
 This is enabled by setting the `x-priority` argument on the consumer.
 The `SimpleMessageListenerContainer` now supports setting consumer arguments:
 
@@ -1104,7 +1104,7 @@ Starting with _version 1.3_ the queue(s) on which the container is listening can
 [[lc-auto-delete]]
 ====== 'auto-delete' Queues
 
-When a container is configured to listen to `auto-delete` queue(s), or the queue has an `x-expires` option or the http://www.rabbitmq.com/ttl.html[Time-To-Live] policy is configured on the Broker, the queue is removed by the broker when the container is stopped (last consumer is cancelled).
+When a container is configured to listen to `auto-delete` queue(s), or the queue has an `x-expires` option or the https://www.rabbitmq.com/ttl.html[Time-To-Live] policy is configured on the Broker, the queue is removed by the broker when the container is stopped (last consumer is cancelled).
 Before _version 1.3_, the container could not be restarted because the queue was missing; the `RabbitAdmin` only automatically redeclares queues etc, when the connection is closed/opens, which does not happen when the container is stopped/started.
 
 Starting with _version 1.3_, the container will now use a `RabbitAdmin` to redeclare any missing queues during startup.
@@ -1865,7 +1865,7 @@ If an inbound message does not contain type information in the `MessagePropertie
 
 Yet another option is the `MarshallingMessageConverter`.
 It delegates to the Spring OXM library's implementations of the `Marshaller` and `Unmarshaller` strategy interfaces.
-You can read more about that library http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html[here].
+You can read more about that library https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/oxm.html[here].
 In terms of configuration, it's most common to provide the constructor argument only since most implementations of `Marshaller` will also implement `Unmarshaller`.
 
 [source,xml]
@@ -1989,7 +1989,7 @@ Also, you must not have registered your own `ReturnCallback` with the `RabbitTem
 [[direct-reply-to]]
 ===== RabbitMQ Direct reply-to
 
-IMPORTANT: Starting with _version 3.4.0_, the RabbitMQ server now supports http://www.rabbitmq.com/direct-reply-to.html[Direct reply-to]; this eliminates the main reason for a fixed reply queue (to avoid the need to create a temporary queue for each request).
+IMPORTANT: Starting with _version 3.4.0_, the RabbitMQ server now supports https://www.rabbitmq.com/direct-reply-to.html[Direct reply-to]; this eliminates the main reason for a fixed reply queue (to avoid the need to create a temporary queue for each request).
 Starting with *Spring AMQP version 1.4.1* Direct reply-to will be used by default (if supported by the server) instead of creating temporary reply queues.
 When no `replyQueue` is provided (or it is set with the name `amq.rabbitmq.reply-to`), the `RabbitTemplate` will automatically detect whether Direct reply-to is supported and either use it or fall back to using a temporary reply queue.
 When using Direct reply-to, a `reply-listener` is not required and should not be configured.
@@ -1999,7 +1999,7 @@ Reply listeners are still supported with named queues (other than `amq.rabbitmq.
 ===== Message Correlation With A Reply Queue
 
 When using a fixed reply queue (other than `amq.rabbitmq.reply-to`), it is necessary to provide correlation data so that replies can be correlated to requests.
-See http://www.rabbitmq.com/tutorials/tutorial-six-java.html[RabbitMQ Remote Procedure Call (RPC)].
+See https://www.rabbitmq.com/tutorials/tutorial-six-java.html[RabbitMQ Remote Procedure Call (RPC)].
 By default, the standard `correlationId` property will be used to hold the correlation data.
 However, if you wish to use a custom property to hold correlation data, you can set the `correlation-key` attribute on the <rabbit-template/>.
 Explicitly setting the attribute to `correlationId` is the same as omitting the attribute.
@@ -2120,7 +2120,7 @@ You can also take a look at the `FixedReplyQueueDeadLetterTests` test case for a
 [[remoting]]
 ===== Spring Remoting with AMQP
 
-The Spring Framework has a general remoting capability, allowing http://static.springsource.org/spring/docs/current/spring-framework-reference/html/remoting.html[Remote Procedure Calls (RPC)] using various transports.
+The Spring Framework has a general remoting capability, allowing https://docs.spring.io/spring/docs/current/spring-framework-reference/html/remoting.html[Remote Procedure Calls (RPC)] using various transports.
 Spring-AMQP supports a similar mechanism with a `AmqpProxyFactoryBean` on the client and a `AmqpInvokerServiceExporter` on the server.
 This provides RPC over AMQP.
 On the client side, a `RabbitTemplate` is used as described above; on the server side, the invoker (configured as a `MessageListener`) receives the message, invokes the configured service, and returns the reply using the inbound message's `replyTo` information.
@@ -2859,19 +2859,19 @@ AMQP transactions only apply to messages and acks sent to the broker, so when th
 The action taken on message rejection is independent of transactions and depends on the `defaultRequeueRejected` property (default `true`).
 For more information about rejecting failed messages, see <<async-listeners>>.
 
-For more information about RabbitMQ transactions, and their limitations, refer to http://www.rabbitmq.com/semantics.html[RabbitMQ Broker Semantics].
+For more information about RabbitMQ transactions, and their limitations, refer to https://www.rabbitmq.com/semantics.html[RabbitMQ Broker Semantics].
 
 NOTE: Prior to *RabbitMQ 2.7.0*, such messages (and any that are unacked when a channel is closed or aborts) went to the back of the queue on a Rabbit broker, since 2.7.0, rejected messages go to the front of the queue, in a similar manner to JMS rolled back messages.
 
 ===== Using the RabbitTransactionManager
 
-The http://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html[RabbitTransactionManager] is an alternative to executing Rabbit operations within, and synchronized with, external transactions.
-This Transaction Manager is an implementation of the http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html[PlatformTransactionManager] interface and should be used with a single Rabbit ConnectionFactory.
+The https://docs.spring.io/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html[RabbitTransactionManager] is an alternative to executing Rabbit operations within, and synchronized with, external transactions.
+This Transaction Manager is an implementation of the https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html[PlatformTransactionManager] interface and should be used with a single Rabbit ConnectionFactory.
 
 IMPORTANT: This strategy is not able to provide XA transactions, for example in order to share transactions between messaging and database access.
 
 Application code is required to retrieve the transactional Rabbit resources via `ConnectionFactoryUtils.getTransactionalResourceHolder(ConnectionFactory, boolean)` instead of a standard `Connection.createChannel()` call with subsequent Channel creation.
-When using Spring AMQP's http://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html[RabbitTemplate], it will autodetect a thread-bound Channel and automatically participate in its transaction.
+When using Spring AMQP's https://docs.spring.io/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html[RabbitTemplate], it will autodetect a thread-bound Channel and automatically participate in its transaction.
 
 With Java Configuration you can setup a new RabbitTransactionManager using:
 
@@ -3289,7 +3289,7 @@ public StatefulRetryOperationsInterceptor interceptor() {
 ----
 
 Only a subset of retry capabilities can be configured this way; more advanced features would need the configuration of a `RetryTemplate` as a Spring bean.
-See the http://static.springsource.org/spring-retry/docs/api/current/[Spring Retry Javadocs] for complete information about available policies and their configuration.
+See the https://docs.spring.io/spring-retry/docs/api/current/[Spring Retry Javadocs] for complete information about available policies and their configuration.
 
 [[async-listeners]]
 ===== Message Listeners and the Asynchronous Case

--- a/src/reference/asciidoc/further-reading.adoc
+++ b/src/reference/asciidoc/further-reading.adoc
@@ -1,10 +1,10 @@
 [[further-reading]]
 === Further Reading
 
-For those who are not familiar with AMQP, the http://www.amqp.org/resources/download[specification] is actually quite readable.
+For those who are not familiar with AMQP, the https://www.amqp.org/resources/download[specification] is actually quite readable.
 It is of course the authoritative source of information, and the Spring AMQP code should be very easy to understand for anyone who is familiar with the spec.
 Our current implementation of the RabbitMQ support is based on their 2.8.x version, and it officially supports AMQP 0.8 and 0.9.1.
 We recommend reading the 0.9.1 document.
 
-There are many great articles, presentations, and blogs available on the RabbitMQ http://www.rabbitmq.com/how.html[Getting Started] page.
+There are many great articles, presentations, and blogs available on the RabbitMQ https://www.rabbitmq.com/how.html[Getting Started] page.
 Since that is currently the only supported implementation for Spring AMQP, we also recommend that as a general starting point for all broker-related concerns.

--- a/src/reference/asciidoc/preface.adoc
+++ b/src/reference/asciidoc/preface.adoc
@@ -4,4 +4,4 @@ We provide a "template" as a high-level abstraction for sending and receiving me
 We also provide support for Message-driven POJOs.
 These libraries facilitate management of AMQP resources while promoting the use of dependency injection and declarative configuration.
 In all of these cases, you will see similarities to the JMS support in the Spring Framework.
-For other project-related information visit the Spring AMQP project http://projects.spring.io/spring-amqp/[homepage].
+For other project-related information visit the Spring AMQP project https://projects.spring.io/spring-amqp/[homepage].

--- a/src/reference/asciidoc/quick-tour.adoc
+++ b/src/reference/asciidoc/quick-tour.adoc
@@ -5,7 +5,7 @@
 
 This is the 5 minute tour to get started with Spring AMQP.
 
-Prerequisites: install and run the RabbitMQ broker (http://www.rabbitmq.com/download.html[http://www.rabbitmq.com/download.html]).
+Prerequisites: install and run the RabbitMQ broker (https://www.rabbitmq.com/download.html[https://www.rabbitmq.com/download.html]).
 Then grab the spring-rabbit JAR and all its dependencies - the easiest way to do that is to declare a dependency in your build tool, e.g.
 for Maven:
 
@@ -77,9 +77,9 @@ String foo = (String) template.receiveAndConvert("myqueue");
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:rabbit="http://www.springframework.org/schema/rabbit"
        xsi:schemaLocation="http://www.springframework.org/schema/rabbit
-           http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+           https://www.springframework.org/schema/rabbit/spring-rabbit.xsd
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans.xsd">
+           https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <rabbit:connection-factory id="connectionFactory"/>
 

--- a/src/reference/asciidoc/sample-apps.adoc
+++ b/src/reference/asciidoc/sample-apps.adoc
@@ -8,7 +8,7 @@ The first is a simple "Hello World" example that demonstrates both synchronous a
 It provides an excellent starting point for acquiring an understanding of the essential components.
 The second sample is based on a stock-trading use case to demonstrate the types of interaction that would be common in real world applications.
 In this chapter, we will provide a quick walk-through of each sample so that you can focus on the most important components.
-The samples are both Maven-based, so you should be able to import them directly into any Maven-aware IDE (such as http://www.springsource.org/sts[SpringSource Tool Suite]).
+The samples are both Maven-based, so you should be able to import them directly into any Maven-aware IDE (such as https://www.springsource.org/sts[SpringSource Tool Suite]).
 
 ==== Hello World
 
@@ -23,7 +23,7 @@ You can import the 'spring-rabbit-helloworld' sample into the IDE and then follo
 Within the 'src/main/java' directory, navigate to the 'org.springframework.amqp.helloworld' package.
 Open the HelloWorldConfiguration class and notice that it contains the @Configuration annotation at class-level and some @Bean annotations at method-level.
 This is an example of Spring's Java-based configuration.
-You can read more about that http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/htmlsingle/spring-framework-reference.html#beans-java[here].
+You can read more about that https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/htmlsingle/spring-framework-reference.html#beans-java[here].
 
 [source,java]
 ----
@@ -135,7 +135,7 @@ static class ScheduledProducer {
 ----
 
 You don't need to understand all of the details since the real focus should be on the receiving side (which we will cover momentarily).
-However, if you are not yet familiar with Spring 3.0 task scheduling support, you can learn more http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/htmlsingle/spring-framework-reference.html#scheduling-annotation-support[here].
+However, if you are not yet familiar with Spring 3.0 task scheduling support, you can learn more https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/htmlsingle/spring-framework-reference.html#scheduling-annotation-support[here].
 The short story is that the "postProcessor" bean in the ProducerConfiguration is registering the task with a scheduler.
 
 Now, let's turn to the receiving side.

--- a/src/reference/asciidoc/si-amqp.adoc
+++ b/src/reference/asciidoc/si-amqp.adoc
@@ -4,7 +4,7 @@
 [[spring-integration-amqp-introduction]]
 ==== Introduction
 
-The http://www.springsource.org/spring-integration[Spring Integration] project includes AMQP Channel Adapters and Gateways that build upon the Spring AMQP project.
+The https://www.springsource.org/spring-integration[Spring Integration] project includes AMQP Channel Adapters and Gateways that build upon the Spring AMQP project.
 Those adapters are developed and released in the Spring Integration project.
 In Spring Integration, "Channel Adapters" are unidirectional (one-way) whereas "Gateways" are bidirectional (request-reply).
 We provide an inbound-channel-adapter, outbound-channel-adapter, inbound-gateway, and outbound-gateway.

--- a/src/reference/asciidoc/stylesheets/golo.css
+++ b/src/reference/asciidoc/stylesheets/golo.css
@@ -1,8 +1,8 @@
-@import url(http://fonts.googleapis.com/css?family=Varela+Round|Open+Sans:400italic,700italic,400,700);
+@import url(https://fonts.googleapis.com/css?family=Varela+Round|Open+Sans:400italic,700italic,400,700);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
 
 /** Correct `inline-block` display not defined in IE 8/9. */


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://www.eddieware.org/EPL (301) with 1 occurrences could not be migrated:  
   ([https](https://www.eddieware.org/EPL) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://bugs.sun.com/view_bug.do?bug_id=6682380 (302) with 1 occurrences migrated to:  
  https://bugs.java.com/view_bug.do?bug_id=6682380 ([https](https://bugs.sun.com/view_bug.do?bug_id=6682380) result SSLHandshakeException).
* [ ] http://static.springsource.org/spring-amqp/reference/html/amqp.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/reference/html/amqp.html ([https](https://static.springsource.org/spring-amqp/reference/html/amqp.html) result 404).
* [ ] http://static.springsource.org/sts/docs/latest/reference/html/gradle/installation.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/sts/docs/latest/reference/html/gradle/installation.html ([https](https://static.springsource.org/sts/docs/latest/reference/html/gradle/installation.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css ([https](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css) result 200).
* [ ] http://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html ([https](https://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/MessageProperties.html) result 200).
* [ ] http://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html ([https](https://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/core/RabbitTemplate.html) result 200).
* [ ] http://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html ([https](https://static.springsource.org/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html) result 200).
* [ ] http://docs.spring.io/spring-amqp/reference/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/reference/ ([https](https://docs.spring.io/spring-amqp/reference/) result 200).
* [ ] http://static.springsource.org/spring-retry/docs/api/current/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-retry/docs/api/current/ ([https](https://static.springsource.org/spring-retry/docs/api/current/) result 200).
* [ ] http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/oxm.html ([https](https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/oxm.html) result 200).
* [ ] http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/htmlsingle/spring-framework-reference.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/htmlsingle/spring-framework-reference.html ([https](https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/htmlsingle/spring-framework-reference.html) result 200).
* [ ] http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html ([https](https://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html) result 200).
* [ ] http://fonts.googleapis.com/css?family=Varela+Round|Open+Sans:400italic,700italic,400,700 with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Varela+Round|Open+Sans:400italic,700italic,400,700 ([https](https://fonts.googleapis.com/css?family=Varela+Round|Open+Sans:400italic,700italic,400,700) result 200).
* [ ] http://github.com/spring-projects/spring-amqp with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-amqp ([https](https://github.com/spring-projects/spring-amqp) result 200).
* [ ] http://github.com/spring-projects/spring-amqp-samples with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-amqp-samples ([https](https://github.com/spring-projects/spring-amqp-samples) result 200).
* [ ] http://gradle.org/ with 2 occurrences migrated to:  
  https://gradle.org/ ([https](https://gradle.org/) result 200).
* [ ] http://projects.spring.io/spring-amqp/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-amqp/ ([https](https://projects.spring.io/spring-amqp/) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-amqp with 3 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-amqp ([https](https://stackoverflow.com/questions/tagged/spring-amqp) result 200).
* [ ] http://www.amqp.org/ with 2 occurrences migrated to:  
  https://www.amqp.org/ ([https](https://www.amqp.org/) result 200).
* [ ] http://www.amqp.org/resources/download with 1 occurrences migrated to:  
  https://www.amqp.org/resources/download ([https](https://www.amqp.org/resources/download) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.rabbitmq.com/ with 2 occurrences migrated to:  
  https://www.rabbitmq.com/ ([https](https://www.rabbitmq.com/) result 200).
* [ ] http://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/ ([https](https://www.rabbitmq.com/blog/2011/02/10/introducing-publisher-confirms/) result 200).
* [ ] http://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/ ([https](https://www.rabbitmq.com/blog/2013/12/16/using-consumer-priorities-with-rabbitmq/) result 200).
* [ ] http://www.rabbitmq.com/direct-reply-to.html with 3 occurrences migrated to:  
  https://www.rabbitmq.com/direct-reply-to.html ([https](https://www.rabbitmq.com/direct-reply-to.html) result 200).
* [ ] http://www.rabbitmq.com/download.html with 2 occurrences migrated to:  
  https://www.rabbitmq.com/download.html ([https](https://www.rabbitmq.com/download.html) result 200).
* [ ] http://www.rabbitmq.com/how.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/how.html ([https](https://www.rabbitmq.com/how.html) result 200).
* [ ] http://www.rabbitmq.com/semantics.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/semantics.html ([https](https://www.rabbitmq.com/semantics.html) result 200).
* [ ] http://www.rabbitmq.com/ttl.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/ttl.html ([https](https://www.rabbitmq.com/ttl.html) result 200).
* [ ] http://www.rabbitmq.com/tutorials/tutorial-six-java.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/tutorials/tutorial-six-java.html ([https](https://www.rabbitmq.com/tutorials/tutorial-six-java.html) result 200).
* [ ] http://www.sonarsource.org/ (301) with 2 occurrences migrated to:  
  https://www.sonarqube.org/ ([https](https://www.sonarsource.org/) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/rabbit/spring-rabbit.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/rabbit/spring-rabbit.xsd ([https](https://www.springframework.org/schema/rabbit/spring-rabbit.xsd) result 200).
* [ ] http://static.springsource.org/spring/docs/current/spring-framework-reference/html/remoting.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/remoting.html ([https](https://static.springsource.org/spring/docs/current/spring-framework-reference/html/remoting.html) result 301).
* [ ] http://forum.springsource.org/forumdisplay.php?f=74 (301) with 2 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?f=74 ([https](https://forum.springsource.org/forumdisplay.php?f=74) result 301).
* [ ] http://github.com/SpringSource/spring-amqp with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-amqp ([https](https://github.com/SpringSource/spring-amqp) result 301).
* [ ] http://github.com/SpringSource/spring-amqp-samples with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-amqp-samples ([https](https://github.com/SpringSource/spring-amqp-samples) result 301).
* [ ] http://help.github.com/forking/ with 2 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://www.mozilla.org/MPL/ with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).
* [ ] http://www.rabbitmq.com/install.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/install.html ([https](https://www.rabbitmq.com/install.html) result 301).
* [ ] http://www.spring.io with 3 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* [ ] http://www.spring.io/spring-amqp with 1 occurrences migrated to:  
  https://www.spring.io/spring-amqp ([https](https://www.spring.io/spring-amqp) result 301).
* [ ] http://www.springsource.org/spring-amqp with 1 occurrences migrated to:  
  https://www.springsource.org/spring-amqp ([https](https://www.springsource.org/spring-amqp) result 301).
* [ ] http://www.springsource.org/spring-integration with 1 occurrences migrated to:  
  https://www.springsource.org/spring-integration ([https](https://www.springsource.org/spring-integration) result 301).
* [ ] http://www.springsource.org/sts with 1 occurrences migrated to:  
  https://www.springsource.org/sts ([https](https://www.springsource.org/sts) result 301).
* [ ] http://www.springsource.org/node/feed with 2 occurrences migrated to:  
  https://www.springsource.org/node/feed ([https](https://www.springsource.org/node/feed) result 302).

# Ignored
These URLs were intentionally ignored.

* http://host1:15672 with 1 occurrences
* http://host2:15672 with 1 occurrences
* http://host:port with 4 occurrences
* http://localhost:11235 with 2 occurrences
* http://localhost:11236 with 2 occurrences
* http://localhost:15672 with 2 occurrences
* http://localhost:15672/api/ with 2 occurrences
* http://www.springframework.org/schema/beans with 14 occurrences
* http://www.springframework.org/schema/rabbit with 16 occurrences
* http://www.springframework.org/schema/tool with 12 occurrences
* http://www.w3.org/2001/XMLSchema with 6 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 7 occurrences