### PR TITLE
Remove log4j-slf4j-impl test dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -300,7 +300,6 @@ project('spring-amqp') {
 		compile ("com.jayway.jsonpath:json-path:$jaywayJsonPathVersion", optional)
 
 		testCompile "org.assertj:assertj-core:$assertjVersion"
-		testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 	}
 
 }
@@ -356,7 +355,8 @@ project('spring-rabbit-junit') {
 		compile "org.assertj:assertj-core:$assertjVersion"
 		compileOnly 'org.apiguardian:apiguardian-api:1.0.0'
 
-		testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+		testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
+
 	}
 
 }

--- a/spring-rabbit/src/test/resources/logback-test.xml
+++ b/spring-rabbit/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration debug="true">
+<configuration debug="false">
 
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>


### PR DESCRIPTION
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/grussell/.gradle/caches/modules-2/files-2.1/org.apache.logging.log4j/log4j-slf4j-impl/2.12.0/7f44f5201f79d6f7010a1515699a5f6c40e49cb/log4j-slf4j-impl-2.12.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/grussell/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-classic/1.2.3/7c4f3c474fb2c041d8028740440937705ebb473a/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
```

Use the logback binding for the amqp client.

