### PR TITLE
GH-1055: Invoke Conf/Return callbacks on executor

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelImpl.java
@@ -32,7 +32,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.logging.Log;
@@ -92,8 +94,9 @@ import com.rabbitmq.client.impl.recovery.AutorecoveringChannel;
 public class PublisherCallbackChannelImpl
 		implements PublisherCallbackChannel, ConfirmListener, ReturnListener, ShutdownListener {
 
-	private static final MessagePropertiesConverter converter // NOSONAR - lower case
-		= new DefaultMessagePropertiesConverter();
+	private static final MessagePropertiesConverter CONVERTER  = new DefaultMessagePropertiesConverter();
+
+	private static final long RETURN_CALLBACK_TIMEOUT = 60;
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
@@ -109,7 +112,11 @@ public class PublisherCallbackChannelImpl
 
 	private final ExecutorService executor;
 
+	private final CountDownLatch returnLatch = new CountDownLatch(1);
+
 	private volatile java.util.function.Consumer<Channel> afterAckCallback;
+
+	private boolean hasReturned;
 
 	/**
 	 * Create a {@link PublisherCallbackChannelImpl} instance based on the provided
@@ -931,17 +938,6 @@ public class PublisherCallbackChannelImpl
 		catch (Exception e) {
 			this.logger.error("Failed to process publisher confirm", e);
 		}
-		finally {
-			try {
-				if (this.afterAckCallback != null && getPendingConfirmsCount() == 0) {
-					this.afterAckCallback.accept(this);
-					this.afterAckCallback = null;
-				}
-			}
-			catch (Exception e) {
-				this.logger.error("Failed to invoke afterAckCallback", e);
-			}
-		}
 	}
 
 	private void doProcessAck(long seq, boolean ack, boolean multiple, boolean remove) {
@@ -1017,17 +1013,34 @@ public class PublisherCallbackChannelImpl
 	}
 
 	private void doHandleConfirm(boolean ack, Listener listener, PendingConfirm pendingConfirm) {
-		try {
-			if (listener.isConfirmListener()) {
-				if (this.logger.isDebugEnabled()) {
-					this.logger.debug("Sending confirm " + pendingConfirm);
+		this.executor.execute(() -> {
+			try {
+				if (listener.isConfirmListener()) {
+					if (this.hasReturned && !this.returnLatch.await(RETURN_CALLBACK_TIMEOUT, TimeUnit.SECONDS)) {
+						this.logger
+								.error("Return callback failed to execute in " + RETURN_CALLBACK_TIMEOUT + " seconds");
+					}
+					if (this.logger.isDebugEnabled()) {
+						this.logger.debug("Sending confirm " + pendingConfirm);
+					}
+					listener.handleConfirm(pendingConfirm, ack);
 				}
-				listener.handleConfirm(pendingConfirm, ack);
 			}
-		}
-		catch (Exception e) {
-			this.logger.error("Exception delivering confirm", e);
-		}
+			catch (Exception e) {
+				this.logger.error("Exception delivering confirm", e);
+			}
+			finally {
+				try {
+					if (this.afterAckCallback != null && getPendingConfirmsCount() == 0) {
+						this.afterAckCallback.accept(this);
+						this.afterAckCallback = null;
+					}
+				}
+				catch (Exception e) {
+					this.logger.error("Failed to invoke afterAckCallback", e);
+				}
+			}
+		});
 	}
 
 	@Override
@@ -1058,7 +1071,7 @@ public class PublisherCallbackChannelImpl
 		if (returnCorrelation != null) {
 			PendingConfirm confirm = this.pendingReturns.remove(returnCorrelation.toString());
 			if (confirm != null) {
-				MessageProperties messageProperties = converter.toMessageProperties(properties,
+				MessageProperties messageProperties = CONVERTER.toMessageProperties(properties,
 						new Envelope(0L, false, exchange, routingKey), StandardCharsets.UTF_8.name());
 				if (confirm.getCorrelationData() != null) {
 					confirm.getCorrelationData().setReturnedMessage(new Message(body, messageProperties)); // NOSONAR never null
@@ -1083,12 +1096,19 @@ public class PublisherCallbackChannelImpl
 			}
 		}
 		else {
-			try {
-				listener.handleReturn(replyCode, replyText, exchange, routingKey, properties, body);
-			}
-			catch (Exception e) {
-				this.logger.error("Exception delivering returned message ", e);
-			}
+			this.hasReturned = true;
+			Listener listenerToInvoke = listener;
+			this.executor.execute(() -> {
+				try {
+					listenerToInvoke.handleReturn(replyCode, replyText, exchange, routingKey, properties, body);
+				}
+				catch (Exception e) {
+					this.logger.error("Exception delivering returned message ", e);
+				}
+				finally {
+					this.returnLatch.countDown();
+				}
+			});
 		}
 	}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1103,6 +1103,7 @@ With those versions, it was necessary to hand off work (such as sending a messas
 This is no longer necessary since the framework now hands off the callback invocation to the executor.
 
 IMPORTANT: The guarantee of receiving a returned message before the ack is still maintained as long as the return callback executes in 60 seconds or less.
+The confirm is scheduled to be delivered after the return callback exits or after 60 seconds, whichever comes first.
 
 Starting with version 2.1, the `CorrelationData` object has a `ListenableFuture` that you can \used to get the result, instead of using a `ConfirmCallback` on the template.
 The following example shows how to configure a `CorrelationData` instance:

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1096,6 +1096,14 @@ Version 2.1 and later no longer return the channel to the cache while confirms a
 The `RabbitTemplate` performs a logical `close()` on the channel after each operation.
 In general, this means that only one confirm is outstanding on a channel at a time.
 
+NOTE: Starting with version 2.2, the callbacks are invoked on one of the connection factory's `executor` threads.
+This is to avoid a potential deadlock if you perform Rabbit operations from within the callback.
+With previous versions, the callbacks were invoked directly on the `amqp-client` connection I/O thread; this would deadlock if you perform some RPC operation (such as opening a new channel) since the I/O thread blocks waiting for the result, but the result needs to be processed by the I/O thread itself.
+With those versions, it was necessary to hand off work (such as sending a messasge) to another thread within the callback.
+This is no longer necessary since the framework now hands off the callback invocation to the executor.
+
+IMPORTANT: The guarantee of receiving a returned message before the ack is still maintained as long as the return callback executes in 60 seconds or less.
+
 Starting with version 2.1, the `CorrelationData` object has a `ListenableFuture` that you can \used to get the result, instead of using a `ConfirmCallback` on the template.
 The following example shows how to configure a `CorrelationData` instance:
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -66,6 +66,10 @@ The `CachingConnectionFactory` has a new property `shuffleAddresses`.
 When providing a list of broker node addresses, the list will be shuffled before creating a connection so that the order in which the connections are attempted is random.
 See <<cluster>> for more information.
 
+When using Publisher confirms and returns, the callbacks are now invoked on the connection factory's `executor`.
+This avoids a possible deadlock in the `amqp-clients` library if you perform rabbit operations from within the callback.
+See <<template-confirms>> for more information.
+
 ===== Other Changes
 
 The `Declarables` object (for declaring multiple queues, exchanges, bindings) now has a filtered getter for each type.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1055

Prevent deadlocks in the amqp-client.

The reason the existing test didn't catch this is because the nested
send was performed on a different template/connection.
