### PR TITLE
Add amqp_batchSize message header

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/AmqpHeaders.java
@@ -124,4 +124,10 @@ public abstract class AmqpHeaders {
 	 */
 	public static final String LAST_IN_BATCH = PREFIX + "lastInBatch";
 
+	/**
+	 * The number of fragments in a batch message.
+	 * @since 2.2
+	 */
+	public static final String BATCH_SIZE = PREFIX + "batchSize";
+
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/batch/SimpleBatchingStrategy.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/batch/SimpleBatchingStrategy.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
+import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.MessageConversionException;
 import org.springframework.util.Assert;
 
@@ -150,9 +151,9 @@ public class SimpleBatchingStrategy implements BatchingStrategy {
 		}
 		messageProperties.getHeaders().put(MessageProperties.SPRING_BATCH_FORMAT,
 				MessageProperties.BATCH_FORMAT_LENGTH_HEADER4);
+		messageProperties.getHeaders().put(AmqpHeaders.BATCH_SIZE, this.messages.size());
 		return new Message(body, messageProperties);
 	}
-
 
 	@Override
 	public boolean canDebatch(MessageProperties properties) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplate.java
@@ -76,6 +76,7 @@ public class BatchingRabbitTemplate extends RabbitTemplate {
 	@Override
 	public synchronized void send(String exchange, String routingKey, Message message, CorrelationData correlationData)
 			throws AmqpException {
+
 		if (correlationData != null) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Cannot use batching with correlation data");

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitBatchIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitBatchIntegrationTests.java
@@ -78,6 +78,8 @@ public class EnableRabbitBatchIntegrationTests {
 		assertThat(this.listener.fooMessages.get(1).getPayload().getBar()).isEqualTo("bar");
 		assertThat(this.listener.fooMessages.get(1).getHeaders().get(AmqpHeaders.LAST_IN_BATCH, Boolean.class))
 				.isTrue();
+		assertThat(this.listener.fooMessages.get(1).getHeaders().get(AmqpHeaders.BATCH_SIZE, Integer.class))
+				.isEqualTo(2);
 	}
 
 	@Configuration

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2811,6 +2811,7 @@ A batch-enabled factory cannot be used with a <<annotation-method-selection, mul
 Also starting with version 2.2. when receiving batched messages one-at-a-time, the last message contains a boolean header set to `true`.
 This header can be obtained by adding the `@Header(AmqpHeaders.LAST_IN_BATCH)` boolean last` parameter to your listener method.
 The header is mapped from `MessageProperties.isLastInBatch()`.
+In addition, `AmqpHeaders.BATCH_SIZE` is populated with the size of the batch in every message fragment.
 
 [[using-container-factories]]
 ===== Using Container Factories

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -25,6 +25,8 @@ When using <<receiving-batch,batching>>, `@RabbitListener` methods can now recei
 
 When receiving batched messages one-at-a-time, the last message has the `isLastInBatch` message property set to true.
 
+In addition, received batched messages now contain the `amqp_batchSize` header.
+
 Spring Data Projection interfaces are now supported by the `Jackson2JsonMessageConverter`.
 See <<data-projection>> for more information.
 


### PR DESCRIPTION
Useful, for example, in a Spring Integration aggregator release
strategy.

