### PR TITLE
GH-1038: RT: More evaluateFastReplyTo Fixes

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -960,16 +960,16 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 				}
 				if (cause instanceof ShutdownSignalException) {
 					if (RabbitUtils.isPassiveDeclarationChannelClose((ShutdownSignalException) cause)) {
-						if (logger.isDebugEnabled()) {
+						if (logger.isWarnEnabled()) {
 							logger.warn("Broker does not support fast replies via 'amq.rabbitmq.reply-to', temporary "
-									+ "queues will be used:" + ex.getMessage() + ".");
+									+ "queues will be used: " + cause.getMessage() + ".");
 						}
 						this.replyAddress = null;
 						return false;
 					}
 				}
 				if (logger.isDebugEnabled()) {
-					logger.debug("IO error, deferring directReplyTo detection");
+					logger.debug("IO error, deferring directReplyTo detection: " + ex.toString());
 				}
 				throw ex;
 			}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.amqp.AmqpConnectException;
 import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.AmqpIOException;
 import org.springframework.amqp.AmqpIllegalStateException;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.Address;
@@ -103,6 +104,7 @@ import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
 
 /**
  * <p>
@@ -951,18 +953,25 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 					return true;
 				});
 			}
-			catch (AmqpConnectException ex) {
+			catch (AmqpConnectException | AmqpIOException ex) {
+				Throwable cause = ex;
+				while (cause != null && !(cause instanceof ShutdownSignalException)) {
+					cause = cause.getCause();
+				}
+				if (cause instanceof ShutdownSignalException) {
+					if (RabbitUtils.isPassiveDeclarationChannelClose((ShutdownSignalException) cause)) {
+						if (logger.isDebugEnabled()) {
+							logger.warn("Broker does not support fast replies via 'amq.rabbitmq.reply-to', temporary "
+									+ "queues will be used:" + ex.getMessage() + ".");
+						}
+						this.replyAddress = null;
+						return false;
+					}
+				}
 				if (logger.isDebugEnabled()) {
-					logger.debug("Connection error, deferring directReplyTo detection");
+					logger.debug("IO error, deferring directReplyTo detection");
 				}
 				throw ex;
-			}
-			catch (Exception e) {
-				if (logger.isDebugEnabled()) {
-					logger.warn("Broker does not support fast replies via 'amq.rabbitmq.reply-to', temporary "
-							+ "queues will be used:" + e.getMessage() + ".");
-				}
-				this.replyAddress = null;
 			}
 		}
 		return false;


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1038

The previous fix to catch `AmqpConnectException` was incorrect - the
`ShutdownSignalException` for the passive queue declaration failure
is wrapped in an `AmqpConnectException` so we would have failed to
detect the failure.

Also, it has been reported that sometimes an `AmqpIOException` is thrown.

- Add `AmqpIOException` to the catch block
- Search for, and explitly check for the queue declaration failed exception
- For all other cases rethrow so we can test again

