### PR TITLE
Setting for BlockingQueueConsumer.failedDeclarationRetryInterval ignored if logging not enabled

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -637,15 +637,15 @@ public class BlockingQueueConsumer {
 		if (passiveDeclareRetries > 0 && this.channel.isOpen()) {
 			if (logger.isWarnEnabled()) {
 				logger.warn("Queue declaration failed; retries left=" + (passiveDeclareRetries), e);
-				try {
-					Thread.sleep(this.failedDeclarationRetryInterval);
-				}
-				catch (InterruptedException e1) {
-					this.declaring = false;
-					Thread.currentThread().interrupt();
-					this.activeObjectCounter.release(this);
-					throw RabbitExceptionTranslator.convertRabbitAccessException(e1); // NOSONAR stack trace loss
-				}
+			}
+			try {
+				Thread.sleep(this.failedDeclarationRetryInterval);
+			}
+			catch (InterruptedException e1) {
+				this.declaring = false;
+				Thread.currentThread().interrupt();
+				this.activeObjectCounter.release(this);
+				throw RabbitExceptionTranslator.convertRabbitAccessException(e1); // NOSONAR stack trace loss
 			}
 		}
 		else if (e.getFailedQueues().size() < this.queues.length) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -86,6 +86,7 @@ import com.rabbitmq.utility.Utility;
  * @author Artem Bilan
  * @author Alex Panchenko
  * @author Johno Crawford
+ * @author Ian Roberts
  */
 public class BlockingQueueConsumer {
 


### PR DESCRIPTION
When a BlockingQueueConsumer fails to passively declare a queue, it is supposed to sleep for `failedDeclarationRetryInterval` milliseconds before retrying.  However the `Thread.sleep` is wrapped inside an `if(logger.isWarnEnabled())` with the effect that, when WARN-level logging is _not_ enabled for this class then it ignores the retry interval and tries again immediately - potentially hundreds of times per second.

This is not caught by the tests, because when the tests are running the root logger is set to INFO.

Fix is to move the sleep outside the logger `if` block.