### PR TITLE
GH-1065: Reject fatal with MANUAL ack mode

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/AmqpRejectAndDontRequeueException.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/AmqpRejectAndDontRequeueException.java
@@ -16,6 +16,8 @@
 
 package org.springframework.amqp;
 
+import org.springframework.lang.Nullable;
+
 /**
  * Exception for listener implementations used to indicate the
  * basic.reject will be sent with requeue=false in order to enable
@@ -27,16 +29,54 @@ package org.springframework.amqp;
 @SuppressWarnings("serial")
 public class AmqpRejectAndDontRequeueException extends AmqpException {
 
-	public AmqpRejectAndDontRequeueException(String message, Throwable cause) {
-		super(message, cause);
-	}
+	private final boolean rejectManual;
 
+	/**
+	 * Construct an instance with the supplied argument.
+	 * @param message A message describing the problem.
+	 */
 	public AmqpRejectAndDontRequeueException(String message) {
-		super(message);
+		this(message, false, null);
 	}
 
+	/**
+	 * Construct an instance with the supplied argument.
+	 * @param cause the cause.
+	 */
 	public AmqpRejectAndDontRequeueException(Throwable cause) {
-		super(cause);
+		this(null, false, cause);
+	}
+
+	/**
+	 * Construct an instance with the supplied arguments.
+	 * @param message A message describing the problem.
+	 * @param cause the cause.
+	 */
+	public AmqpRejectAndDontRequeueException(String message, Throwable cause) {
+		this(message, false, cause);
+	}
+
+	/**
+	 * Construct an instance with the supplied arguments.
+	 * @param message A message describing the problem.
+	 * @param rejectManual true to reject the message, even with Manual Acks if this is
+	 * the top-level exception (e.g. thrown by an error handler).
+	 * @param cause the cause.
+	 * @since 2.1.9
+	 */
+	public AmqpRejectAndDontRequeueException(@Nullable String message, boolean rejectManual,
+			@Nullable Throwable cause) {
+
+		super(message, cause);
+		this.rejectManual = rejectManual;
+	}
+
+	/**
+	 * True if the container should reject the message, even with manual acks.
+	 * @return true to reject.
+	 */
+	public boolean isRejectManual() {
+		return this.rejectManual;
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.AmqpIOException;
-import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -402,17 +401,6 @@ public abstract class RabbitUtils {
 		default:
 			throw new IllegalStateException("Unrecognized SaslConfig: " + saslConfig);
 		}
-	}
-
-	/**
-	 * Return true for {@link AmqpRejectAndDontRequeueException#isRejectManual()}.
-	 * @param ex the exception.
-	 * @return the exception's rejectManual property, if it's an
-	 * {@link AmqpRejectAndDontRequeueException}.
-	 */
-	public static boolean isRejectManual(Throwable ex) {
-		return ex instanceof AmqpRejectAndDontRequeueException
-				&& ((AmqpRejectAndDontRequeueException) ex).isRejectManual();
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.AmqpIOException;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -401,6 +402,17 @@ public abstract class RabbitUtils {
 		default:
 			throw new IllegalStateException("Unrecognized SaslConfig: " + saslConfig);
 		}
+	}
+
+	/**
+	 * Return true for {@link AmqpRejectAndDontRequeueException#isRejectManual()}.
+	 * @param ex the exception.
+	 * @return the exception's rejectManual property, if it's an
+	 * {@link AmqpRejectAndDontRequeueException}.
+	 */
+	public static boolean isRejectManual(Throwable ex) {
+		return ex instanceof AmqpRejectAndDontRequeueException
+				&& ((AmqpRejectAndDontRequeueException) ex).isRejectManual();
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -749,7 +749,8 @@ public class BlockingQueueConsumer {
 	 */
 	public void rollbackOnExceptionIfNecessary(Throwable ex) {
 
-		boolean ackRequired = !this.acknowledgeMode.isAutoAck() && !this.acknowledgeMode.isManual();
+		boolean ackRequired = !this.acknowledgeMode.isAutoAck()
+				&& (!this.acknowledgeMode.isManual() || RabbitUtils.isRejectManual(ex));
 		try {
 			if (this.transactional) {
 				if (logger.isDebugEnabled()) {
@@ -780,11 +781,11 @@ public class BlockingQueueConsumer {
 
 	/**
 	 * Perform a commit or message acknowledgement, as appropriate.
-	 * @param locallyTransacted Whether the channel is locally transacted.
+	 * @param localTx Whether the channel is locally transacted.
 	 * @return true if at least one delivery tag exists.
 	 * @throws IOException Any IOException.
 	 */
-	public boolean commitIfNecessary(boolean locallyTransacted) throws IOException {
+	public boolean commitIfNecessary(boolean localTx) throws IOException {
 
 		if (this.deliveryTags.isEmpty()) {
 			return false;
@@ -793,7 +794,7 @@ public class BlockingQueueConsumer {
 		/*
 		 * If we have a TX Manager, but no TX, act like we are locally transacted.
 		 */
-		boolean isLocallyTransacted = locallyTransacted
+		boolean isLocallyTransacted = localTx
 				|| (this.transactional
 				&& TransactionSynchronizationManager.getResource(this.connectionFactory) == null);
 		try {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -750,7 +750,7 @@ public class BlockingQueueConsumer {
 	public void rollbackOnExceptionIfNecessary(Throwable ex) {
 
 		boolean ackRequired = !this.acknowledgeMode.isAutoAck()
-				&& (!this.acknowledgeMode.isManual() || RabbitUtils.isRejectManual(ex));
+				&& (!this.acknowledgeMode.isManual() || ContainerUtils.isRejectManual(ex));
 		try {
 			if (this.transactional) {
 				if (logger.isDebugEnabled()) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ConditionalRejectingErrorHandler.java
@@ -60,6 +60,8 @@ public class ConditionalRejectingErrorHandler implements ErrorHandler {
 
 	private boolean discardFatalsWithXDeath = true;
 
+	private boolean rejectManual = true;
+
 	/**
 	 * Create a handler with the {@link ConditionalRejectingErrorHandler.DefaultExceptionStrategy}.
 	 */
@@ -87,6 +89,15 @@ public class ConditionalRejectingErrorHandler implements ErrorHandler {
 		this.discardFatalsWithXDeath = discardFatalsWithXDeath;
 	}
 
+	/**
+	 * Set to false to NOT reject a fatal message when MANUAL ack mode is being used.
+	 * @param rejectManual false to leave the message in an unack'd state.
+	 * @since 2.1.9
+	 */
+	public void setRejectManual(boolean rejectManual) {
+		this.rejectManual = rejectManual;
+	}
+
 	@Override
 	public void handleError(Throwable t) {
 		log(t);
@@ -102,7 +113,8 @@ public class ConditionalRejectingErrorHandler implements ErrorHandler {
 					}
 				}
 			}
-			throw new AmqpRejectAndDontRequeueException("Error Handler converted exception to fatal", t);
+			throw new AmqpRejectAndDontRequeueException("Error Handler converted exception to fatal", this.rejectManual,
+					t);
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ContainerUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/ContainerUtils.java
@@ -67,4 +67,16 @@ public final class ContainerUtils {
 		return shouldRequeue;
 	}
 
+	/**
+	 * Return true for {@link AmqpRejectAndDontRequeueException#isRejectManual()}.
+	 * @param ex the exception.
+	 * @return the exception's rejectManual property, if it's an
+	 * {@link AmqpRejectAndDontRequeueException}.
+	 * @since 2.2
+	 */
+	public static boolean isRejectManual(Throwable ex) {
+		return ex instanceof AmqpRejectAndDontRequeueException
+				&& ((AmqpRejectAndDontRequeueException) ex).isRejectManual();
+	}
+
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1127,7 +1127,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			if (isChannelTransacted()) {
 				RabbitUtils.rollbackIfNecessary(getChannel());
 			}
-			if (this.ackRequired || RabbitUtils.isRejectManual(e)) {
+			if (this.ackRequired || ContainerUtils.isRejectManual(e)) {
 				try {
 					if (this.messagesPerAck > 1) {
 						synchronized (this) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1127,7 +1127,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			if (isChannelTransacted()) {
 				RabbitUtils.rollbackIfNecessary(getChannel());
 			}
-			if (this.ackRequired) {
+			if (this.ackRequired || RabbitUtils.isRejectManual(e)) {
 				try {
 					if (this.messagesPerAck > 1) {
 						synchronized (this) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -194,19 +194,49 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 	}
 
 	@Test
-	public void testRejectingErrorHandler() throws Exception {
+	public void testRejectingErrorHandlerSimpleAuto() throws Exception {
 		RabbitTemplate template = createTemplate(1);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(template.getConnectionFactory());
+		container.setReceiveTimeout(50);
+		testRejectingErrorHandler(template, container);
+	}
+
+	@Test
+	public void testRejectingErrorHandlerSimpleManual() throws Exception {
+		RabbitTemplate template = createTemplate(1);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(template.getConnectionFactory());
+		container.setReceiveTimeout(50);
+		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+		testRejectingErrorHandler(template, container);
+	}
+
+	@Test
+	public void testRejectingErrorHandlerDirectAuto() throws Exception {
+		RabbitTemplate template = createTemplate(1);
+		DirectMessageListenerContainer container = new DirectMessageListenerContainer(template.getConnectionFactory());
+		testRejectingErrorHandler(template, container);
+	}
+
+	@Test
+	public void testRejectingErrorHandlerDirectManual() throws Exception {
+		RabbitTemplate template = createTemplate(1);
+		DirectMessageListenerContainer container = new DirectMessageListenerContainer(template.getConnectionFactory());
+		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+		testRejectingErrorHandler(template, container);
+	}
+
+	private void testRejectingErrorHandler(RabbitTemplate template, AbstractMessageListenerContainer container)
+			throws Exception {
 		MessageListenerAdapter messageListener = new MessageListenerAdapter();
 		messageListener.setDelegate(new Object());
 		container.setMessageListener(messageListener);
 
 		RabbitAdmin admin = new RabbitAdmin(template.getConnectionFactory());
-		Queue queue = QueueBuilder.nonDurable("")
+		Queue queueForTest = QueueBuilder.nonDurable("")
 				.autoDelete()
 				.withArgument("x-dead-letter-exchange", "test.DLE")
 				.build();
-		String testQueueName = admin.declareQueue(queue);
+		String testQueueName = admin.declareQueue(queueForTest);
 		// Create a DeadLetterExchange and bind a queue to it with the original routing key
 		DirectExchange dle = new DirectExchange("test.DLE", false, true);
 		admin.declareExchange(dle);
@@ -215,7 +245,6 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 		admin.declareBinding(BindingBuilder.bind(dlq).to(dle).with(testQueueName));
 
 		container.setQueueNames(testQueueName);
-		container.setReceiveTimeout(50);
 		container.afterPropertiesSet();
 		container.start();
 
@@ -225,7 +254,7 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 				.build();
 		template.send("", testQueueName, message);
 
-		Message rejected = template.receive(dlq.getName());
+		Message rejected = template.receive(dlq.getName()); // can't use timed receive, queue will be deleted
 		int n = 0;
 		while (n++ < 100 && rejected == null) {
 			Thread.sleep(100);

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4927,6 +4927,11 @@ A common pattern for handling DLQ messages is to set a `time-to-live` on those m
 The problem with this technique is that messages that cause fatal exceptions loop forever.
 Starting with version 2.1, the `ConditionalRejectingErrorHandler` detects an `x-death` header on a message that causes a fatal exception to be thrown.
 The message is logged and discarded.
+You can revert to the previous behavior by setting the `discardFatalsWithXDeath` property on the `ConditionalRejectingErrorHandler` to `false`.
+
+IMPORTANT: Starting with version 2.1.9, messages with these fatal exceptions are rejected and NOT requeued by default, even if the container acknowledge mode is MANUAL.
+These exceptions generally occur before the listener is invoked so the listener does not have a chance to ack or nack the message so it remained in the queue in an un-acked state.
+To revert to the previous behavior, set the `rejectManual` property on the `ConditionalRejectingErrorHandler` to `false`.
 
 [[transactions]]
 ==== Transactions

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -15,6 +15,11 @@ The following classes/interfaces have been moved from `org.springframework.amqp.
 
 In addition, `ListenerExecutionFailedException` has been moved from `org.springframework.amqp.rabbit.listener.exception` to `org.springframework.amqp.rabbit.support`.
 
+===== ListenerContainer Changes
+
+Messages with fatal exceptions are now rejected and NOT requeued, by default, even if the acknowledge mode is manual.
+See <<exception-handling>> for more information.
+
 ===== @RabbitListener Changes
 
 You can now configure an `executor` on each listener, overriding the factory configuration, to more easily identify threads associated with the listener.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1065

Previously, messages with fatal errors (e.g. conversion) would be
left in an un-acked state.

They are now rejected and NOT requeued by default.

**cherry-pick to 2.1.x**
