### PR TITLE
GH-1058: Fix Reject/Requeue for Async Returns [BackPort]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk: oraclejdk8
 sudo: false

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
@@ -396,7 +396,8 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 				.acceptIfNotNull(this.beforeSendReplyPostProcessors, messageListener::setBeforeSendReplyPostProcessors)
 				.acceptIfNotNull(this.retryTemplate, messageListener::setRetryTemplate)
 				.acceptIfCondition(this.retryTemplate != null && this.recoveryCallback != null, this.recoveryCallback,
-					messageListener::setRecoveryCallback);
+					messageListener::setRecoveryCallback)
+				.acceptIfNotNull(this.defaultRequeueRejected, messageListener::setDefaultRequeueRejected);
 		}
 		initializeContainer(instance, endpoint);
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -32,6 +32,7 @@ import org.springframework.amqp.core.Address;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.listener.ContainerUtils;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
 import org.springframework.amqp.rabbit.support.MessagePropertiesConverter;
@@ -114,6 +115,7 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 
 	private boolean isManualAck;
 
+	private boolean defaultRequeueRejected = true;
 
 	/**
 	 * Set the routing key to use when sending response messages.
@@ -260,6 +262,16 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 		return this.messageConverter;
 	}
 
+	/**
+	 * Set to the value of this listener's container equivalent property. Used when
+	 * rejecting from an async listener.
+	 * @param defaultRequeueRejected false to not requeue.
+	 * @since 2.1.8
+	 */
+	public void setDefaultRequeueRejected(boolean defaultRequeueRejected) {
+		this.defaultRequeueRejected = defaultRequeueRejected;
+	}
+
 	@Override
 	public void containerAckMode(AcknowledgeMode mode) {
 		this.isManualAck = AcknowledgeMode.MANUAL.equals(mode);
@@ -391,7 +403,8 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 	private void asyncFailure(Message request, Channel channel, Throwable t) {
 		this.logger.error("Future or Mono was completed with an exception for " + request, t);
 		try {
-			channel.basicNack(request.getMessageProperties().getDeliveryTag(), false, true);
+			channel.basicNack(request.getMessageProperties().getDeliveryTag(), false,
+					ContainerUtils.shouldRequeue(this.defaultRequeueRejected, t, this.logger));
 		}
 		catch (IOException e) {
 			this.logger.error("Failed to nack message", e);

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2834,8 +2834,9 @@ Starting with version 2.1, `@RabbitListener` (and `@RabbitHandler`) methods can 
 
 IMPORTANT: The listener container factory must be configured with `AcknowledgeMode.MANUAL` so that the consumer thread will not ack the message; instead, the asynchronous completion will ack or nack the message when the async operation completes.
 When the async result is completed with an error, whether the message is requeued or not depends on the exception type thrown, the container configuration, and the container error handler.
-By default, the message will be requeued, unless the container's `defaultRequeueRejected` property is set to `false`.
+By default, the message will be requeued, unless the container's `defaultRequeueRejected` property is set to `false` (it is `true` by default).
 If the async result is completed with an `AmqpRejectAndDontRequeueException`, the message will not be requeued.
+If the container's `defaultRequeueRejected` property is `false`, you can override that by setting the future's exception to a `ImmediateRequeueException` and the message will be requeued.
 If some exception occurs within the listener method that prevents creation of the async result object, you MUST catch that exception and return an appropriate return object that will cause the message to be acknowledged or requeued.
 
 [[threading]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -86,7 +86,7 @@ See <<async-annotation-driven-enable>> for more information.
 ===== Async `@RabbitListener` Return
 
 `@RabbitListener` methods can now return `ListenableFuture<?>` or `Mono<?>`.
-See <<async-return>> for more information.
+See <<async-returns>> for more information.
 
 ===== Connection Factory Bean Changes
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1058

The listener adapter did not honor the exception types used to
complete the async result and always requeued.

