### PR TITLE
Fix `SmartLifecycle.stop(Runnable)` usage

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -563,12 +563,6 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 		return this.autoStartup;
 	}
 
-	@Override
-	public void stop(Runnable callback) {
-		stop();
-		callback.run();
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public void onMessage(Message message, Channel channel) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
@@ -495,6 +495,9 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 		if (this.listenerContainer != null) {
 			this.listenerContainer.stop(callback);
 		}
+		else {
+			callback.run();
+		}
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/BrokerEventListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/BrokerEventListener.java
@@ -186,12 +186,6 @@ public class BrokerEventListener implements MessageListener, ApplicationEventPub
 	}
 
 	@Override
-	public void stop(Runnable callback) {
-		stop();
-		callback.run();
-	}
-
-	@Override
 	public void onMessage(Message message) {
 		if (this.applicationEventPublisher != null) {
 			this.applicationEventPublisher.publishEvent(new BrokerEvent(this, message.getMessageProperties()));

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1272,16 +1272,6 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 		}
 	}
 
-	@Override
-	public void stop(Runnable callback) {
-		try {
-			stop();
-		}
-		finally {
-			callback.run();
-		}
-	}
-
 	/**
 	 * This method is invoked when the container is stopping.
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
@@ -260,16 +260,21 @@ public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLife
 	@Override
 	public void stop(Runnable callback) {
 		Collection<MessageListenerContainer> containers = getListenerContainers();
-		AggregatingCallback aggregatingCallback = new AggregatingCallback(containers.size(), callback);
-		for (MessageListenerContainer listenerContainer : containers) {
-			try {
-				listenerContainer.stop(aggregatingCallback);
-			}
-			catch (Exception e) {
-				if (this.logger.isWarnEnabled()) {
-					this.logger.warn("Failed to stop listener container [" + listenerContainer + "]", e);
+		if (containers.size() > 0) {
+			AggregatingCallback aggregatingCallback = new AggregatingCallback(containers.size(), callback);
+			for (MessageListenerContainer listenerContainer : containers) {
+				try {
+					listenerContainer.stop(aggregatingCallback);
+				}
+				catch (Exception e) {
+					if (this.logger.isWarnEnabled()) {
+						this.logger.warn("Failed to stop listener container [" + listenerContainer + "]", e);
+					}
 				}
 			}
+		}
+		else {
+			callback.run();
 		}
 	}
 


### PR DESCRIPTION
* Also remove redundant `stop(Runnable)` implementations which repeat
 a `default` one in the `SmartLifecycle`

**Cherry-pick to 2.1.x & 2.0.x**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
