### PR TITLE
GH-973: Higher order for RabbitListenerTestHarness

### DIFF
--- a/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
+++ b/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
@@ -47,6 +47,8 @@ import org.springframework.util.StringUtils;
  * by autowiring the test harness into test cases.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.6
  *
  */
@@ -54,11 +56,11 @@ public class RabbitListenerTestHarness extends RabbitListenerAnnotationBeanPostP
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
-	private final Map<String, CaptureAdvice> listenerCapture = new HashMap<String, CaptureAdvice>();
+	private final Map<String, CaptureAdvice> listenerCapture = new HashMap<>();
+
+	private final Map<String, Object> listeners = new HashMap<>();
 
 	private final AnnotationAttributes attributes;
-
-	private final Map<String, Object> listeners = new HashMap<String, Object>();
 
 	public RabbitListenerTestHarness(AnnotationMetadata importMetadata) {
 		Map<String, Object> map = importMetadata.getAnnotationAttributes(RabbitListenerTest.class.getName());
@@ -112,9 +114,14 @@ public class RabbitListenerTestHarness extends RabbitListenerAnnotationBeanPostP
 		return (T) this.listeners.get(id);
 	}
 
+	@Override
+	public int getOrder() {
+		return super.getOrder() - 100;
+	}
+
 	private static final class CaptureAdvice implements MethodInterceptor {
 
-		private final BlockingQueue<InvocationData> invocationData = new LinkedBlockingQueue<InvocationData>();
+		private final BlockingQueue<InvocationData> invocationData = new LinkedBlockingQueue<>();
 
 		CaptureAdvice() {
 			super();
@@ -122,15 +129,15 @@ public class RabbitListenerTestHarness extends RabbitListenerAnnotationBeanPostP
 
 		@Override
 		public Object invoke(MethodInvocation invocation) throws Throwable {
-			Object result = null;
 			boolean isListenerMethod =
 					AnnotationUtils.findAnnotation(invocation.getMethod(), RabbitListener.class) != null
 					|| AnnotationUtils.findAnnotation(invocation.getMethod(), RabbitHandler.class) != null;
 			try {
-				result = invocation.proceed();
+				Object result = invocation.proceed();
 				if (isListenerMethod) {
 					this.invocationData.put(new InvocationData(invocation, result));
 				}
+				return result;
 			}
 			catch (Throwable t) { // NOSONAR - rethrown below
 				if (isListenerMethod) {
@@ -138,7 +145,6 @@ public class RabbitListenerTestHarness extends RabbitListenerAnnotationBeanPostP
 				}
 				throw t;
 			}
-			return result;
 		}
 
 	}

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/ExampleRabbitListenerSpyTest.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/ExampleRabbitListenerSpyTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
@@ -50,6 +51,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.6
  *
  */
@@ -74,7 +77,7 @@ public class ExampleRabbitListenerSpyTest {
 	private RabbitListenerTestHarness harness;
 
 	@Test
-	public void testTwoWay() throws Exception {
+	public void testTwoWay() {
 		assertEquals("FOO", this.rabbitTemplate.convertSendAndReceive(this.queue1.getName(), "foo"));
 
 		Listener listener = this.harness.getSpy("foo");
@@ -99,6 +102,7 @@ public class ExampleRabbitListenerSpyTest {
 	}
 
 	@Configuration
+	@EnableRabbit
 	@RabbitListenerTest
 	public static class Config {
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/973

When we use `@EnableRabbit` and `@RabbitListenerTest` in the same
configuration set, e.g. mixing real `@Configuration` and test one for
`@RabbitListenerTest`, we may end up with the case when `@EnableRabbit`
is processed before `@RabbitListenerTest`, so, `RabbitListenerTestHarness`
bean is not going to appear in the application context.

* Override `getOrder()` for the `RabbitListenerTestHarness` to give it
higher priority than regular `RabbitListenerAnnotationBeanPostProcessor`,
so it is registered first and then the last one won't override existing
bean

**Cherry-pick to 2.1.x**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
