### PR TITLE
Fix ImmediateRequeueAmqpException

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerUtilsTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerUtilsTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.apache.commons.logging.Log;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.ImmediateRequeueAmqpException;
+import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
+
+/**
+ * @author Gary Russell
+ * @since 2.1.8
+ *
+ */
+public class ContainerUtilsTests {
+
+	@Test
+	void testMustRequeue() {
+		assertThat(ContainerUtils.shouldRequeue(false,
+				new ListenerExecutionFailedException("", new ImmediateRequeueAmqpException("requeue")),
+				mock(Log.class)))
+			.isTrue();
+	}
+
+	@Test
+	void testMustNotRequeue() {
+		assertThat(ContainerUtils.shouldRequeue(true,
+				new ListenerExecutionFailedException("", new AmqpRejectAndDontRequeueException("no requeue")),
+				mock(Log.class)))
+			.isFalse();
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1053

`ContainerUtils.shouldRequeue` did not traverse the cause tree so we never
matched on this exception.

**cherry-pick to 2.1.x**