### PR TITLE
Fix RejectedExecutionException during close

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import java.util.concurrent.ExecutorService;
+
+import com.rabbitmq.client.Channel;
+
+/**
+ * A factory for {@link PublisherCallbackChannel}s.
+ *
+ * @author Gary Russell
+ * @since 2.1.6
+ *
+ */
+@FunctionalInterface
+public interface PublisherCallbackChannelFactory {
+
+	/**
+	 * Create a {@link PublisherCallbackChannel} instance based on the provided delegate
+	 * and executor.
+	 * @param delegate the delegate channel.
+	 * @param executor the executor.
+	 * @return the channel.
+	 */
+	PublisherCallbackChannel createChannel(Channel delegate, ExecutorService executor);
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelImpl.java
@@ -115,7 +115,7 @@ public class PublisherCallbackChannelImpl
 	 * Create a {@link PublisherCallbackChannelImpl} instance based on the provided
 	 * delegate and executor.
 	 * @param delegate the delegate channel.
-	 * @param executor the exceutor.
+	 * @param executor the executor.
 	 */
 	public PublisherCallbackChannelImpl(Channel delegate, ExecutorService executor) {
 		Assert.notNull(executor, "'executor' must not be null");
@@ -1115,6 +1115,10 @@ public class PublisherCallbackChannelImpl
 	@Override
 	public String toString() {
 		return "PublisherCallbackChannelImpl: " + this.delegate.toString();
+	}
+
+	public static PublisherCallbackChannelFactory factory() {
+		return (channel, exec) -> new PublisherCallbackChannelImpl(channel, exec);
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -49,6 +51,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -65,6 +68,8 @@ import org.springframework.amqp.AmqpConnectException;
 import org.springframework.amqp.AmqpTimeoutException;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
 import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.rabbitmq.client.Address;
@@ -1603,6 +1608,63 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		channel.close();
 		RabbitUtils.setPhysicalCloseRequired(channel, false);
 		Thread.sleep(6000);
+	}
+
+	@Test
+	public void testOrderlyShutDown() throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
+		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
+		Channel mockChannel = mock(Channel.class);
+
+		given(mockConnectionFactory.newConnection((ExecutorService) isNull(), anyString())).willReturn(mockConnection);
+		given(mockConnection.createChannel()).willReturn(mockChannel);
+		given(mockChannel.isOpen()).willReturn(true);
+		given(mockConnection.isOpen()).willReturn(true);
+
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ccf.setPublisherConfirms(true);
+		ApplicationContext ac = mock(ApplicationContext.class);
+		ccf.setApplicationContext(ac);
+		PublisherCallbackChannel pcc = mock(PublisherCallbackChannel.class);
+		given(pcc.isOpen()).willReturn(true);
+		AtomicReference<ExecutorService> executor = new AtomicReference<>();
+		AtomicBoolean rejected = new AtomicBoolean(true);
+		CountDownLatch closeLatch = new CountDownLatch(1);
+		ccf.setPublisherChannelFactory((channel, exec) -> {
+			executor.set(spy(exec));
+			return pcc;
+		});
+		willAnswer(invoc -> {
+			try {
+				executor.get().execute(() -> {
+				});
+				rejected.set(false);
+			}
+			catch (@SuppressWarnings("unused") RejectedExecutionException e) {
+				rejected.set(true);
+			}
+			closeLatch.countDown();
+			return null;
+		}).given(pcc).close();
+		Channel channel = ccf.createConnection().createChannel(false);
+		ExecutorService closeExec = Executors.newSingleThreadExecutor();
+		CountDownLatch asyncClosingLatch = new CountDownLatch(1);
+		closeExec.execute(() -> {
+			RabbitUtils.setPhysicalCloseRequired(channel, true);
+			try {
+				channel.close();
+				asyncClosingLatch.countDown();
+			}
+			catch (@SuppressWarnings("unused") IOException | TimeoutException e) {
+				// ignore
+			}
+		});
+		assertThat(asyncClosingLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		ccf.onApplicationEvent(new ContextClosedEvent(ac));
+		ccf.destroy();
+		assertThat(closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(rejected.get()).isFalse();
+		closeExec.shutdownNow();
 	}
 
 }


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/994

`CCF.destroy()` abruptly shuts down the `channelsExecutor` (if present).
This can cause `RejectedExecutionException` because the publisher
callback channel uses the same executor to schedule nacks if necessary.

- Use an `ActiveObjectCounter` to keep track of in-flight async closes
- Wait until there are not active objects before calling `shutDown()` (instead of `shutDownNow()`)
- Wait until all queued tasks are complete
- Add `PublisherCallbackChannelFactory` to make testing possible

__cherry-pick to 2.1.x__

**Suggest reviewing with `?w=1`**