### PR TITLE
GH-1026: Fix Delay with CacheMode.CONNECTION

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -719,7 +719,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 	private Connection connectionFromCache() {
 		ChannelCachingConnectionProxy cachedConnection = findIdleConnection();
 		long now = System.currentTimeMillis();
-		if (cachedConnection == null) {
+		if (cachedConnection == null && countOpenConnections() >= this.connectionLimit) {
 			cachedConnection = waitForConnection(now);
 		}
 		if (cachedConnection == null) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1026

When using a `channelCheckoutTimeout` with `CacheModeConnection`,
we incorrectly spin waiting for a connection until the timeout
expires.

We should only wait for a connection if the limit is exceeded.

**cherry-pick to all supported**

