### PR TITLE
Add Spring Data projection support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ subprojects { subproject ->
 		googleJsr305Version = '3.0.2'
 		hamcrestVersion = '1.3'
 		jackson2Version = '2.9.8'
+		jaywayJsonPathVersion = '2.4.0'
 		junit4Version = '4.12'
 		junitJupiterVersion = '5.4.0'
 		junitPlatformVersion = '1.4.0'
@@ -88,6 +89,7 @@ subprojects { subproject ->
 		rabbitmqVersion = project.hasProperty('rabbitmqVersion') ? project.rabbitmqVersion : '5.7.0'
 		rabbitmqHttpClientVersion = '3.2.0.RELEASE'
 		reactorVersion = '3.2.6.RELEASE'
+		springDataCommonsVersion = '2.2.0.M3'
 
 		springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.2.0.M1'
 
@@ -283,6 +285,10 @@ project('spring-amqp') {
 		compile ("com.fasterxml.jackson.core:jackson-core:$jackson2Version", optional)
 		compile ("com.fasterxml.jackson.core:jackson-databind:$jackson2Version", optional)
 		compile ("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jackson2Version", optional)
+
+		// Spring Data projection message binding support
+		compile ("org.springframework.data:spring-data-commons:$springDataCommonsVersion", optional)
+		compile ("com.jayway.jsonpath:json-path:$jaywayJsonPathVersion", optional)
 
 		testCompile "org.assertj:assertj-core:$assertjVersion"
 		testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJackson2MessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJackson2MessageConverter.java
@@ -74,6 +74,10 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 
 	private Jackson2JavaTypeMapper javaTypeMapper = new DefaultJackson2JavaTypeMapper();
 
+	private boolean useProjectionForInterfaces;
+
+	private ProjectingMessageConverter projectingConverter;
+
 	/**
 	 * Construct with the provided {@link ObjectMapper} instance.
 	 * @param objectMapper the {@link ObjectMapper} to use.
@@ -184,6 +188,20 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 		}
 	}
 
+	protected boolean isUseProjectionForInterfaces() {
+		return this.useProjectionForInterfaces;
+	}
+
+	/**
+	 * Set to true to use Spring Data projection to create the object if the inferred
+	 * parameter type is an interface.
+	 * @param useProjectionForInterfaces true to use projection.
+	 * @since 2.2
+	 */
+	public void setUseProjectionForInterfaces(boolean useProjectionForInterfaces) {
+		this.useProjectionForInterfaces = useProjectionForInterfaces;
+	}
+
 	@Override
 	public Object fromMessage(Message message) throws MessageConversionException {
 		return fromMessage(message, null);
@@ -205,7 +223,15 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 					encoding = getDefaultCharset();
 				}
 				try {
-					if (conversionHint instanceof ParameterizedTypeReference) {
+					JavaType inferredType = this.javaTypeMapper.getInferredType(properties);
+					if (inferredType != null && this.useProjectionForInterfaces && inferredType.isInterface()
+							&& !inferredType.getRawClass().getPackage().getName().startsWith("java.util")) { // List etc
+						if (this.projectingConverter == null) {
+							this.projectingConverter = new ProjectingMessageConverter(this.objectMapper);
+						}
+						content = this.projectingConverter.convert(message, inferredType.getRawClass());
+					}
+					else if (conversionHint instanceof ParameterizedTypeReference) {
 						content = convertBytesToObject(message.getBody(), encoding,
 								this.objectMapper.getTypeFactory().constructType(
 										((ParameterizedTypeReference<?>) conversionHint).getType()));
@@ -265,9 +291,14 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 
 		byte[] bytes;
 		try {
-			String jsonString = this.objectMapper
-					.writeValueAsString(objectToConvert);
-			bytes = jsonString.getBytes(getDefaultCharset());
+			if (getDefaultCharset().equals("UTF-8")) {
+				bytes = this.objectMapper.writeValueAsBytes(objectToConvert);
+			}
+			else {
+				String jsonString = this.objectMapper
+						.writeValueAsString(objectToConvert);
+				bytes = jsonString.getBytes(getDefaultCharset());
+			}
 		}
 		catch (IOException e) {
 			throw new MessageConversionException("Failed to convert Message content", e);

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  * @author Artem Bilan
  * @author Gary Russell
  */
-public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
-		implements Jackson2JavaTypeMapper, ClassMapper {
+public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper implements Jackson2JavaTypeMapper {
 
 	private static final List<String> TRUSTED_PACKAGES =
 			Arrays.asList(

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/Jackson2JavaTypeMapper.java
@@ -17,6 +17,7 @@
 package org.springframework.amqp.support.converter;
 
 import org.springframework.amqp.core.MessageProperties;
+import org.springframework.lang.Nullable;
 
 import com.fasterxml.jackson.databind.JavaType;
 
@@ -70,5 +71,15 @@ public interface Jackson2JavaTypeMapper extends ClassMapper {
 	default void addTrustedPackages(String... packages) {
 		// no op
 	}
+
+	/**
+	 * Return the inferred type, if the type precedence is inferred and the
+	 * header is present.
+	 * @param properties the message properties.
+	 * @return the type.
+	 * @since 2.2
+	 */
+	@Nullable
+	JavaType getInferredType(MessageProperties properties);
 
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/ProjectingMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/ProjectingMessageConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.support.converter;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Type;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.core.ResolvableType;
+import org.springframework.data.projection.MethodInterceptorFactory;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.web.JsonProjectingMethodInterceptorFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+
+/**
+ * Uses a Spring Data {@link ProjectionFactory} to bind incoming messages to projection
+ * interfaces.
+ *
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+public class ProjectingMessageConverter {
+
+	private final ProjectionFactory projectionFactory;
+
+	public ProjectingMessageConverter(ObjectMapper mapper) {
+		JacksonMappingProvider provider = new JacksonMappingProvider(mapper);
+		MethodInterceptorFactory interceptorFactory = new JsonProjectingMethodInterceptorFactory(provider);
+
+		SpelAwareProxyProjectionFactory factory = new SpelAwareProxyProjectionFactory();
+		factory.registerMethodInvokerFactory(interceptorFactory);
+
+		this.projectionFactory = factory;
+	}
+
+	public Object convert(Message message, Type type) {
+		return this.projectionFactory.createProjection(ResolvableType.forType(type).resolve(Object.class),
+				new ByteArrayInputStream(message.getBody()));
+	}
+
+}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/ProjectingMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/ProjectingMessageConverter.java
@@ -25,6 +25,7 @@ import org.springframework.data.projection.MethodInterceptorFactory;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.web.JsonProjectingMethodInterceptorFactory;
+import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
@@ -42,6 +43,7 @@ public class ProjectingMessageConverter {
 	private final ProjectionFactory projectionFactory;
 
 	public ProjectingMessageConverter(ObjectMapper mapper) {
+		Assert.notNull(mapper, "'mapper' cannot be null");
 		JacksonMappingProvider provider = new JacksonMappingProvider(mapper);
 		MethodInterceptorFactory interceptorFactory = new JsonProjectingMethodInterceptorFactory(provider);
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3308,7 +3308,7 @@ public void projection(SomeSample in) {
 ====
 
 Accessor methods will be used to lookup the property name as field in the received JSON document by default.
-The @JsonPath expression allows customization of the value lookup, and even to define multiple JSONPath expressions, to lookup values from multiple places until an expression returns an actual value.
+The `@JsonPath` expression allows customization of the value lookup, and even to define multiple JSON path expressions, to lookup values from multiple places until an expression returns an actual value.
 
 To enable this feature, set the `useProjectionForInterfaces` to `true` on the message converter.
 You must also add `spring-data:spring-data-commons` and `com.jayway.jsonpath:json-path` to the class path.

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3277,6 +3277,44 @@ converter to determine the type.
 IMPORTANT: Starting with version 1.6.11, `Jackson2JsonMessageConverter` and, therefore, `DefaultJackson2JavaTypeMapper` (`DefaultClassMapper`) provide the `trustedPackages` option to overcome https://pivotal.io/security/cve-2017-4995[Serialization Gadgets] vulnerability.
 By default and for backward compatiblity, the `Jackson2JsonMessageConverter` trusts all packages -- that is, it uses `*` for the option.
 
+[[data-projection]]
+====== Using Spring Data Projection Interfaces
+
+Starting with version 2.2, you can convert JSON to a Spring Data Projection interface instead of a concrete type.
+This allows very selective, and low-coupled bindings to data, including the lookup of values from multiple places inside the JSON document.
+For example the following interface can be defined as message payload type:
+
+====
+[source, java]
+----
+interface SomeSample {
+
+  @JsonPath({ "$.username", "$.user.name" })
+  String getUsername();
+
+}
+----
+====
+
+====
+[source, java]
+----
+@RabbitListener(queues = "projection")
+public void projection(SomeSample in) {
+    String username = in.getUsername();
+    ...
+}
+----
+====
+
+Accessor methods will be used to lookup the property name as field in the received JSON document by default.
+The @JsonPath expression allows customization of the value lookup, and even to define multiple JSONPath expressions, to lookup values from multiple places until an expression returns an actual value.
+
+To enable this feature, set the `useProjectionForInterfaces` to `true` on the message converter.
+You must also add `spring-data:spring-data-commons` and `com.jayway.jsonpath:json-path` to the class path.
+
+When used as the parameter to a `@RabbitListener` method, the interface type is automatically passed to the converter as normal.
+
 [[json-complex]]
 ====== Converting From a `Message` With `RabbitTemplate`
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -12,6 +12,9 @@ See <<async-annotation-driven-enable>> for more information.
 
 When using <<receiving-batch,batching>>, `@RabbitListener` methods can now receive a complete batch of messages in one call instead of getting them one at at time.
 
+Spring Data Projection interfaces are now supported by the `Jackson2JsonMessageConverter`.
+See <<data-projection>> for more information.
+
 ===== AMQP Logging Appenders Changes
 
 The Log4J and Logback `AmqpAppender` s now support a `verifyHostname` SSL option.


### PR DESCRIPTION
Add support for converting JSON message bodies to Spring Data Projection interfaces.
This allows very selective, and low-coupled bindings to data, including
the lookup of values from multiple places inside the JSON document.
For example the following interface can be defined as a message payload type:

```
interface SomeSample {

  @JsonPath({ "$.username", "$.user.name" })
  String getUsername();

}
```

Accessor methods will be used to lookup the property name as field in the
received JSON document by default.
The @JsonPath expression allows customization of the value lookup, and even
to define multiple JSONPath expressions, to lookup values from multiple
places until an expression returns an actual value.
