### PR TITLE
GH-1014 introduced new parameter `serializeMdc` for log4j2 appender

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -184,7 +184,7 @@ public class AmqpAppender extends AbstractAppender {
 			@PluginAttribute("charset") String charset,
 			@PluginAttribute(value = "bufferSize", defaultInt = Integer.MAX_VALUE) int bufferSize,
 			@PluginElement(BlockingQueueFactory.ELEMENT_TYPE) BlockingQueueFactory<Event> blockingQueueFactory,
-  		    @PluginAttribute("serializeMdc") boolean serializeMdc) {
+  		    @PluginAttribute("addMdcAsHeaders") boolean addMdcAsHeaders) {
 		if (name == null) {
 			LOGGER.error("No name for AmqpAppender");
 		}
@@ -227,7 +227,7 @@ public class AmqpAppender extends AbstractAppender {
 		manager.clientConnectionProperties = clientConnectionProperties;
 		manager.charset = charset;
 		manager.async = async;
-		manager.serializeMdc = serializeMdc;
+		manager.addMdcAsHeaders = addMdcAsHeaders;
 
 		BlockingQueue<Event> eventQueue;
 		if (blockingQueueFactory == null) {
@@ -314,7 +314,7 @@ public class AmqpAppender extends AbstractAppender {
 		amqpProps.setTimestamp(tstamp.getTime());
 
 		// Copy properties in from MDC
-		if (this.manager.serializeMdc) {
+		if (this.manager.addMdcAsHeaders) {
 			for (Entry<?, ?> entry : properties.entrySet()) {
 				amqpProps.setHeader(entry.getKey().toString(), entry.getValue());
 			}
@@ -610,9 +610,9 @@ public class AmqpAppender extends AbstractAppender {
 		private String charset = Charset.defaultCharset().name();
 
 		/**
-		 * Whether or not add MDC properties into message headers. Default is true to keep backward compatibility.
+		 * Whether or not add MDC properties into message headers.
 		 */
-		private boolean serializeMdc = true;
+		private boolean addMdcAsHeaders = false;
 
 		private boolean durable = true;
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -184,7 +184,7 @@ public class AmqpAppender extends AbstractAppender {
 			@PluginAttribute("charset") String charset,
 			@PluginAttribute(value = "bufferSize", defaultInt = Integer.MAX_VALUE) int bufferSize,
 			@PluginElement(BlockingQueueFactory.ELEMENT_TYPE) BlockingQueueFactory<Event> blockingQueueFactory,
-  		    @PluginAttribute("addMdcAsHeaders") boolean addMdcAsHeaders) {
+  		    @PluginAttribute(value = "addMdcAsHeaders", defaultBoolean = true) boolean addMdcAsHeaders) {
 		if (name == null) {
 			LOGGER.error("No name for AmqpAppender");
 		}
@@ -610,9 +610,9 @@ public class AmqpAppender extends AbstractAppender {
 		private String charset = Charset.defaultCharset().name();
 
 		/**
-		 * Whether or not add MDC properties into message headers.
+		 * Whether or not add MDC properties into message headers. true by default for backward compatibility
 		 */
-		private boolean addMdcAsHeaders = false;
+		private boolean addMdcAsHeaders = true;
 
 		private boolean durable = true;
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -184,7 +184,7 @@ public class AmqpAppender extends AbstractAppender {
 			@PluginAttribute("charset") String charset,
 			@PluginAttribute(value = "bufferSize", defaultInt = Integer.MAX_VALUE) int bufferSize,
 			@PluginElement(BlockingQueueFactory.ELEMENT_TYPE) BlockingQueueFactory<Event> blockingQueueFactory,
-  		    @PluginAttribute(value = "serializeMdc") boolean serializeMdc) {
+  		    @PluginAttribute("serializeMdc") boolean serializeMdc) {
 		if (name == null) {
 			LOGGER.error("No name for AmqpAppender");
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -540,7 +540,7 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	}
 
 	public boolean isAddMdcAsHeaders() {
-		return addMdcAsHeaders;
+		return this.addMdcAsHeaders;
 	}
 
 	public void setAddMdcAsHeaders(boolean addMdcAsHeaders) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -872,7 +872,7 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 				while (true) {
 					final Event event = AmqpAppender.this.events.take();
 
-					MessageProperties amqpProps = AmqpAppender.this.prepareMessageProperties(event);
+					MessageProperties amqpProps = prepareMessageProperties(event);
 
 					String routingKey = AmqpAppender.this.routingKeyLayout.doLayout(event.getEvent());
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -297,9 +297,9 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 	private String charset;
 
 	/**
-	 * Whether or not add MDC properties into message headers.
+	 * Whether or not add MDC properties into message headers. true by default for backward compatibility
 	 */
-	private boolean addMdcAsHeaders = false;
+	private boolean addMdcAsHeaders = true;
 
 	private boolean durable = true;
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
@@ -154,6 +154,8 @@ public class AmqpAppenderTests {
 		assertThat(TestUtils.getPropertyValue(manager, "maxSenderRetries")).isEqualTo(5);
 		// change the property to true and this fails and test() randomly fails too.
 		assertThat(TestUtils.getPropertyValue(manager, "async", Boolean.class)).isFalse();
+		// default value
+		assertThat(TestUtils.getPropertyValue(manager, "serializeMdc", Boolean.class)).isFalse();
 
 		assertThat(TestUtils.getPropertyValue(appender, "events.items", Object[].class).length).isEqualTo(10);
 
@@ -168,6 +170,10 @@ public class AmqpAppenderTests {
 				Map.class).get("rabbitmq_default_queue");
 
 		Object events = TestUtils.getPropertyValue(appender, "events");
+
+		Object manager = TestUtils.getPropertyValue(appender, "manager");
+		assertThat(TestUtils.getPropertyValue(manager, "serializeMdc", Boolean.class)).isTrue();
+
 		assertThat(events.getClass()).isEqualTo(LinkedBlockingQueue.class);
 	}
 
@@ -184,6 +190,7 @@ public class AmqpAppenderTests {
 		assertThat(TestUtils.getPropertyValue(manager, "username")).isNull();
 		assertThat(TestUtils.getPropertyValue(manager, "password")).isNull();
 		assertThat(TestUtils.getPropertyValue(manager, "virtualHost")).isNull();
+		assertThat(TestUtils.getPropertyValue(manager, "serializeMdc", Boolean.class)).isFalse();
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
@@ -155,7 +155,7 @@ public class AmqpAppenderTests {
 		// change the property to true and this fails and test() randomly fails too.
 		assertThat(TestUtils.getPropertyValue(manager, "async", Boolean.class)).isFalse();
 		// default value
-		assertThat(TestUtils.getPropertyValue(manager, "serializeMdc", Boolean.class)).isFalse();
+		assertThat(TestUtils.getPropertyValue(manager, "addMdcAsHeaders", Boolean.class)).isFalse();
 
 		assertThat(TestUtils.getPropertyValue(appender, "events.items", Object[].class).length).isEqualTo(10);
 
@@ -172,7 +172,7 @@ public class AmqpAppenderTests {
 		Object events = TestUtils.getPropertyValue(appender, "events");
 
 		Object manager = TestUtils.getPropertyValue(appender, "manager");
-		assertThat(TestUtils.getPropertyValue(manager, "serializeMdc", Boolean.class)).isTrue();
+		assertThat(TestUtils.getPropertyValue(manager, "addMdcAsHeaders", Boolean.class)).isTrue();
 
 		assertThat(events.getClass()).isEqualTo(LinkedBlockingQueue.class);
 	}
@@ -190,7 +190,7 @@ public class AmqpAppenderTests {
 		assertThat(TestUtils.getPropertyValue(manager, "username")).isNull();
 		assertThat(TestUtils.getPropertyValue(manager, "password")).isNull();
 		assertThat(TestUtils.getPropertyValue(manager, "virtualHost")).isNull();
-		assertThat(TestUtils.getPropertyValue(manager, "serializeMdc", Boolean.class)).isFalse();
+		assertThat(TestUtils.getPropertyValue(manager, "addMdcAsHeaders", Boolean.class)).isFalse();
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/AmqpAppenderTests.java
@@ -155,7 +155,7 @@ public class AmqpAppenderTests {
 		// change the property to true and this fails and test() randomly fails too.
 		assertThat(TestUtils.getPropertyValue(manager, "async", Boolean.class)).isFalse();
 		// default value
-		assertThat(TestUtils.getPropertyValue(manager, "addMdcAsHeaders", Boolean.class)).isFalse();
+		assertThat(TestUtils.getPropertyValue(manager, "addMdcAsHeaders", Boolean.class)).isTrue();
 
 		assertThat(TestUtils.getPropertyValue(appender, "events.items", Object[].class).length).isEqualTo(10);
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderIntegrationTests.java
@@ -190,8 +190,8 @@ public class AmqpAppenderIntegrationTests {
 		// Given
 		Logger logWithMdc = (Logger) LoggerFactory.getLogger("withMdc");
 		Logger logWithoutMdc = (Logger) LoggerFactory.getLogger("withoutMdc");
-		MDC.put("mdc1", "test1" );
-		MDC.put("mdc2", "test2" );
+		MDC.put("mdc1", "test1");
+		MDC.put("mdc2", "test2");
 
 		// When
 		logWithMdc.info("test message with MDC in headers");

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/logback/AmqpAppenderIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.logback;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -75,15 +76,20 @@ public class AmqpAppenderIntegrationTests {
 	@Autowired
 	private Queue encodedQueue;
 
+	@Autowired
+	private Queue testQueue;
+
 	private SimpleMessageListenerContainer listenerContainer;
 
 	@Before
 	public void setUp() throws Exception {
 		listenerContainer = applicationContext.getBean(SimpleMessageListenerContainer.class);
+		MDC.clear();
 	}
 
 	@After
 	public void tearDown() {
+		MDC.clear();
 		listenerContainer.shutdown();
 	}
 
@@ -175,6 +181,38 @@ public class AmqpAppenderIntegrationTests {
 		BlockingQueue<AmqpAppender.Event> appenderQueue =
 				((CustomQueueAppender) log.getAppender("AMQPWithCustomQueue")).mockedQueue;
 		verify(appenderQueue).add(argThat(arg -> arg.getEvent().getMessage().equals(testMessage)));
+	}
+
+	@Test
+	public void testAddMdcAsHeaders() {
+		this.applicationContext.getBean(SingleConnectionFactory.class).createConnection().close();
+
+		// Given
+		Logger logWithMdc = (Logger) LoggerFactory.getLogger("withMdc");
+		Logger logWithoutMdc = (Logger) LoggerFactory.getLogger("withoutMdc");
+		MDC.put("mdc1", "test1" );
+		MDC.put("mdc2", "test2" );
+
+		// When
+		logWithMdc.info("test message with MDC in headers");
+		Message received1 = this.template.receive(this.testQueue.getName());
+
+		// Then
+		assertThat(received1).isNotNull();
+		assertThat(new String(received1.getBody())).isEqualTo("test message with MDC in headers");
+		assertThat(received1.getMessageProperties().getHeaders())
+				.contains(entry("mdc1", "test1"), entry("mdc1", "test1"));
+
+
+		// When
+		logWithoutMdc.info("test message without MDC in headers");
+		Message received2 = this.template.receive(this.testQueue.getName());
+
+		// Then
+		assertThat(received2).isNotNull();
+		assertThat(new String(received2.getBody())).isEqualTo("test message without MDC in headers");
+		assertThat(received2.getMessageProperties().getHeaders())
+				.doesNotContain(entry("mdc1", "test1"), entry("mdc1", "test1"));
 	}
 
 	public static class EnhancedAppender extends AmqpAppender {

--- a/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
+++ b/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
@@ -23,7 +23,7 @@
 				  host="localhost" port="5672" user="guest" password="guest" applicationId="testAppId" charset="UTF-8"
 				  routingKeyPattern="%X{applicationId}.%c.%p"
 				  exchange="log4j2Test_default_queue" deliveryMode="NON_PERSISTENT"
-				  serializeMdc="true">
+				  addMdcAsHeaders="true">
 		</RabbitMQ>
 		<RabbitMQ name="rabbitmq_uri"
 				  uri="amqp://guest:guest@localhost:5672/"
@@ -34,7 +34,7 @@
 				  charset="UTF-8"
 				  clientConnectionProperties="bar:foo,baz:qux"
 				  senderPoolSize="3" maxSenderRetries="5"
-				  serializeMdc="false">
+				  addMdcAsHeaders="false">
 		</RabbitMQ>
 	</Appenders>
 	<Loggers>

--- a/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
+++ b/spring-rabbit/src/test/resources/log4j2-amqp-appender.xml
@@ -22,7 +22,8 @@
 				  addresses="localhost:5672"
 				  host="localhost" port="5672" user="guest" password="guest" applicationId="testAppId" charset="UTF-8"
 				  routingKeyPattern="%X{applicationId}.%c.%p"
-				  exchange="log4j2Test_default_queue" deliveryMode="NON_PERSISTENT">
+				  exchange="log4j2Test_default_queue" deliveryMode="NON_PERSISTENT"
+				  serializeMdc="true">
 		</RabbitMQ>
 		<RabbitMQ name="rabbitmq_uri"
 				  uri="amqp://guest:guest@localhost:5672/"
@@ -32,7 +33,8 @@
 				  contentType="text/plain" contentEncoding="UTF-8" generateId="true" deliveryMode="NON_PERSISTENT"
 				  charset="UTF-8"
 				  clientConnectionProperties="bar:foo,baz:qux"
-				  senderPoolSize="3" maxSenderRetries="5">
+				  senderPoolSize="3" maxSenderRetries="5"
+				  serializeMdc="false">
 		</RabbitMQ>
 	</Appenders>
 	<Loggers>

--- a/spring-rabbit/src/test/resources/logback-test.xml
+++ b/spring-rabbit/src/test/resources/logback-test.xml
@@ -24,6 +24,7 @@
 		<connectionName>logbackAppender</connectionName>
 		<clientConnectionProperties>foo:bar,baz:qux</clientConnectionProperties>
 		<foo>bar</foo>
+		<addMdcAsHeaders>true</addMdcAsHeaders>
 	</appender>
 
 	<appender name="AMQPWithCustomQueue"
@@ -61,6 +62,39 @@
 		<senderPoolSize>1</senderPoolSize>
 	</appender>
 
+	<appender name="AMQPWithMdc" class="org.springframework.amqp.rabbit.logback.AmqpAppender">
+		<layout>
+			<pattern>%m</pattern>
+		</layout>
+		<addresses>localhost:5672</addresses>
+		<abbreviation>36</abbreviation>
+		<includeCallerData>true</includeCallerData>
+		<applicationId>AmqpAppenderTest</applicationId>
+		<routingKeyPattern>%property{applicationId}.%c.%p</routingKeyPattern>
+		<generateId>true</generateId>
+		<charset>UTF-8</charset>
+		<durable>false</durable>
+		<deliveryMode>NON_PERSISTENT</deliveryMode>
+		<declareExchange>false</declareExchange>
+		<addMdcAsHeaders>true</addMdcAsHeaders>
+	</appender>
+
+	<appender name="AMQPWithoutMdc" class="org.springframework.amqp.rabbit.logback.AmqpAppender">
+		<layout>
+			<pattern>%m</pattern>
+		</layout>
+		<addresses>localhost:5672</addresses>
+		<abbreviation>36</abbreviation>
+		<includeCallerData>true</includeCallerData>
+		<applicationId>AmqpAppenderTest</applicationId>
+		<routingKeyPattern>%property{applicationId}.%c.%p</routingKeyPattern>
+		<generateId>true</generateId>
+		<charset>UTF-8</charset>
+		<durable>false</durable>
+		<deliveryMode>NON_PERSISTENT</deliveryMode>
+		<declareExchange>false</declareExchange>
+	</appender>
+
 	<logger name="org.springframework.amqp.rabbit.logback" level="DEBUG" additivity="false">
 		<appender-ref ref="AMQP"/>
 	</logger>
@@ -71,6 +105,14 @@
 
 	<logger name="customQueue" level="DEBUG" additivity="false">
 		<appender-ref ref="AMQPWithCustomQueue"/>
+	</logger>
+
+	<logger name="withMdc" level="DEBUG" additivity="false">
+		<appender-ref ref="AMQPWithMdc"/>
+	</logger>
+
+	<logger name="withoutMdc" level="DEBUG" additivity="false">
+		<appender-ref ref="AMQPWithoutMdc"/>
 	</logger>
 
 	<root level="INFO">

--- a/spring-rabbit/src/test/resources/logback-test.xml
+++ b/spring-rabbit/src/test/resources/logback-test.xml
@@ -24,7 +24,6 @@
 		<connectionName>logbackAppender</connectionName>
 		<clientConnectionProperties>foo:bar,baz:qux</clientConnectionProperties>
 		<foo>bar</foo>
-		<addMdcAsHeaders>true</addMdcAsHeaders>
 	</appender>
 
 	<appender name="AMQPWithCustomQueue"
@@ -93,6 +92,7 @@
 		<durable>false</durable>
 		<deliveryMode>NON_PERSISTENT</deliveryMode>
 		<declareExchange>false</declareExchange>
+		<addMdcAsHeaders>false</addMdcAsHeaders>
 	</appender>
 
 	<logger name="org.springframework.amqp.rabbit.logback" level="DEBUG" additivity="false">

--- a/src/reference/asciidoc/logging.adoc
+++ b/src/reference/asciidoc/logging.adoc
@@ -168,11 +168,28 @@ The following example shows how to configure a Log4j 2 appender:
         applicationId="myAppId" routingKeyPattern="%X{applicationId}.%c.%p"
         contentType="text/plain" contentEncoding="UTF-8" generateId="true" deliveryMode="NON_PERSISTENT"
         charset="UTF-8"
-        senderPoolSize="3" maxSenderRetries="5">
+        senderPoolSize="3" maxSenderRetries="5"
+        addMdcAsHeaders="true">
     </RabbitMQ>
 </Appenders>
 ----
 ====
+
+.Log4j 2 Appender Properties
+[cols="2l,2l,4", options="header"]
+|===
+| Property
+| Default
+| Description
+
+| `addMdcAsHeaders`
+| `false`
+| MDC properties were always added into RabbitMQ message headers Until this property was introduced.
+  It can lead to issues for big MDC as while RabbitMQ has limited buffer size for all headers and this buffer is pretty small.
+  And this property was introduced to avoid issues in case of big MDC.
+   `true` turns on serialization MDC into headers. Please note, JsonLayout adds MDC into the message by default.
+|===
+
 
 [IMPORTANT]
 ====

--- a/src/reference/asciidoc/logging.adoc
+++ b/src/reference/asciidoc/logging.adoc
@@ -151,6 +151,13 @@ If the character set is unsupported on the current platform, we fall back to usi
 | null
 | A comma-delimited list of `key:value` pairs for custom client properties to the RabbitMQ connection.
 
+| addMdcAsHeaders
+| false
+| MDC properties were always added into RabbitMQ message headers until this property was introduced.
+  It can lead to issues for big MDC as while RabbitMQ has limited buffer size for all headers and this buffer is pretty small.
+  This property was introduced to avoid issues in cases of big MDC.
+   `true` turns on serialization MDC into headers. Please note, JsonLayout adds MDC into the message by default.
+
 |===
 
 ==== Log4j 2 Appender
@@ -174,22 +181,6 @@ The following example shows how to configure a Log4j 2 appender:
 </Appenders>
 ----
 ====
-
-.Log4j 2 Appender Properties
-[cols="2l,2l,4", options="header"]
-|===
-| Property
-| Default
-| Description
-
-| `addMdcAsHeaders`
-| `false`
-| MDC properties were always added into RabbitMQ message headers Until this property was introduced.
-  It can lead to issues for big MDC as while RabbitMQ has limited buffer size for all headers and this buffer is pretty small.
-  And this property was introduced to avoid issues in case of big MDC.
-   `true` turns on serialization MDC into headers. Please note, JsonLayout adds MDC into the message by default.
-|===
-
 
 [IMPORTANT]
 ====
@@ -223,6 +214,7 @@ The following example shows how to configure a logback appender:
     <durable>false</durable>
     <deliveryMode>NON_PERSISTENT</deliveryMode>
     <declareExchange>true</declareExchange>
+    <addMdcAsHeaders>true</addMdcAsHeaders>
 </appender>
 ----
 ====

--- a/src/reference/asciidoc/logging.adoc
+++ b/src/reference/asciidoc/logging.adoc
@@ -152,11 +152,11 @@ If the character set is unsupported on the current platform, we fall back to usi
 | A comma-delimited list of `key:value` pairs for custom client properties to the RabbitMQ connection.
 
 | addMdcAsHeaders
-| false
+| true
 | MDC properties were always added into RabbitMQ message headers until this property was introduced.
   It can lead to issues for big MDC as while RabbitMQ has limited buffer size for all headers and this buffer is pretty small.
-  This property was introduced to avoid issues in cases of big MDC.
-   `true` turns on serialization MDC into headers. Please note, JsonLayout adds MDC into the message by default.
+  This property was introduced to avoid issues in cases of big MDC. By default this value set to `true` for backward compatibility.
+   `false` turns off serialization MDC into headers. Please note, JsonLayout adds MDC into the message by default.
 
 |===
 
@@ -176,7 +176,7 @@ The following example shows how to configure a Log4j 2 appender:
         contentType="text/plain" contentEncoding="UTF-8" generateId="true" deliveryMode="NON_PERSISTENT"
         charset="UTF-8"
         senderPoolSize="3" maxSenderRetries="5"
-        addMdcAsHeaders="true">
+        addMdcAsHeaders="false">
     </RabbitMQ>
 </Appenders>
 ----
@@ -214,7 +214,7 @@ The following example shows how to configure a logback appender:
     <durable>false</durable>
     <deliveryMode>NON_PERSISTENT</deliveryMode>
     <declareExchange>true</declareExchange>
-    <addMdcAsHeaders>true</addMdcAsHeaders>
+    <addMdcAsHeaders>false</addMdcAsHeaders>
 </appender>
 ----
 ====
@@ -244,7 +244,7 @@ In addition they populate headers with the following values:
 * The level of the log event
 * `thread`: the name of the thread where log event happened
 * The location of the stack trace of the log event call
-* A copy of all the MDC properties (in the case if `addMdcAsHeaders` is set to `true`)
+* A copy of all the MDC properties (unless `addMdcAsHeaders` is set to `false`)
 
 Each of the appenders can be subclassed, letting you modify the messages before publishing.
 The following example shows how to customize log messages:

--- a/src/reference/asciidoc/logging.adoc
+++ b/src/reference/asciidoc/logging.adoc
@@ -244,7 +244,7 @@ In addition they populate headers with the following values:
 * The level of the log event
 * `thread`: the name of the thread where log event happened
 * The location of the stack trace of the log event call
-* A copy of all the MDC properties
+* A copy of all the MDC properties (in the case if `addMdcAsHeaders` is set to `true`)
 
 Each of the appenders can be subclassed, letting you modify the messages before publishing.
 The following example shows how to customize log messages:


### PR DESCRIPTION
GH-1014 introduced new parameter `serializeMdc` for log4j2 appender to turn on the serialization of MDC into header. by default it turned off

https://github.com/spring-projects/spring-amqp/issues/1014

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
