### PR TITLE
GH-1038: RT: Fix evaluatedFastReplyTo

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.springframework.amqp.AmqpConnectException;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpIllegalStateException;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
@@ -945,11 +946,13 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 		}
 		if (this.replyAddress == null || Address.AMQ_RABBITMQ_REPLY_TO.equals(this.replyAddress)) {
 			try {
-				execute(channel -> {
+				return execute(channel -> {
 					channel.queueDeclarePassive(Address.AMQ_RABBITMQ_REPLY_TO);
-					return null;
+					return true;
 				});
-				return true;
+			}
+			catch (AmqpConnectException ex) {
+				throw ex;
 			}
 			catch (Exception e) {
 				if (logger.isDebugEnabled()) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1038

Don't set `evaluatedFastReplyTo` if we didn't actually evaluate it because
the broker is down on the first request.

**cherry-pick to all 2.x; backport to 1.7.x**

