### PR TITLE
GH-920: Propagate afterReceive to AsyncRTemplate

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/AbstractCompressingPostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/postprocessor/AbstractCompressingPostProcessor.java
@@ -27,7 +27,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpIOException;
 import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.MessageBuilderSupport;
 import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.core.MessagePropertiesBuilder;
@@ -52,6 +51,8 @@ public abstract class AbstractCompressingPostProcessor implements MessagePostPro
 
 	private int order;
 
+	private boolean copyProperties = false;
+
 	/**
 	 * Construct a post processor that will include the
 	 * {@link MessageProperties#SPRING_AUTO_DECOMPRESS} header set to 'true'.
@@ -72,29 +73,47 @@ public abstract class AbstractCompressingPostProcessor implements MessagePostPro
 		this.autoDecompress = autoDecompress;
 	}
 
+	/**
+	 * Flag to indicate if {@link MessageProperties} should be used as is or cloned for new message
+	 * after compression.
+	 * By default this flag is turned off for better performance since in most cases the original message
+	 * is not used any more.
+	 * @param copyProperties clone or reuse original message properties.
+	 * @since 2.1.5
+	 */
+	public void setCopyProperties(boolean copyProperties) {
+		this.copyProperties = copyProperties;
+	}
+
 	@Override
 	public Message postProcessMessage(Message message) throws AmqpException {
-		ByteArrayOutputStream zipped = new ByteArrayOutputStream();
 		try {
+			ByteArrayOutputStream zipped = new ByteArrayOutputStream();
 			OutputStream zipper = getCompressorStream(zipped);
 			FileCopyUtils.copy(new ByteArrayInputStream(message.getBody()), zipper);
-			MessageProperties originalProperties = message.getMessageProperties();
-			MessageBuilderSupport<MessageProperties> messagePropertiesMessageBuilder =
-					MessagePropertiesBuilder.fromClonedProperties(originalProperties)
-							.setContentEncoding(getEncoding() +
-									(originalProperties.getContentEncoding() == null
-											? ""
-											: ":" + originalProperties.getContentEncoding()));
-
-			if (this.autoDecompress) {
-				messagePropertiesMessageBuilder.setHeader(MessageProperties.SPRING_AUTO_DECOMPRESS, true);
-			}
-
-			MessageProperties messageProperties = messagePropertiesMessageBuilder.build();
 			byte[] compressed = zipped.toByteArray();
 			if (this.logger.isTraceEnabled()) {
 				this.logger.trace("Compressed " + message.getBody().length + " to " + compressed.length);
 			}
+
+			MessageProperties originalProperties = message.getMessageProperties();
+
+			MessagePropertiesBuilder messagePropertiesBuilder =
+					this.copyProperties
+							? MessagePropertiesBuilder.fromClonedProperties(originalProperties)
+							: MessagePropertiesBuilder.fromProperties(originalProperties);
+
+			if (this.autoDecompress) {
+				messagePropertiesBuilder.setHeader(MessageProperties.SPRING_AUTO_DECOMPRESS, true);
+			}
+
+			MessageProperties messageProperties =
+					messagePropertiesBuilder.setContentEncoding(getEncoding() +
+							(originalProperties.getContentEncoding() == null
+									? ""
+									: ":" + originalProperties.getContentEncoding()))
+							.build();
+
 			return new Message(compressed, messageProperties);
 		}
 		catch (IOException e) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -16,7 +16,6 @@
 
 package org.springframework.amqp.rabbit;
 
-import java.util.Collection;
 import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,6 +48,7 @@ import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SmartMessageConverter;
+import org.springframework.amqp.utils.JavaUtils;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.core.ParameterizedTypeReference;
@@ -158,11 +158,10 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 		this.template.setExchange(exchange == null ? "" : exchange);
 		this.template.setRoutingKey(routingKey);
 		this.container = new SimpleMessageListenerContainer(connectionFactory);
-		Collection<MessagePostProcessor> afterReceivePostProcessors = this.template.getAfterReceivePostProcessors();
-		if (afterReceivePostProcessors != null) {
-			this.container.setAfterReceivePostProcessors(
-					afterReceivePostProcessors.toArray(new MessagePostProcessor[0]));
-		}
+		JavaUtils.INSTANCE
+				.acceptIfNotNull(this.template.getAfterReceivePostProcessors(),
+						(value) -> this.container.setAfterReceivePostProcessors(
+								value.toArray(new MessagePostProcessor[0])));
 		this.container.setQueueNames(replyQueue);
 		this.container.setMessageListener(this);
 		this.container.afterPropertiesSet();
@@ -240,11 +239,10 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 		this.container = null;
 		this.replyAddress = null;
 		this.directReplyToContainer = new DirectReplyToMessageListenerContainer(this.template.getConnectionFactory());
-		Collection<MessagePostProcessor> afterReceivePostProcessors = template.getAfterReceivePostProcessors();
-		if (afterReceivePostProcessors != null) {
-			this.directReplyToContainer.setAfterReceivePostProcessors(
-					afterReceivePostProcessors.toArray(new MessagePostProcessor[0]));
-		}
+		JavaUtils.INSTANCE
+				.acceptIfNotNull(template.getAfterReceivePostProcessors(),
+						(value) -> this.directReplyToContainer.setAfterReceivePostProcessors(
+								value.toArray(new MessagePostProcessor[0])));
 		this.directReplyToContainer.setMessageListener(this);
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -290,7 +290,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 	 *
 	 * @param exchange the exchange name to use for send operations
 	 */
-	public void setExchange(String exchange) {
+	public void setExchange(@Nullable String exchange) {
 		this.exchange = (exchange != null) ? exchange : DEFAULT_EXCHANGE;
 	}
 
@@ -643,6 +643,18 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 		Assert.notNull(afterReceivePostProcessors, "'afterReceivePostProcessors' cannot be null");
 		Assert.noNullElements(afterReceivePostProcessors, "'afterReceivePostProcessors' cannot have null elements");
 		this.afterReceivePostProcessors = MessagePostProcessorUtils.sort(Arrays.asList(afterReceivePostProcessors));
+	}
+
+	/**
+	 * Return configured after receive {@link MessagePostProcessor}s or {@code null}.
+	 * @return configured after receive {@link MessagePostProcessor}s or {@code null}.
+	 * @since 2.1.5
+	 */
+	@Nullable
+	public Collection<MessagePostProcessor> getAfterReceivePostProcessors() {
+		return this.afterReceivePostProcessors != null
+				? Collections.unmodifiableCollection(this.afterReceivePostProcessors)
+				: null;
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
@@ -394,7 +394,7 @@ public class AsyncRabbitTemplateTests {
 
 	private void checkConverterResult(ListenableFuture<String> future, String expected) throws InterruptedException {
 		final CountDownLatch latch = new CountDownLatch(1);
-		final AtomicReference<String> resultRef = new AtomicReference<String>();
+		final AtomicReference<String> resultRef = new AtomicReference<>();
 		future.addCallback(new ListenableFutureCallback<String>() {
 
 			@Override
@@ -415,7 +415,7 @@ public class AsyncRabbitTemplateTests {
 
 	private Message checkMessageResult(ListenableFuture<Message> future, String expected) throws InterruptedException {
 		final CountDownLatch latch = new CountDownLatch(1);
-		final AtomicReference<Message> resultRef = new AtomicReference<Message>();
+		final AtomicReference<Message> resultRef = new AtomicReference<>();
 		future.addCallback(new ListenableFutureCallback<Message>() {
 
 			@Override
@@ -489,10 +489,17 @@ public class AsyncRabbitTemplateTests {
 		}
 
 		@Bean
+		public GZipPostProcessor gZipPostProcessor() {
+			GZipPostProcessor gZipPostProcessor = new GZipPostProcessor();
+			gZipPostProcessor.setCopyProperties(true);
+			return gZipPostProcessor;
+		}
+
+		@Bean
 		public RabbitTemplate template(ConnectionFactory connectionFactory) {
 			RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
 			rabbitTemplate.setRoutingKey(requests().getName());
-			rabbitTemplate.addBeforePublishPostProcessors(new GZipPostProcessor());
+			rabbitTemplate.addBeforePublishPostProcessors(gZipPostProcessor());
 			rabbitTemplate.addAfterReceivePostProcessors(new GUnzipPostProcessor());
 			return rabbitTemplate;
 		}
@@ -501,7 +508,7 @@ public class AsyncRabbitTemplateTests {
 		public RabbitTemplate templateForDirect(ConnectionFactory connectionFactory) {
 			RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
 			rabbitTemplate.setRoutingKey(requests().getName());
-			rabbitTemplate.addBeforePublishPostProcessors(new GZipPostProcessor());
+			rabbitTemplate.addBeforePublishPostProcessors(gZipPostProcessor());
 			rabbitTemplate.addAfterReceivePostProcessors(new GUnzipPostProcessor());
 			return rabbitTemplate;
 		}
@@ -556,7 +563,7 @@ public class AsyncRabbitTemplateTests {
 								return message.toUpperCase();
 							});
 
-			messageListener.setBeforeSendReplyPostProcessors(new GZipPostProcessor());
+			messageListener.setBeforeSendReplyPostProcessors(gZipPostProcessor());
 			container.setMessageListener(messageListener);
 			return container;
 		}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3435,6 +3435,11 @@ The second is invoked immediately after a message is received.
 These extension points are used for such features as compression and, for this purpose, several `MessagePostProcessor` implementations are provided.
 `GZipPostProcessor` and `ZipPostProcessor` compress messages before sending, and `GUnzipPostProcessor` and `UnzipPostProcessor` decompress received messages.
 
+NOTE: Starting with version 2.1.5, the `GZipPostProcessor` can be configured with the `copyProperties = true` option to make a fully fresh copy of an original message properties.
+By default these properties are re-used for performance reason and modified with compression content encoding and optional `MessageProperties.SPRING_AUTO_DECOMPRESS` header.
+This way an original message get modified properties as well.
+So, if your application produces messages by itself (e.g. direct usage of `RabbitTemplate.sendAndReceive()`), consider to turn ``copyProperties` option on.
+
 Similarly, the `SimpleMessageListenerContainer` also has a `setAfterReceivePostProcessors()` method, letting the decompression be performed after messages are received by the container.
 
 Starting with version 2.1.4, `addBeforePublishPostProcessors()` and `addAfterReceivePostProcessors()` have been added to the `RabbitTemplate` to allow appending new post processors to the list of before publish and after receive post processors respectively.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/920

The `AsyncRabbitTemplate` is missing an after receive post-processing
in its internal containers for replies

* Reuse `afterPostProcessors` from the provided `RabbitTemplate` and
propagate them into the internal listener containers for replies
* Fix `AbstractCompressingPostProcessor` do not mutate provided
`MessageProperties` and build a fresh instance.
* Demonstrate post-processors propagation by the `GZipPostProcessor`
& `GUnzipPostProcessor` configuration in the `AsyncRabbitTemplateTests`

**Cherry-pick to 2.1.x**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
