### PR TITLE
DMLC: Publish event for connection failure

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -663,6 +663,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			connection = getConnectionFactory().createConnection();
 		}
 		catch (Exception e) {
+			publishConsumerFailedEvent(e.getMessage(), false, e);
 			addConsumerToRestart(new SimpleConsumer(null, null, queue));
 			throw e instanceof AmqpConnectException // NOSONAR exception type check
 					? (AmqpConnectException) e

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerIntegrationTests.java
@@ -162,7 +162,7 @@ public class DirectMessageListenerContainerIntegrationTests {
 		container.setConsumersPerQueue(2);
 		container.setMessageListener(in -> {
 		});
-		container.setBeanName("simple");
+		container.setBeanName("badHost");
 		container.setConsumerTagStrategy(new Tag());
 		CountDownLatch latch = new CountDownLatch(1);
 		container.setApplicationEventPublisher(ev -> {
@@ -175,6 +175,8 @@ public class DirectMessageListenerContainerIntegrationTests {
 		container.start();
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		container.stop();
+		cf.destroy();
+		executor.destroy();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
The `DirectMessageListenerContainer` did not publish a listener
failed event for a connection failure.

**cherry-pick to all 2.x branches**
