### PR TITLE
GH-1009: Fix NPE in the AbsAdaptMessageListener

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -82,9 +82,9 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 	private static final boolean monoPresent = // NOSONAR - lower case
 			ClassUtils.isPresent("reactor.core.publisher.Mono", ChannelAwareMessageListener.class.getClassLoader());
 
-	;
-
-	/** Logger available to subclasses. */
+	/**
+	 * Logger available to subclasses.
+	 */
 	protected final Log logger = LogFactory.getLog(getClass()); // NOSONAR protected
 
 	private final StandardEvaluationContext evalContext = new StandardEvaluationContext();

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -80,7 +80,9 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 	private static final ParserContext PARSER_CONTEXT = new TemplateParserContext("!{", "}");
 
 	private static final boolean monoPresent = // NOSONAR - lower case
-			ClassUtils.isPresent("reactor.core.publisher.Mono", ChannelAwareMessageListener.class.getClassLoader());;
+			ClassUtils.isPresent("reactor.core.publisher.Mono", ChannelAwareMessageListener.class.getClassLoader());
+
+	;
 
 	/** Logger available to subclasses. */
 	protected final Log logger = LogFactory.getLog(getClass()); // NOSONAR protected
@@ -95,7 +97,7 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 
 	private Expression responseExpression;
 
-	private volatile boolean mandatoryPublish;
+	private boolean mandatoryPublish;
 
 	private MessageConverter messageConverter = new SimpleMessageConverter();
 
@@ -344,10 +346,17 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 		}
 		else {
 			// We only get here with Mono<?> and ListenableFuture<?> which have exactly one type argument
-			Type returnType = ((ParameterizedType) resultArg.getReturnType()).getActualTypeArguments()[0]; // NOSONAR
-			if (returnType instanceof WildcardType) {
-				// Set the return type to null so the converter will use the actual returned object's class for type info
-				returnType = null;
+			Type returnType = resultArg.getReturnType();
+			if (returnType != null) {
+				Type[] actualTypeArguments = ((ParameterizedType) returnType).getActualTypeArguments();
+				if (actualTypeArguments.length > 0) {
+					returnType = actualTypeArguments[0]; // NOSONAR
+					if (returnType instanceof WildcardType) {
+						// Set the return type to null so the converter will use the actual returned
+						// object's class for type info
+						returnType = null;
+					}
+				}
 			}
 			doHandleResult(new InvocationResult(deferredResult, resultArg.getSendTo(), returnType), request, channel,
 					source);
@@ -475,7 +484,7 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 	}
 
 	private Address evaluateReplyTo(Message request, Object source, Object result, Expression expression) {
-		Address replyTo = null;
+		Address replyTo;
 		Object value = expression.getValue(this.evalContext, new ReplyExpressionRoot(request, source, result));
 		Assert.state(value instanceof String || value instanceof Address,
 				"response expression must evaluate to a String or Address");


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1009

The `MessageListenerAdapter` build an `InvocationResult` without
a return type info leading to the NPE in the
`AbstractAdaptableMessageListener` when we try to parse a generic
argument for the returned `Mono` or `ListenableFuture`

* Fix a potential NPE in the `AbstractAdaptableMessageListener.asyncSuccess()`
* Add `MessageListenerAdapterTests.testListenableFutureReturn()` to ensure
that `channel.basicAck()` is called from the `MessageListenerAdapter`
as well

**Cherry-pick to 2.1.x**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
