### PR TITLE
GH-1006: Fix listener ack for `Mono<Void>`

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
@@ -47,6 +47,7 @@ import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
 
 import com.rabbitmq.client.Channel;
+import reactor.core.publisher.Mono;
 
 /**
  * @author Dave Syer
@@ -238,6 +239,23 @@ public class MessageListenerAdapterTests {
 		verify(mockChannel).basicAck(anyLong(), eq(false));
 	}
 
+	@Test
+	public void testMonoVoidReturnAck() throws Exception {
+		class Delegate {
+
+			@SuppressWarnings("unused")
+			public Mono<Void> myPojoMessageMethod(String input) {
+				return Mono.empty();
+			}
+
+		}
+		this.adapter = new MessageListenerAdapter(new Delegate(), "myPojoMessageMethod");
+		this.adapter.containerAckMode(AcknowledgeMode.MANUAL);
+		this.adapter.setResponseExchange("default");
+		Channel mockChannel = mock(Channel.class);
+		this.adapter.onMessage(new Message("foo".getBytes(), this.messageProperties), mockChannel);
+		verify(mockChannel).basicAck(anyLong(), eq(false));
+	}
 
 	public interface Service {
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1006

When listener method returns `Mono<Void>`, the `success` callback is
not called from the Reactor because there is no value to handle.

* Move `basicAck()` to the `completeConsumer` which is called when `Mono`
is completed successfully with value or without

**Cherry-pick to 2.1.x**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
