### PR TITLE
GH-1014 introduced new parameter `serializeMdc` for log4j2 appender

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -157,7 +157,7 @@ public class AmqpAppender extends AbstractAppender {
 			@PluginAttribute("clientConnectionProperties") String clientConnectionProperties,
 			@PluginAttribute("async") boolean async,
 			@PluginAttribute("charset") String charset,
-      	    @PluginAttribute("serializeMdc") boolean serializeMdc) {
+      	    @PluginAttribute("addMdcAsHeaders") boolean addMdcAsHeaders) {
 		if (name == null) {
 			LOGGER.error("No name for AmqpAppender");
 		}
@@ -188,7 +188,7 @@ public class AmqpAppender extends AbstractAppender {
 		manager.clientConnectionProperties = clientConnectionProperties;
 		manager.charset = charset;
 		manager.async = async;
-		manager.serializeMdc = serializeMdc;
+		manager.addMdcAsHeaders = addMdcAsHeaders;
 
 		AmqpAppender appender = new AmqpAppender(name, filter, theLayout, ignoreExceptions, manager);
 		if (manager.activateOptions()) {
@@ -267,7 +267,7 @@ public class AmqpAppender extends AbstractAppender {
 		amqpProps.setTimestamp(tstamp.getTime());
 
 		// Copy properties in from MDC
-		if (this.manager.serializeMdc) {
+		if (this.manager.addMdcAsHeaders) {
 			for (Entry<?, ?> entry : properties.entrySet()) {
 				amqpProps.setHeader(entry.getKey().toString(), entry.getValue());
 			}
@@ -501,9 +501,9 @@ public class AmqpAppender extends AbstractAppender {
 		private String charset = Charset.defaultCharset().name();
 
 		/**
-		 * Whether or not add MDC properties into message headers. Default is true to keep backward compatibility.
+		 * Whether or not add MDC properties into message headers.
 		 */
-		private boolean serializeMdc = true;
+		private boolean addMdcAsHeaders = false;
 
 		private boolean durable = true;
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/log4j2/AmqpAppender.java
@@ -157,7 +157,7 @@ public class AmqpAppender extends AbstractAppender {
 			@PluginAttribute("clientConnectionProperties") String clientConnectionProperties,
 			@PluginAttribute("async") boolean async,
 			@PluginAttribute("charset") String charset,
-      	    @PluginAttribute(value = "serializeMdc") boolean serializeMdc) {
+      	    @PluginAttribute("serializeMdc") boolean serializeMdc) {
 		if (name == null) {
 			LOGGER.error("No name for AmqpAppender");
 		}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/test/AmqpAppenderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/test/AmqpAppenderTests.java
@@ -111,6 +111,7 @@ public class AmqpAppenderTests {
 		assertEquals("UTF-8", TestUtils.getPropertyValue(manager, "contentEncoding"));
 		assertEquals(3, TestUtils.getPropertyValue(manager, "senderPoolSize"));
 		assertEquals(5, TestUtils.getPropertyValue(manager, "maxSenderRetries"));
+		assertEquals(true, TestUtils.getPropertyValue(manager, "serializeMdc"));
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/test/AmqpAppenderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/log4j2/test/AmqpAppenderTests.java
@@ -111,7 +111,7 @@ public class AmqpAppenderTests {
 		assertEquals("UTF-8", TestUtils.getPropertyValue(manager, "contentEncoding"));
 		assertEquals(3, TestUtils.getPropertyValue(manager, "senderPoolSize"));
 		assertEquals(5, TestUtils.getPropertyValue(manager, "maxSenderRetries"));
-		assertEquals(true, TestUtils.getPropertyValue(manager, "serializeMdc"));
+		assertEquals(true, TestUtils.getPropertyValue(manager, "addMdcAsHeaders"));
 	}
 
 }

--- a/spring-rabbit/src/test/resources/log4j2.xml
+++ b/spring-rabbit/src/test/resources/log4j2.xml
@@ -13,7 +13,7 @@
 			charset="UTF-8"
 			clientConnectionProperties="foo:bar,baz:qux"
 			async="false"
-			serializeMdc="true"
+			addMdcAsHeaders="true"
 			senderPoolSize="3" maxSenderRetries="5">
 		</RabbitMQ>
 	</Appenders>

--- a/spring-rabbit/src/test/resources/log4j2.xml
+++ b/spring-rabbit/src/test/resources/log4j2.xml
@@ -13,6 +13,7 @@
 			charset="UTF-8"
 			clientConnectionProperties="foo:bar,baz:qux"
 			async="false"
+			serializeMdc="true"
 			senderPoolSize="3" maxSenderRetries="5">
 		</RabbitMQ>
 	</Appenders>


### PR DESCRIPTION
GH-1014 introduced new parameter `serializeMdc` for log4j2 appender to turn on the serialization of MDC into header. by default it turned off

https://github.com/spring-projects/spring-amqp/issues/1014

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
