### PR TITLE
GH-1058: Fix Reject/Requeue for Async Returns

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractRabbitListenerContainerFactory.java
@@ -442,8 +442,8 @@ public abstract class AbstractRabbitListenerContainerFactory<C extends AbstractM
 							messageListener::setBeforeSendReplyPostProcessors)
 					.acceptIfNotNull(this.retryTemplate, messageListener::setRetryTemplate)
 					.acceptIfCondition(this.retryTemplate != null && this.recoveryCallback != null,
-							this.recoveryCallback,
-							messageListener::setRecoveryCallback);
+							this.recoveryCallback, messageListener::setRecoveryCallback)
+					.acceptIfNotNull(this.defaultRequeueRejected, messageListener::setDefaultRequeueRejected);
 		}
 		initializeContainer(instance, endpoint);
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2994,8 +2994,9 @@ Starting with version 2.1, `@RabbitListener` (and `@RabbitHandler`) methods can 
 
 IMPORTANT: The listener container factory must be configured with `AcknowledgeMode.MANUAL` so that the consumer thread will not ack the message; instead, the asynchronous completion will ack or nack the message when the async operation completes.
 When the async result is completed with an error, whether the message is requeued or not depends on the exception type thrown, the container configuration, and the container error handler.
-By default, the message will be requeued, unless the container's `defaultRequeueRejected` property is set to `false`.
+By default, the message will be requeued, unless the container's `defaultRequeueRejected` property is set to `false` (it is `true` by default).
 If the async result is completed with an `AmqpRejectAndDontRequeueException`, the message will not be requeued.
+If the container's `defaultRequeueRejected` property is `false`, you can override that by setting the future's exception to a `ImmediateRequeueException` and the message will be requeued.
 If some exception occurs within the listener method that prevents creation of the async result object, you MUST catch that exception and return an appropriate return object that will cause the message to be acknowledged or requeued.
 
 [[threading]]

--- a/src/reference/asciidoc/appendix.adoc
+++ b/src/reference/asciidoc/appendix.adoc
@@ -92,7 +92,7 @@ See <<async-annotation-driven-enable>> for more information.
 ===== Async `@RabbitListener` Return
 
 `@RabbitListener` methods can now return `ListenableFuture<?>` or `Mono<?>`.
-See <<async-return>> for more information.
+See <<async-returns>> for more information.
 
 ===== Connection Factory Bean Changes
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1058

The listener adapter did not honor the exception types used to
complete the async result and always requeued.
