### PR TITLE
Add isLastInBatch to MessageProperties

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -68,69 +68,71 @@ public class MessageProperties implements Serializable {
 
 	private final Map<String, Object> headers = new HashMap<>();
 
-	private volatile Date timestamp;
+	private Date timestamp;
 
-	private volatile String messageId;
+	private String messageId;
 
-	private volatile String userId;
+	private String userId;
 
-	private volatile String appId;
+	private String appId;
 
-	private volatile String clusterId;
+	private String clusterId;
 
-	private volatile String type;
+	private String type;
 
-	private volatile String correlationId;
+	private String correlationId;
 
-	private volatile String replyTo;
+	private String replyTo;
 
-	private volatile String contentType = DEFAULT_CONTENT_TYPE;
+	private String contentType = DEFAULT_CONTENT_TYPE;
 
-	private volatile String contentEncoding;
+	private String contentEncoding;
 
-	private volatile long contentLength;
+	private long contentLength;
 
-	private volatile boolean contentLengthSet;
+	private boolean contentLengthSet;
 
-	private volatile MessageDeliveryMode deliveryMode = DEFAULT_DELIVERY_MODE;
+	private MessageDeliveryMode deliveryMode = DEFAULT_DELIVERY_MODE;
 
-	private volatile String expiration;
+	private String expiration;
 
-	private volatile Integer priority = DEFAULT_PRIORITY;
+	private Integer priority = DEFAULT_PRIORITY;
 
-	private volatile Boolean redelivered;
+	private Boolean redelivered;
 
-	private volatile String receivedExchange;
+	private String receivedExchange;
 
-	private volatile String receivedRoutingKey;
+	private String receivedRoutingKey;
 
-	private volatile String receivedUserId;
+	private String receivedUserId;
 
-	private volatile long deliveryTag;
+	private long deliveryTag;
 
-	private volatile boolean deliveryTagSet;
+	private boolean deliveryTagSet;
 
-	private volatile Integer messageCount;
+	private Integer messageCount;
 
 	// Not included in hashCode()
 
-	private volatile String consumerTag;
+	private String consumerTag;
 
-	private volatile String consumerQueue;
+	private String consumerQueue;
 
-	private volatile Integer receivedDelay;
+	private Integer receivedDelay;
 
-	private volatile MessageDeliveryMode receivedDeliveryMode;
+	private MessageDeliveryMode receivedDeliveryMode;
 
-	private volatile boolean finalRetryForMessageWithNoId;
+	private boolean finalRetryForMessageWithNoId;
 
-	private volatile long publishSequenceNumber;
+	private long publishSequenceNumber;
 
-	private transient volatile Type inferredArgumentType;
+	private boolean lastInBatch;
 
-	private transient volatile Method targetMethod;
+	private transient Type inferredArgumentType;
 
-	private transient volatile Object targetBean;
+	private transient Method targetMethod;
+
+	private transient Object targetBean;
 
 	public void setHeader(String key, Object value) {
 		this.headers.put(key, value);
@@ -533,6 +535,24 @@ public class MessageProperties implements Serializable {
 	}
 
 	/**
+	 * When true; the message having these properties is the last message from a batch.
+	 * @return true for the last message.
+	 * @since 2.2
+	 */
+	public boolean isLastInBatch() {
+		return this.lastInBatch;
+	}
+
+	/**
+	 * Set to true to indicate these properties are for the last message in a batch.
+	 * @param lastInBatch true for the last.
+	 * @since 2.2
+	 */
+	public void setLastInBatch(boolean lastInBatch) {
+		this.lastInBatch = lastInBatch;
+	}
+
+	/**
 	 * Return the x-death header.
 	 * @return the header.
 	 */
@@ -541,7 +561,7 @@ public class MessageProperties implements Serializable {
 		try {
 			return (List<Map<String, ?>>) this.headers.get("x-death");
 		}
-		catch (Exception e) {
+		catch (@SuppressWarnings("unused") Exception e) {
 			return null;
 		}
 	}

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
@@ -118,4 +118,10 @@ public abstract class AmqpHeaders {
 	 */
 	public static final String RAW_MESSAGE = PREFIX + "raw_message";
 
+	/**
+	 * A flag to indicate that the current message is the last from a batch.
+	 * @since 2.2
+	 */
+	public static final String LAST_IN_BATCH = PREFIX + "lastInBatch";
+
 }

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/SimpleAmqpHeaderMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/SimpleAmqpHeaderMapper.java
@@ -163,6 +163,7 @@ public class SimpleAmqpHeaderMapper extends AbstractHeaderMapper<MessageProperti
 							putString)
 					.acceptIfHasText(AmqpHeaders.CONSUMER_TAG, amqpMessageProperties.getConsumerTag(), putString)
 					.acceptIfHasText(AmqpHeaders.CONSUMER_QUEUE, amqpMessageProperties.getConsumerQueue(), putString);
+			headers.put(AmqpHeaders.LAST_IN_BATCH, amqpMessageProperties.isLastInBatch());
 
 			// Map custom headers
 			for (Map.Entry<String, Object> entry : amqpMessageProperties.getHeaders().entrySet()) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/batch/SimpleBatchingStrategy.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/batch/SimpleBatchingStrategy.java
@@ -185,6 +185,9 @@ public class SimpleBatchingStrategy implements BatchingStrategy {
 			messageProperties.setContentLength(length);
 			// Caveat - shared MessageProperties.
 			Message fragment = new Message(body, messageProperties);
+			if (!byteBuffer.hasRemaining()) {
+				messageProperties.setLastInBatch(true);
+			}
 			fragmentConsumer.accept(fragment);
 		}
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitBatchIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitBatchIntegrationTests.java
@@ -32,6 +32,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.BatchingRabbitTemplate;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
+import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -72,7 +73,11 @@ public class EnableRabbitBatchIntegrationTests {
 		this.template.convertAndSend("batch.2", new Foo("bar"));
 		assertThat(this.listener.fooMessagesLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.listener.fooMessages.get(0).getPayload().getBar()).isEqualTo("foo");
+		assertThat(this.listener.fooMessages.get(0).getHeaders().get(AmqpHeaders.LAST_IN_BATCH, Boolean.class))
+				.isFalse();
 		assertThat(this.listener.fooMessages.get(1).getPayload().getBar()).isEqualTo("bar");
+		assertThat(this.listener.fooMessages.get(1).getHeaders().get(AmqpHeaders.LAST_IN_BATCH, Boolean.class))
+				.isTrue();
 	}
 
 	@Configuration

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1465,7 +1465,7 @@ This preempts the `batchSize`, if exceeded, and causes a partial batch to be sen
 The `SimpleBatchingStrategy` formats the batch by preceding each embedded message with a four-byte binary length.
 This is communicated to the receiving system by setting the `springBatchFormat` message property to `lengthHeader4`.
 
-IMPORTANT: Batched messages are automatically de-batched by listener containers (by using the `springBatchFormat` message header).
+IMPORTANT: Batched messages are automatically de-batched by listener containers by default (by using the `springBatchFormat` message header).
 Rejecting any message from a batch causes the entire batch to be rejected.
 
 However, see <<receiving-batch>> for more information.
@@ -2807,6 +2807,10 @@ public void listen2(List<Message<Thing>> in) {
 Setting the `batchListener` property to true automatically turns off the `debatchingEnabled` container property in containers that the factory creates - effectively, the debatching is moved from the container to the listener adapter and the adapter creates the list that is passed to the listener.
 
 A batch-enabled factory cannot be used with a <<annotation-method-selection, multi-method listener>>.
+
+Also starting with version 2.2. when receiving batched messages one-at-a-time, the last message contains a boolean header set to `true`.
+This header can be obtained by adding the `@Header(AmqpHeaders.LAST_IN_BATCH)` boolean last` parameter to your listener method.
+The header is mapped from `MessageProperties.isLastInBatch()`.
 
 [[using-container-factories]]
 ===== Using Container Factories

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -21,7 +21,9 @@ You can now configure an `executor` on each listener, overriding the factory con
 You can now override the container factory's `acknowledgeMode` property with the annotation's `ackMode` property.
 See <<listener-property-overrides,overriding container factory properties>> for more information.
 
-When using <<receiving-batch,batching>>, `@RabbitListener` methods can now receive a complete batch of messages in one call instead of getting them one at at time.
+When using <<receiving-batch,batching>>, `@RabbitListener` methods can now receive a complete batch of messages in one call instead of getting them one-at-a-time.
+
+When receiving batched messages one-at-a-time, the last message has the `isLastInBatch` message property set to true.
 
 Spring Data Projection interfaces are now supported by the `Jackson2JsonMessageConverter`.
 See <<data-projection>> for more information.


### PR DESCRIPTION
When debatching a batched message and the listener handles them
one-at-a-time, it may be helpful to know when the last message in
the batch is being processed.
