### PR TITLE
Add type-safe queue properties to AmqpAdmin

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpAdmin.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpAdmin.java
@@ -119,6 +119,14 @@ public interface AmqpAdmin {
 	Properties getQueueProperties(String queueName);
 
 	/**
+	 * Returns information about the queue, if it exists.
+	 * @param queueName the name of the queue.
+	 * @return the information or null if the queue doesn't exist.
+	 */
+	@Nullable
+	QueueInformation getQueueInfo(String queueName);
+
+	/**
 	 * Initialize the admin.
 	 * @since 2.1
 	 */

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/QueueInformation.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/QueueInformation.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.core;
+
+/**
+ * Information about a queue, resulting from a passive declaration.
+ *
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+public class QueueInformation {
+
+	private final String name;
+
+	private final int messageCount;
+
+	private final int consumerCount;
+
+	public QueueInformation(String name, int messageCount, int consumerCount) {
+		this.name = name;
+		this.messageCount = messageCount;
+		this.consumerCount = consumerCount;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public int getMessageCount() {
+		return this.messageCount;
+	}
+
+	public int getConsumerCount() {
+		return this.consumerCount;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		QueueInformation other = (QueueInformation) obj;
+		if (this.name == null) {
+			if (other.name != null) {
+				return false;
+			}
+		}
+		else if (!this.name.equals(other.name)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "QueueInformation [name=" + this.name + ", messageCount=" + this.messageCount + ", consumerCount="
+				+ this.consumerCount + "]";
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/QueueInformation.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/QueueInformation.java
@@ -20,7 +20,7 @@ package org.springframework.amqp.core;
  * Information about a queue, resulting from a passive declaration.
  *
  * @author Gary Russell
- * @since 2.1
+ * @since 2.2
  *
  */
 public class QueueInformation {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitAdminTests.java
@@ -68,6 +68,7 @@ import org.springframework.amqp.core.Declarables;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Exchange;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueInformation;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -185,10 +186,9 @@ public class RabbitAdminTests {
 	}
 
 	private int messageCount(RabbitAdmin rabbitAdmin, String queueName) {
-		Properties props = rabbitAdmin.getQueueProperties(queueName);
-		assertNotNull(props);
-		assertNotNull(props.get(RabbitAdmin.QUEUE_MESSAGE_COUNT));
-		return (Integer) props.get(RabbitAdmin.QUEUE_MESSAGE_COUNT);
+		QueueInformation info = rabbitAdmin.getQueueInfo(queueName);
+		assertNotNull(info);
+		return info.getMessageCount();
 	}
 
 	@Test


### PR DESCRIPTION
Retain (don't deprecate) the current method for JMX users.

