### PR TITLE
GH-1034: DMLC: Cancel consumer after failed ack

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -472,11 +472,11 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		final List<SimpleConsumer> consumersToCancel;
 		synchronized (this.consumersMonitor) {
 			consumersToCancel = this.consumers.stream()
-					.filter(c -> {
-						boolean open = c.getChannel().isOpen();
+					.filter(consumer -> {
+						boolean open = consumer.getChannel().isOpen() && !consumer.isAckFailed();
 						if (open && this.messagesPerAck > 1) {
 							try {
-								c.ackIfNecessary(now);
+								consumer.ackIfNecessary(now);
 							}
 							catch (IOException e) {
 								this.logger.error("Exception while sending delayed ack", e);
@@ -487,18 +487,18 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 					.collect(Collectors.toList());
 		}
 		consumersToCancel
-				.forEach(c -> {
+				.forEach(consumer -> {
 					try {
-						RabbitUtils.closeMessageConsumer(c.getChannel(),
-								Collections.singletonList(c.getConsumerTag()), isChannelTransacted());
+						RabbitUtils.closeMessageConsumer(consumer.getChannel(),
+								Collections.singletonList(consumer.getConsumerTag()), isChannelTransacted());
 					}
 					catch (Exception e) {
 						if (logger.isDebugEnabled()) {
-							logger.debug("Error closing consumer " + c, e);
+							logger.debug("Error closing consumer " + consumer, e);
 						}
 					}
-					this.logger.error("Consumer canceled - channel closed " + c);
-					c.cancelConsumer("Consumer " + c + " channel closed");
+					this.logger.error("Consumer canceled - channel closed " + consumer);
+					consumer.cancelConsumer("Consumer " + consumer + " channel closed");
 				});
 	}
 
@@ -813,7 +813,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 				this.logger.debug("Canceling " + consumer);
 			}
 			synchronized (consumer) {
-				consumer.canceled = true;
+				consumer.setCanceled(true);
 				if (this.messagesPerAck > 1) {
 					consumer.ackIfNecessary(0L);
 				}
@@ -887,6 +887,8 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 
 		private volatile boolean canceled;
 
+		private volatile boolean ackFailed;
+
 		private SimpleConsumer(Connection connection, Channel channel, String queue) {
 			super(channel);
 			this.connection = connection;
@@ -909,6 +911,23 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		 */
 		int getEpoch() {
 			return this.epoch;
+		}
+
+		/**
+		 * Set to true to indicate this consumer is canceled and should send any pending
+		 * acks.
+		 * @param canceled the canceled to set
+		 */
+		void setCanceled(boolean canceled) {
+			this.canceled = canceled;
+		}
+
+		/**
+		 * True if an ack/nack failed (probably due to a closed channel).
+		 * @return the ackFailed
+		 */
+		boolean isAckFailed() {
+			return this.ackFailed;
 		}
 
 		/**
@@ -1069,6 +1088,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 				}
 			}
 			catch (Exception e) {
+				this.ackFailed = true;
 				this.logger.error("Error acking", e);
 			}
 		}
@@ -1079,7 +1099,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		 * @param now the current time.
 		 * @throws IOException if one occurs.
 		 */
-		private synchronized void ackIfNecessary(long now) throws IOException {
+		synchronized void ackIfNecessary(long now) throws IOException {
 			if (this.pendingAcks >= this.messagesPerAck || (
 					this.pendingAcks > 0 && (now - this.lastAck > this.ackTimeout || this.canceled))) {
 				sendAck(now);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -40,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.rabbit.connection.ChannelProxy;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -260,6 +262,50 @@ public class DirectMessageListenerContainerMockTests {
 		verify(channel, times(2)).basicConsume(eq("test2"), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
 				anyMap(), any(Consumer.class));
 
+		container.stop();
+	}
+
+	@Test
+	public void testMonitorCancelsAfterBadAckEvenIfChannelReportsOpen() throws Exception {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		Connection connection = mock(Connection.class);
+		ChannelProxy channel = mock(ChannelProxy.class);
+		Channel rabbitChannel = mock(Channel.class);
+		given(channel.getTargetChannel()).willReturn(rabbitChannel);
+
+		given(connectionFactory.createConnection()).willReturn(connection);
+		given(connection.createChannel(anyBoolean())).willReturn(channel);
+		given(channel.isOpen()).willReturn(true);
+		given(channel.queueDeclarePassive(Mockito.anyString()))
+				.willAnswer(invocation -> mock(AMQP.Queue.DeclareOk.class));
+		AtomicReference<Consumer> consumer = new AtomicReference<>();
+		final CountDownLatch latch1 = new CountDownLatch(1);
+		final CountDownLatch latch2 = new CountDownLatch(1);
+		willAnswer(inv -> {
+			consumer.set(inv.getArgument(6));
+			latch1.countDown();
+			return "consumerTag";
+		}).given(channel).basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
+						anyMap(), any(Consumer.class));
+
+		willThrow(new RuntimeException("bad ack")).given(channel).basicAck(1L, false);
+		willAnswer(inv -> {
+			consumer.get().handleCancelOk("consumerTag");
+			latch2.countDown();
+			return null;
+		}).given(channel).basicCancel("consumerTag");
+
+		DirectMessageListenerContainer container = new DirectMessageListenerContainer(connectionFactory);
+		container.setQueueNames("test");
+		container.setPrefetchCount(2);
+		container.setMonitorInterval(100);
+		container.setMessageListener(mock(MessageListener.class));
+		container.afterPropertiesSet();
+		container.start();
+
+		assertThat(latch1.await(10, TimeUnit.SECONDS)).isTrue();
+		consumer.get().handleDelivery("consumerTag", envelope(1L), new BasicProperties(), new byte[1]);
+		assertThat(latch2.await(10, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1034

The monitor task now cancels the consumer after a failed ack/nack,
whether or not the channel `isOpen()` returns true.

Test with a mock channel that stays open after a failed ack.

**cherry-pick to 2.1.x, 2.0.x**
