### PR TITLE
GH-1071: JUnit 5 Support Improvements

### DIFF
--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupport.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupport.java
@@ -96,9 +96,6 @@ public final class BrokerRunningSupport {
 
 	private final String[] queues;
 
-	private final int defaultPort = fromEnvironment(BROKER_PORT, null) == null ? BrokerTestUtils.getPort()
-			: Integer.valueOf(fromEnvironment(BROKER_PORT, null));
-
 	private int port;
 
 	private String hostName = fromEnvironment(BROKER_HOSTNAME, "localhost");
@@ -204,7 +201,9 @@ public final class BrokerRunningSupport {
 		}
 		this.purge = purge;
 		this.management = management;
-		setPort(this.defaultPort);
+		setPort(fromEnvironment(BROKER_PORT, null) == null
+				? BrokerTestUtils.getPort()
+				: Integer.valueOf(fromEnvironment(BROKER_PORT, null)));
 	}
 
 	private BrokerRunningSupport(boolean assumeOnline, String... queues) {

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupport.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupport.java
@@ -17,7 +17,6 @@
 package org.springframework.amqp.rabbit.junit;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -41,37 +40,19 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.http.client.Client;
 
 /**
- * A rule that prevents integration tests from failing if the Rabbit broker application is
+ * A class that can be used to prevent integration tests from failing if the Rabbit broker application is
  * not running or not accessible. If the Rabbit broker is not running in the background
  * all the tests here will simply be skipped (by default) because of a violated assumption
- * (showing as successful). Usage:
- *
- * <pre class="code">
- * &#064;Rule
- * public static BrokerRunning brokerIsRunning = BrokerRunning.isRunning();
- *
- * &#064;Test
- * public void testSendAndReceive() throws Exception {
- * 	// ... test using RabbitTemplate etc.
- * }
- * </pre>
- *
- * The rule can be declared as static so that it only has to check once for all tests in
- * the enclosing test case, but there isn't a lot of overhead in making it non-static.
- * <p>Use {@link #isRunningWithEmptyQueues(String...)} to declare and/or purge test queue(s)
- * when the rule is run.
- * <p>Call {@link #removeTestQueues(String...)} from an {@code @After} method to remove
- * those queues (and optionally others).
- * <p>If you wish to enforce the broker being available, for example, on a CI server,
+ * (showing as successful).
+ * <p>
+ * If you wish to enforce the broker being available, for example, on a CI server,
  * set the environment variable {@value #BROKER_REQUIRED} to {@code true} and the
  * tests will fail fast.
  *
  * @author Dave Syer
  * @author Gary Russell
  *
- * @since 1.7
- * @see Assume
- * @see org.junit.internal.AssumptionViolatedException
+ * @since 2.2
  */
 public final class BrokerRunningSupport {
 
@@ -97,15 +78,15 @@ public final class BrokerRunningSupport {
 
 	private static final String GUEST = "guest";
 
-	private static final Log logger = LogFactory.getLog(BrokerRunningSupport.class); // NOSONAR - lower case
+	private static final Log LOGGER = LogFactory.getLog(BrokerRunningSupport.class);
 
 	// Static so that we only test once on failure: speeds up test suite
-	private static final Map<Integer, Boolean> brokerOnline = new HashMap<Integer, Boolean>(); // NOSONAR - lower case
+	private static final Map<Integer, Boolean> BROKER_ONLINE = new HashMap<>();
 
 	// Static so that we only test once on failure
-	private static final Map<Integer, Boolean> brokerOffline = new HashMap<Integer, Boolean>(); // NOSONAR - lower case
+	private static final Map<Integer, Boolean> BROKER_OFFLINE = new HashMap<>();
 
-	private static final Map<String, String> environmentOverrides = new HashMap<>(); // NOSONAR - lower case
+	private static final Map<String, String> ENVIRONMENT_OVERRIDES = new HashMap<>();
 
 	private final boolean assumeOnline;
 
@@ -136,8 +117,8 @@ public final class BrokerRunningSupport {
 
 	private boolean purgeAfterEach;
 
-	private String fromEnvironment(String key, String defaultValue) {
-		String environmentValue = environmentOverrides.get(key);
+	private static String fromEnvironment(String key, String defaultValue) {
+		String environmentValue = ENVIRONMENT_OVERRIDES.get(key);
 		if (!StringUtils.hasText(environmentValue)) {
 			environmentValue = System.getenv(key);
 		}
@@ -158,14 +139,14 @@ public final class BrokerRunningSupport {
 	 * @param environmentVariables the variables.
 	 */
 	public static void setEnvironmentVariableOverrides(Map<String, String> environmentVariables) {
-		environmentOverrides.putAll(environmentVariables);
+		ENVIRONMENT_OVERRIDES.putAll(environmentVariables);
 	}
 
 	/**
 	 * Clear any environment variable overrides set in {@link #setEnvironmentVariableOverrides(Map)}.
 	 */
 	public static void clearEnvironmentVariableOverrides() {
-		environmentOverrides.clear();
+		ENVIRONMENT_OVERRIDES.clear();
 	}
 
 	/**
@@ -243,11 +224,11 @@ public final class BrokerRunningSupport {
 	 */
 	public void setPort(int port) {
 		this.port = port;
-		if (!brokerOffline.containsKey(port)) {
-			brokerOffline.put(port, true);
+		if (!BROKER_OFFLINE.containsKey(port)) {
+			BROKER_OFFLINE.put(port, true);
 		}
-		if (!brokerOnline.containsKey(port)) {
-			brokerOnline.put(port, true);
+		if (!BROKER_ONLINE.containsKey(port)) {
+			BROKER_ONLINE.put(port, true);
 		}
 	}
 
@@ -261,7 +242,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Set the user for the amqp connection default "guest".
 	 * @param user the user.
-	 * @since 1.7.2
 	 */
 	public void setUser(String user) {
 		this.user = user;
@@ -270,7 +250,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Set the password for the amqp connection default "guest".
 	 * @param password the password.
-	 * @since 1.7.2
 	 */
 	public void setPassword(String password) {
 		this.password = password;
@@ -279,7 +258,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Set the uri for the REST API.
 	 * @param adminUri the uri.
-	 * @since 1.7.2
 	 */
 	public void setAdminUri(String adminUri) {
 		this.adminUri = adminUri;
@@ -288,7 +266,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Set the user for the management REST API connection default "guest".
 	 * @param user the user.
-	 * @since 1.7.2
 	 */
 	public void setAdminUser(String user) {
 		this.adminUser = user;
@@ -297,7 +274,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Set the password for the management REST API connection default "guest".
 	 * @param password the password.
-	 * @since 1.7.2
 	 */
 	public void setAdminPassword(String password) {
 		this.adminPassword = password;
@@ -306,7 +282,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Return the port.
 	 * @return the port.
-	 * @since 1.7.2
 	 */
 	public int getPort() {
 		return this.port;
@@ -315,7 +290,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Return the port.
 	 * @return the port.
-	 * @since 1.7.2
 	 */
 	public String getHostName() {
 		return this.hostName;
@@ -324,7 +298,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Return the user.
 	 * @return the user.
-	 * @since 1.7.2
 	 */
 	public String getUser() {
 		return this.user;
@@ -333,7 +306,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Return the password.
 	 * @return the password.
-	 * @since 1.7.2
 	 */
 	public String getPassword() {
 		return this.password;
@@ -342,7 +314,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Return the admin user.
 	 * @return the user.
-	 * @since 1.7.2
 	 */
 	public String getAdminUser() {
 		return this.adminUser;
@@ -351,7 +322,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Return the admin password.
 	 * @return the password.
-	 * @since 1.7.2
 	 */
 	public String getAdminPassword() {
 		return this.adminPassword;
@@ -365,7 +335,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Purge the test queues after each test (JUnit 5).
 	 * @param purgeAfterEach true to purge.
-	 * @since 2.2
 	 */
 	public void setPurgeAfterEach(boolean purgeAfterEach) {
 		this.purgeAfterEach = purgeAfterEach;
@@ -375,12 +344,12 @@ public final class BrokerRunningSupport {
 
 		// Check at the beginning, so this can be used as a static field
 		if (this.assumeOnline) {
-			if (Boolean.FALSE.equals(brokerOnline.get(this.port))) {
+			if (Boolean.FALSE.equals(BROKER_ONLINE.get(this.port))) {
 				throw new BrokerNotAliveException("Require broker online and it's not");
 			}
 		}
 		else {
-			if (Boolean.FALSE.equals(brokerOffline.get(this.port))) {
+			if (Boolean.FALSE.equals(BROKER_OFFLINE.get(this.port))) {
 				throw new BrokerNotAliveException("Require broker offline and it's not");
 			}
 		}
@@ -393,8 +362,8 @@ public final class BrokerRunningSupport {
 			channel = createQueues(connection);
 		}
 		catch (Exception e) {
-			logger.warn("Not executing tests because basic connectivity test failed: " + e.getMessage());
-			brokerOnline.put(this.port, false);
+			LOGGER.warn("Not executing tests because basic connectivity test failed: " + e.getMessage());
+			BROKER_ONLINE.put(this.port, false);
 			if (this.assumeOnline) {
 				if (fatal()) {
 					throw new BrokerNotAliveException("RabbitMQ Broker is required, but not available");
@@ -415,14 +384,14 @@ public final class BrokerRunningSupport {
 		return connection;
 	}
 
-	private Channel createQueues(Connection connection) throws IOException, MalformedURLException, URISyntaxException {
+	private Channel createQueues(Connection connection) throws IOException, URISyntaxException {
 		Channel channel;
 		channel = connection.createChannel();
 
 		for (String queueName : this.queues) {
 
 			if (this.purge) {
-				logger.debug("Deleting queue: " + queueName);
+				LOGGER.debug("Deleting queue: " + queueName);
 				// Delete completely - gets rid of consumers and bindings as well
 				channel.queueDelete(queueName);
 			}
@@ -435,9 +404,9 @@ public final class BrokerRunningSupport {
 				channel.queueDeclare(queueName, true, false, false, null);
 			}
 		}
-		brokerOffline.put(this.port, false);
+		BROKER_OFFLINE.put(this.port, false);
 		if (!this.assumeOnline) {
-			Assume.assumeTrue(brokerOffline.get(this.port));
+			Assume.assumeTrue(BROKER_OFFLINE.get(this.port));
 		}
 
 		if (this.management) {
@@ -453,7 +422,7 @@ public final class BrokerRunningSupport {
 	public static boolean fatal() {
 		String serversRequired = System.getenv(BROKER_REQUIRED);
 		if (Boolean.parseBoolean(serversRequired)) {
-			logger.error("RABBITMQ IS REQUIRED BUT NOT AVAILABLE");
+			LOGGER.error("RABBITMQ IS REQUIRED BUT NOT AVAILABLE");
 			return true;
 		}
 		else {
@@ -490,7 +459,7 @@ public final class BrokerRunningSupport {
 			queuesToRemove = new ArrayList<>(queuesToRemove);
 			queuesToRemove.addAll(Arrays.asList(additionalQueues));
 		}
-		logger.debug("deleting test queues: " + queuesToRemove);
+		LOGGER.debug("deleting test queues: " + queuesToRemove);
 		Connection connection = null; // NOSONAR (closeResources())
 		Channel channel = null;
 
@@ -504,7 +473,7 @@ public final class BrokerRunningSupport {
 			}
 		}
 		catch (Exception e) {
-			logger.warn("Failed to delete queues", e);
+			LOGGER.warn("Failed to delete queues", e);
 		}
 		finally {
 			closeResources(connection, channel);
@@ -524,7 +493,7 @@ public final class BrokerRunningSupport {
 			channel = createQueues(connection);
 		}
 		catch (Exception e) {
-			logger.warn("Failed to re-declare queues during purge: " + e.getMessage());
+			LOGGER.warn("Failed to re-declare queues during purge: " + e.getMessage());
 		}
 		finally {
 			closeResources(connection, channel);
@@ -549,7 +518,7 @@ public final class BrokerRunningSupport {
 			}
 		}
 		catch (Exception e) {
-			logger.warn("Failed to delete queues", e);
+			LOGGER.warn("Failed to delete queues", e);
 		}
 		finally {
 			closeResources(connection, channel);
@@ -574,7 +543,7 @@ public final class BrokerRunningSupport {
 			}
 		}
 		catch (Exception e) {
-			logger.warn("Failed to delete queues", e);
+			LOGGER.warn("Failed to delete queues", e);
 		}
 		finally {
 			closeResources(connection, channel);
@@ -605,7 +574,6 @@ public final class BrokerRunningSupport {
 	/**
 	 * Return the admin uri.
 	 * @return the uri.
-	 * @since 1.7.2
 	 */
 	public String getAdminUri() {
 		if (!StringUtils.hasText(this.adminUri)) {

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupport.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupport.java
@@ -1,0 +1,655 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.junit;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Assume;
+
+import org.springframework.util.Base64Utils;
+import org.springframework.util.StringUtils;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.http.client.Client;
+
+/**
+ * A rule that prevents integration tests from failing if the Rabbit broker application is
+ * not running or not accessible. If the Rabbit broker is not running in the background
+ * all the tests here will simply be skipped (by default) because of a violated assumption
+ * (showing as successful). Usage:
+ *
+ * <pre class="code">
+ * &#064;Rule
+ * public static BrokerRunning brokerIsRunning = BrokerRunning.isRunning();
+ *
+ * &#064;Test
+ * public void testSendAndReceive() throws Exception {
+ * 	// ... test using RabbitTemplate etc.
+ * }
+ * </pre>
+ *
+ * The rule can be declared as static so that it only has to check once for all tests in
+ * the enclosing test case, but there isn't a lot of overhead in making it non-static.
+ * <p>Use {@link #isRunningWithEmptyQueues(String...)} to declare and/or purge test queue(s)
+ * when the rule is run.
+ * <p>Call {@link #removeTestQueues(String...)} from an {@code @After} method to remove
+ * those queues (and optionally others).
+ * <p>If you wish to enforce the broker being available, for example, on a CI server,
+ * set the environment variable {@value #BROKER_REQUIRED} to {@code true} and the
+ * tests will fail fast.
+ *
+ * @author Dave Syer
+ * @author Gary Russell
+ *
+ * @since 1.7
+ * @see Assume
+ * @see org.junit.internal.AssumptionViolatedException
+ */
+public final class BrokerRunningSupport {
+
+	private static final int SIXTEEN = 16;
+
+	public static final String BROKER_ADMIN_URI = "RABBITMQ_TEST_ADMIN_URI";
+
+	public static final String BROKER_HOSTNAME = "RABBITMQ_TEST_HOSTNAME";
+
+	public static final String BROKER_PORT = "RABBITMQ_TEST_PORT";
+
+	public static final String BROKER_USER = "RABBITMQ_TEST_USER";
+
+	public static final String BROKER_PW = "RABBITMQ_TEST_PASSWORD";
+
+	public static final String BROKER_ADMIN_USER = "RABBITMQ_TEST_ADMIN_USER";
+
+	public static final String BROKER_ADMIN_PW = "RABBITMQ_TEST_ADMIN_PASSWORD";
+
+	public static final String BROKER_REQUIRED = "RABBITMQ_SERVER_REQUIRED";
+
+	public static final String DEFAULT_QUEUE_NAME = BrokerRunningSupport.class.getName();
+
+	private static final String GUEST = "guest";
+
+	private static final Log logger = LogFactory.getLog(BrokerRunningSupport.class); // NOSONAR - lower case
+
+	// Static so that we only test once on failure: speeds up test suite
+	private static final Map<Integer, Boolean> brokerOnline = new HashMap<Integer, Boolean>(); // NOSONAR - lower case
+
+	// Static so that we only test once on failure
+	private static final Map<Integer, Boolean> brokerOffline = new HashMap<Integer, Boolean>(); // NOSONAR - lower case
+
+	private static final Map<String, String> environmentOverrides = new HashMap<>(); // NOSONAR - lower case
+
+	private final boolean assumeOnline;
+
+	private final boolean purge;
+
+	private final boolean management;
+
+	private final String[] queues;
+
+	private final int defaultPort = fromEnvironment(BROKER_PORT, null) == null ? BrokerTestUtils.getPort()
+			: Integer.valueOf(fromEnvironment(BROKER_PORT, null));
+
+	private int port;
+
+	private String hostName = fromEnvironment(BROKER_HOSTNAME, "localhost");
+
+	private String adminUri = fromEnvironment(BROKER_ADMIN_URI, null);
+
+	private ConnectionFactory connectionFactory;
+
+	private String user = fromEnvironment(BROKER_USER, GUEST);
+
+	private String password = fromEnvironment(BROKER_PW, GUEST);
+
+	private String adminUser = fromEnvironment(BROKER_ADMIN_USER, GUEST);
+
+	private String adminPassword = fromEnvironment(BROKER_ADMIN_PW, GUEST);
+
+	private boolean purgeAfterEach;
+
+	private String fromEnvironment(String key, String defaultValue) {
+		String environmentValue = environmentOverrides.get(key);
+		if (!StringUtils.hasText(environmentValue)) {
+			environmentValue = System.getenv(key);
+		}
+		if (StringUtils.hasText(environmentValue)) {
+			return environmentValue;
+		}
+		else {
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * Set environment variable overrides for host, port etc. Will override any real
+	 * environment variables, if present.
+	 * <p><b>The variables will only apply to rule instances that are created after this
+	 * method is called.</b>
+	 * The overrides will remain until
+	 * @param environmentVariables the variables.
+	 */
+	public static void setEnvironmentVariableOverrides(Map<String, String> environmentVariables) {
+		environmentOverrides.putAll(environmentVariables);
+	}
+
+	/**
+	 * Clear any environment variable overrides set in {@link #setEnvironmentVariableOverrides(Map)}.
+	 */
+	public static void clearEnvironmentVariableOverrides() {
+		environmentOverrides.clear();
+	}
+
+	/**
+	 * Ensure the broker is running and has a empty queue(s) with the specified name(s) in the
+	 * default exchange.
+	 *
+	 * @param names the queues to declare for the test.
+	 * @return a new rule that assumes an existing running broker
+	 */
+	public static BrokerRunningSupport isRunningWithEmptyQueues(String... names) {
+		return new BrokerRunningSupport(true, true, names);
+	}
+
+	/**
+	 * @return a new rule that assumes an existing running broker
+	 */
+	public static BrokerRunningSupport isRunning() {
+		return new BrokerRunningSupport(true);
+	}
+
+	/**
+	 * @return a new rule that assumes there is no existing broker
+	 */
+	public static BrokerRunningSupport isNotRunning() {
+		return new BrokerRunningSupport(false);
+	}
+
+	/**
+	 * @return a new rule that assumes an existing broker with the management plugin
+	 */
+	public static BrokerRunningSupport isBrokerAndManagementRunning() {
+		return new BrokerRunningSupport(true, false, true);
+	}
+
+	/**
+	 * @param queues the queues.
+	 * @return a new rule that assumes an existing broker with the management plugin with
+	 * the provided queues declared (and emptied if needed)..
+	 */
+	public static BrokerRunningSupport isBrokerAndManagementRunningWithEmptyQueues(String...queues) {
+		return new BrokerRunningSupport(true, false, true, queues);
+	}
+
+	private BrokerRunningSupport(boolean assumeOnline, boolean purge, String... queues) {
+		this(assumeOnline, purge, false, queues);
+	}
+
+	BrokerRunningSupport(boolean assumeOnline, boolean purge, boolean management, String... queues) {
+		this.assumeOnline = assumeOnline;
+		if (queues != null) {
+			this.queues = Arrays.copyOf(queues, queues.length);
+		}
+		else {
+			this.queues = null;
+		}
+		this.purge = purge;
+		this.management = management;
+		setPort(this.defaultPort);
+	}
+
+	private BrokerRunningSupport(boolean assumeOnline, String... queues) {
+		this(assumeOnline, false, queues);
+	}
+
+	private BrokerRunningSupport(boolean assumeOnline) {
+		this(assumeOnline, DEFAULT_QUEUE_NAME);
+	}
+
+	private BrokerRunningSupport(boolean assumeOnline, boolean purge, boolean management) {
+		this(assumeOnline, purge, management, DEFAULT_QUEUE_NAME);
+	}
+
+	/**
+	 * @param port the port to set
+	 */
+	public void setPort(int port) {
+		this.port = port;
+		if (!brokerOffline.containsKey(port)) {
+			brokerOffline.put(port, true);
+		}
+		if (!brokerOnline.containsKey(port)) {
+			brokerOnline.put(port, true);
+		}
+	}
+
+	/**
+	 * @param hostName the hostName to set
+	 */
+	public void setHostName(String hostName) {
+		this.hostName = hostName;
+	}
+
+	/**
+	 * Set the user for the amqp connection default "guest".
+	 * @param user the user.
+	 * @since 1.7.2
+	 */
+	public void setUser(String user) {
+		this.user = user;
+	}
+
+	/**
+	 * Set the password for the amqp connection default "guest".
+	 * @param password the password.
+	 * @since 1.7.2
+	 */
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	/**
+	 * Set the uri for the REST API.
+	 * @param adminUri the uri.
+	 * @since 1.7.2
+	 */
+	public void setAdminUri(String adminUri) {
+		this.adminUri = adminUri;
+	}
+
+	/**
+	 * Set the user for the management REST API connection default "guest".
+	 * @param user the user.
+	 * @since 1.7.2
+	 */
+	public void setAdminUser(String user) {
+		this.adminUser = user;
+	}
+
+	/**
+	 * Set the password for the management REST API connection default "guest".
+	 * @param password the password.
+	 * @since 1.7.2
+	 */
+	public void setAdminPassword(String password) {
+		this.adminPassword = password;
+	}
+
+	/**
+	 * Return the port.
+	 * @return the port.
+	 * @since 1.7.2
+	 */
+	public int getPort() {
+		return this.port;
+	}
+
+	/**
+	 * Return the port.
+	 * @return the port.
+	 * @since 1.7.2
+	 */
+	public String getHostName() {
+		return this.hostName;
+	}
+
+	/**
+	 * Return the user.
+	 * @return the user.
+	 * @since 1.7.2
+	 */
+	public String getUser() {
+		return this.user;
+	}
+
+	/**
+	 * Return the password.
+	 * @return the password.
+	 * @since 1.7.2
+	 */
+	public String getPassword() {
+		return this.password;
+	}
+
+	/**
+	 * Return the admin user.
+	 * @return the user.
+	 * @since 1.7.2
+	 */
+	public String getAdminUser() {
+		return this.adminUser;
+	}
+
+	/**
+	 * Return the admin password.
+	 * @return the password.
+	 * @since 1.7.2
+	 */
+	public String getAdminPassword() {
+		return this.adminPassword;
+	}
+
+
+	public boolean isPurgeAfterEach() {
+		return this.purgeAfterEach;
+	}
+
+	/**
+	 * Purge the test queues after each test (JUnit 5).
+	 * @param purgeAfterEach true to purge.
+	 * @since 2.2
+	 */
+	public void setPurgeAfterEach(boolean purgeAfterEach) {
+		this.purgeAfterEach = purgeAfterEach;
+	}
+
+	public void test() {
+
+		// Check at the beginning, so this can be used as a static field
+		if (this.assumeOnline) {
+			if (Boolean.FALSE.equals(brokerOnline.get(this.port))) {
+				throw new BrokerNotAliveException("Require broker online and it's not");
+			}
+		}
+		else {
+			if (Boolean.FALSE.equals(brokerOffline.get(this.port))) {
+				throw new BrokerNotAliveException("Require broker offline and it's not");
+			}
+		}
+
+		Connection connection = null; // NOSONAR (closeResources())
+		Channel channel = null;
+
+		try {
+			connection = getConnection(getConnectionFactory());
+			channel = createQueues(connection);
+		}
+		catch (Exception e) {
+			logger.warn("Not executing tests because basic connectivity test failed: " + e.getMessage());
+			brokerOnline.put(this.port, false);
+			if (this.assumeOnline) {
+				if (fatal()) {
+					throw new BrokerNotAliveException("RabbitMQ Broker is required, but not available");
+				}
+				else {
+					Assume.assumeNoException(e);
+				}
+			}
+		}
+		finally {
+			closeResources(connection, channel);
+		}
+	}
+
+	private Connection getConnection(ConnectionFactory cf) throws IOException, TimeoutException {
+		Connection connection = cf.newConnection();
+		connection.setId(generateId());
+		return connection;
+	}
+
+	private Channel createQueues(Connection connection) throws IOException, MalformedURLException, URISyntaxException {
+		Channel channel;
+		channel = connection.createChannel();
+
+		for (String queueName : this.queues) {
+
+			if (this.purge) {
+				logger.debug("Deleting queue: " + queueName);
+				// Delete completely - gets rid of consumers and bindings as well
+				channel.queueDelete(queueName);
+			}
+
+			if (isDefaultQueue(queueName)) {
+				// Just for test probe.
+				channel.queueDelete(queueName);
+			}
+			else {
+				channel.queueDeclare(queueName, true, false, false, null);
+			}
+		}
+		brokerOffline.put(this.port, false);
+		if (!this.assumeOnline) {
+			Assume.assumeTrue(brokerOffline.get(this.port));
+		}
+
+		if (this.management) {
+			Client client = new Client(getAdminUri(), this.adminUser, this.adminPassword);
+			if (!client.alivenessTest("/")) {
+				throw new BrokerNotAliveException("Aliveness test failed for localhost:15672 guest/quest; "
+						+ "management not available");
+			}
+		}
+		return channel;
+	}
+
+	public static boolean fatal() {
+		String serversRequired = System.getenv(BROKER_REQUIRED);
+		if (Boolean.parseBoolean(serversRequired)) {
+			logger.error("RABBITMQ IS REQUIRED BUT NOT AVAILABLE");
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+	/**
+	 * Generate the connection id for the connection used by the rule's
+	 * connection factory.
+	 * @return the id.
+	 */
+	public String generateId() {
+		UUID uuid = UUID.randomUUID();
+		ByteBuffer bb = ByteBuffer.wrap(new byte[SIXTEEN]);
+		bb.putLong(uuid.getMostSignificantBits())
+		  .putLong(uuid.getLeastSignificantBits());
+		return "SpringBrokerRunning." + Base64Utils.encodeToUrlSafeString(bb.array()).replaceAll("=", "");
+	}
+
+	private boolean isDefaultQueue(String queue) {
+		return DEFAULT_QUEUE_NAME.equals(queue);
+	}
+
+	/**
+	 * Remove any test queues that were created by an
+	 * {@link #isRunningWithEmptyQueues(String...)} method.
+	 * @param additionalQueues additional queues to remove that might have been created by
+	 * tests.
+	 */
+	public void removeTestQueues(String... additionalQueues) {
+		List<String> queuesToRemove = Arrays.asList(this.queues);
+		if (additionalQueues != null) {
+			queuesToRemove = new ArrayList<>(queuesToRemove);
+			queuesToRemove.addAll(Arrays.asList(additionalQueues));
+		}
+		logger.debug("deleting test queues: " + queuesToRemove);
+		Connection connection = null; // NOSONAR (closeResources())
+		Channel channel = null;
+
+		try {
+			connection = getConnection(getConnectionFactory());
+			connection.setId(generateId() + ".queueDelete");
+			channel = connection.createChannel();
+
+			for (String queue : queuesToRemove) {
+				channel.queueDelete(queue);
+			}
+		}
+		catch (Exception e) {
+			logger.warn("Failed to delete queues", e);
+		}
+		finally {
+			closeResources(connection, channel);
+		}
+	}
+
+	/**
+	 * Delete and re-declare all the configured queues. Can be used between tests when
+	 * a test might leave stale data and multiple tests use the same queue.
+	 */
+	public void purgeTestQueues() {
+		removeTestQueues();
+		Connection connection = null; // NOSONAR (closeResources())
+		Channel channel = null;
+		try {
+			connection = getConnection(getConnectionFactory());
+			channel = createQueues(connection);
+		}
+		catch (Exception e) {
+			logger.warn("Failed to re-declare queues during purge: " + e.getMessage());
+		}
+		finally {
+			closeResources(connection, channel);
+		}
+	}
+
+	/**
+	 * Delete arbitrary queues from the broker.
+	 * @param queuesToDelete the queues to delete.
+	 */
+	public void deleteQueues(String... queuesToDelete) {
+		Connection connection = null; // NOSONAR (closeResources())
+		Channel channel = null;
+
+		try {
+			connection = getConnection(getConnectionFactory());
+			connection.setId(generateId() + ".queueDelete");
+			channel = connection.createChannel();
+
+			for (String queue : queuesToDelete) {
+				channel.queueDelete(queue);
+			}
+		}
+		catch (Exception e) {
+			logger.warn("Failed to delete queues", e);
+		}
+		finally {
+			closeResources(connection, channel);
+		}
+	}
+
+	/**
+	 * Delete arbitrary exchanges from the broker.
+	 * @param exchanges the exchanges to delete.
+	 */
+	public void deleteExchanges(String... exchanges) {
+		Connection connection = null; // NOSONAR (closeResources())
+		Channel channel = null;
+
+		try {
+			connection = getConnection(getConnectionFactory());
+			connection.setId(generateId() + ".exchangeDelete");
+			channel = connection.createChannel();
+
+			for (String exchange : exchanges) {
+				channel.exchangeDelete(exchange);
+			}
+		}
+		catch (Exception e) {
+			logger.warn("Failed to delete queues", e);
+		}
+		finally {
+			closeResources(connection, channel);
+		}
+	}
+
+	/**
+	 * Get the connection factory used by this rule.
+	 * @return the connection factory.
+	 */
+	public ConnectionFactory getConnectionFactory() {
+		if (this.connectionFactory == null) {
+			this.connectionFactory = new ConnectionFactory();
+			if (StringUtils.hasText(this.hostName)) {
+				this.connectionFactory.setHost(this.hostName);
+			}
+			else {
+				this.connectionFactory.setHost("localhost");
+			}
+			this.connectionFactory.setPort(this.port);
+			this.connectionFactory.setUsername(this.user);
+			this.connectionFactory.setPassword(this.password);
+			this.connectionFactory.setAutomaticRecoveryEnabled(false);
+		}
+		return this.connectionFactory;
+	}
+
+	/**
+	 * Return the admin uri.
+	 * @return the uri.
+	 * @since 1.7.2
+	 */
+	public String getAdminUri() {
+		if (!StringUtils.hasText(this.adminUri)) {
+			if (!StringUtils.hasText(this.hostName)) {
+				this.adminUri = "http://localhost:15672/api/";
+			}
+			else {
+				this.adminUri = "http://" + this.hostName + ":15672/api/";
+			}
+		}
+		return this.adminUri;
+	}
+
+	private void closeResources(Connection connection, Channel channel) {
+		if (channel != null) {
+			try {
+				channel.close();
+			}
+			catch (@SuppressWarnings("unused") IOException | TimeoutException e) {
+				// Ignore
+			}
+		}
+		if (connection != null) {
+			try {
+				connection.close();
+			}
+			catch (@SuppressWarnings("unused") IOException e) {
+				// Ignore
+			}
+		}
+	}
+
+	/**
+	 * The {@link RuntimeException} thrown when broker is not available
+	 * on the provided host port.
+	 */
+	public static class BrokerNotAliveException extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
+
+		BrokerNotAliveException(String message) {
+			super(message);
+		}
+
+	}
+
+}

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/LogLevels.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/LogLevels.java
@@ -53,8 +53,8 @@ public @interface LogLevels {
 
 	/**
 	 * The Log4j level name to switch the categories to during the test.
-	 * @return the level.
+	 * @return the level (default DEBUG).
 	 */
-	String level();
+	String level() default "DEBUG";
 
 }

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/LogLevels.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/LogLevels.java
@@ -55,6 +55,6 @@ public @interface LogLevels {
 	 * The Log4j level name to switch the categories to during the test.
 	 * @return the level.
 	 */
-	String level() default "";
+	String level();
 
 }

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/LogLevelsCondition.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/LogLevelsCondition.java
@@ -74,10 +74,12 @@ public class LogLevelsCondition
 			store = parent.getStore(Namespace.create(getClass(), parent));
 			logLevels = store.get(STORE_ANNOTATION_KEY, LogLevels.class);
 		}
-		store.put(STORE_CONTAINER_KEY, JUnitUtils.adjustLogLevels(context.getDisplayName(),
-				Arrays.asList((logLevels.classes())),
-				Arrays.asList(logLevels.categories()),
-				Level.toLevel(logLevels.level())));
+		if (logLevels != null) {
+			store.put(STORE_CONTAINER_KEY, JUnitUtils.adjustLogLevels(context.getDisplayName(),
+					Arrays.asList((logLevels.classes())),
+					Arrays.asList(logLevels.categories()),
+					Level.toLevel(logLevels.level())));
+		}
 	}
 
 	@Override
@@ -91,10 +93,12 @@ public class LogLevelsCondition
 			container = store.get(STORE_CONTAINER_KEY, LevelsContainer.class);
 			parentStore = true;
 		}
-		JUnitUtils.revertLevels(context.getDisplayName(), container);
-		store.remove(STORE_CONTAINER_KEY);
-		if (!parentStore) {
-			store.remove(STORE_ANNOTATION_KEY);
+		if (container != null) {
+			JUnitUtils.revertLevels(context.getDisplayName(), container);
+			store.remove(STORE_CONTAINER_KEY);
+			if (!parentStore) {
+				store.remove(STORE_ANNOTATION_KEY);
+			}
 		}
 	}
 

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailable.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailable.java
@@ -62,4 +62,11 @@ public @interface RabbitAvailable {
 	 */
 	boolean management() default false;
 
+	/**
+	 * Purge the test queues after each test.
+	 * @return true to purge (default).
+	 * @since 2.2
+	 */
+	boolean purgeAfterEach() default true;
+
 }

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCondition.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCondition.java
@@ -20,6 +20,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.util.Optional;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -35,100 +36,110 @@ import org.springframework.util.Assert;
 import com.rabbitmq.client.ConnectionFactory;
 
 /**
- * JUnit5 {@link ExecutionCondition}.
- * Looks for {@code @RabbitAvailable} annotated classes and disables
- * if found the broker is not available.
+ * JUnit5 {@link ExecutionCondition}. Looks for {@code @RabbitAvailable} annotated classes
+ * and disables if found the broker is not available.
  *
  * @author Gary Russell
  * @since 2.0.2
  *
  */
-public class RabbitAvailableCondition implements ExecutionCondition, AfterAllCallback, ParameterResolver {
+public class RabbitAvailableCondition
+		implements ExecutionCondition, AfterEachCallback, AfterAllCallback, ParameterResolver {
 
-    private static final String BROKER_RUNNING_BEAN = "brokerRunning";
+	private static final String BROKER_RUNNING_BEAN = "brokerRunning";
 
-    private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
-            "@RabbitAvailable is not present");
+	private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
+			"@RabbitAvailable is not present");
 
-    private static final ThreadLocal<BrokerRunning> brokerRunningHolder = new ThreadLocal<>(); // NOSONAR - lower case
+	private static final ThreadLocal<BrokerRunningSupport> BROKER_RUNNING_HOLDER = new ThreadLocal<>();
 
-    @Override
-    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-        Optional<AnnotatedElement> element = context.getElement();
-        MergedAnnotations annotations = MergedAnnotations.from(element.get(),
-                MergedAnnotations.SearchStrategy.TYPE_HIERARCHY);
-        if (annotations.get(RabbitAvailable.class).isPresent()) {
-            RabbitAvailable rabbit = annotations.get(RabbitAvailable.class).synthesize();
-            try {
-                String[] queues = rabbit.queues();
-                BrokerRunning brokerRunning = getStore(context).get(BROKER_RUNNING_BEAN, BrokerRunning.class);
-                if (brokerRunning == null) {
-                    if (rabbit.management()) {
-                        brokerRunning = BrokerRunning.isBrokerAndManagementRunningWithEmptyQueues(queues);
-                    }
-                    else {
-                        brokerRunning = BrokerRunning.isRunningWithEmptyQueues(queues);
-                    }
-                }
-                brokerRunning.isUp();
-                brokerRunningHolder.set(brokerRunning);
-                Store store = getStore(context);
-                store.put(BROKER_RUNNING_BEAN, brokerRunning);
-                store.put("queuesToDelete", queues);
-                return ConditionEvaluationResult.enabled("RabbitMQ is available");
-            }
-            catch (Exception e) {
-                if (BrokerRunning.fatal()) {
-                    throw new IllegalStateException("Required RabbitMQ is not available", e);
-                }
-                return ConditionEvaluationResult.disabled("RabbitMQ is not available");
-            }
-        }
-        return ENABLED;
-    }
+	@Override
+	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+		Optional<AnnotatedElement> element = context.getElement();
+		MergedAnnotations annotations = MergedAnnotations.from(element.get(),
+				MergedAnnotations.SearchStrategy.TYPE_HIERARCHY);
+		if (annotations.get(RabbitAvailable.class).isPresent()) {
+			RabbitAvailable rabbit = annotations.get(RabbitAvailable.class).synthesize();
+			try {
+				String[] queues = rabbit.queues();
+				BrokerRunningSupport brokerRunning = getStore(context).get(BROKER_RUNNING_BEAN,
+						BrokerRunningSupport.class);
+				if (brokerRunning == null) {
+					if (rabbit.management()) {
+						brokerRunning = BrokerRunningSupport.isBrokerAndManagementRunningWithEmptyQueues(queues);
+					}
+					else {
+						brokerRunning = BrokerRunningSupport.isRunningWithEmptyQueues(queues);
+					}
+				}
+				brokerRunning.setPurgeAfterEach(rabbit.purgeAfterEach());
+				brokerRunning.test();
+				BROKER_RUNNING_HOLDER.set(brokerRunning);
+				Store store = getStore(context);
+				store.put(BROKER_RUNNING_BEAN, brokerRunning);
+				store.put("queuesToDelete", queues);
+				return ConditionEvaluationResult.enabled("RabbitMQ is available");
+			}
+			catch (Exception e) {
+				if (BrokerRunningSupport.fatal()) {
+					throw new IllegalStateException("Required RabbitMQ is not available", e);
+				}
+				return ConditionEvaluationResult.disabled("RabbitMQ is not available");
+			}
+		}
+		return ENABLED;
+	}
 
-    @Override
-    public void afterAll(ExtensionContext context) {
-        brokerRunningHolder.remove();
-        Store store = getStore(context);
-        BrokerRunning brokerRunning = store.remove(BROKER_RUNNING_BEAN, BrokerRunning.class);
-        if (brokerRunning != null) {
-            brokerRunning.removeTestQueues();
-        }
-    }
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		BrokerRunningSupport brokerRunning = BROKER_RUNNING_HOLDER.get();
+		if (brokerRunning != null && brokerRunning.isPurgeAfterEach()) {
+			brokerRunning.purgeTestQueues();
+		}
+	}
 
-    @Override
-    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
-            throws ParameterResolutionException {
-        Class<?> type = parameterContext.getParameter().getType();
-        return type.equals(ConnectionFactory.class) || type.equals(BrokerRunning.class);
-    }
+	@Override
+	public void afterAll(ExtensionContext context) {
+		BROKER_RUNNING_HOLDER.remove();
+		Store store = getStore(context);
+		BrokerRunningSupport brokerRunning = store.remove(BROKER_RUNNING_BEAN, BrokerRunningSupport.class);
+		if (brokerRunning != null) {
+			brokerRunning.removeTestQueues();
+		}
+	}
 
-    @Override
-    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext context)
-            throws ParameterResolutionException {
-        // in parent for method injection, Composite key causes a store miss
-        BrokerRunning brokerRunning =
-                getParentStore(context).get(BROKER_RUNNING_BEAN, BrokerRunning.class) == null
-                    ? getStore(context).get(BROKER_RUNNING_BEAN, BrokerRunning.class)
-                    : getParentStore(context).get(BROKER_RUNNING_BEAN, BrokerRunning.class);
-        Assert.state(brokerRunning != null, "Could not find brokerRunning instance");
-        Class<?> type = parameterContext.getParameter().getType();
-        return type.equals(ConnectionFactory.class) ? brokerRunning.getConnectionFactory()
-                : brokerRunning;
-    }
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		Class<?> type = parameterContext.getParameter().getType();
+		return type.equals(ConnectionFactory.class) || type.equals(BrokerRunningSupport.class);
+	}
 
-    private Store getStore(ExtensionContext context) {
-        return context.getStore(Namespace.create(getClass(), context));
-    }
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext context)
+			throws ParameterResolutionException {
+		// in parent for method injection, Composite key causes a store miss
+		BrokerRunningSupport brokerRunning = getParentStore(context).get(BROKER_RUNNING_BEAN,
+				BrokerRunningSupport.class) == null
+						? getStore(context).get(BROKER_RUNNING_BEAN, BrokerRunningSupport.class)
+						: getParentStore(context).get(BROKER_RUNNING_BEAN, BrokerRunningSupport.class);
+		Assert.state(brokerRunning != null, "Could not find brokerRunning instance");
+		Class<?> type = parameterContext.getParameter().getType();
+		return type.equals(ConnectionFactory.class) ? brokerRunning.getConnectionFactory()
+				: brokerRunning;
+	}
 
-    private Store getParentStore(ExtensionContext context) {
-        ExtensionContext parent = context.getParent().get();
-        return parent.getStore(Namespace.create(getClass(), parent));
-    }
+	private Store getStore(ExtensionContext context) {
+		return context.getStore(Namespace.create(getClass(), context));
+	}
 
-    public static BrokerRunning getBrokerRunning() {
-        return brokerRunningHolder.get();
-    }
+	private Store getParentStore(ExtensionContext context) {
+		ExtensionContext parent = context.getParent().get();
+		return parent.getStore(Namespace.create(getClass(), parent));
+	}
+
+	public static BrokerRunningSupport getBrokerRunning() {
+		return BROKER_RUNNING_HOLDER.get();
+	}
 
 }

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCondition.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCondition.java
@@ -91,7 +91,7 @@ public class RabbitAvailableCondition
 	}
 
 	@Override
-	public void afterEach(ExtensionContext context) throws Exception {
+	public void afterEach(ExtensionContext context) {
 		BrokerRunningSupport brokerRunning = BROKER_RUNNING_HOLDER.get();
 		if (brokerRunning != null && brokerRunning.isPurgeAfterEach()) {
 			brokerRunning.purgeTestQueues();

--- a/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningTests.java
+++ b/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningTests.java
@@ -72,8 +72,8 @@ public class BrokerRunningTests {
 		assertThat(connectionFactory.getUsername()).isEqualTo("FIZ");
 		assertThat(connectionFactory.getPassword()).isEqualTo("QUX");
 		DirectFieldAccessor dfa = new DirectFieldAccessor(brokerRunning);
-		assertThat(dfa.getPropertyValue("adminUser")).isEqualTo("BAR");
-		assertThat(dfa.getPropertyValue("adminPassword")).isEqualTo("FOO");
+		assertThat(dfa.getPropertyValue("brokerRunning.adminUser")).isEqualTo("BAR");
+		assertThat(dfa.getPropertyValue("brokerRunning.adminPassword")).isEqualTo("FOO");
 
 		BrokerRunning.clearEnvironmentVariableOverrides();
 	}

--- a/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCTORInjectionTests.java
+++ b/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCTORInjectionTests.java
@@ -35,7 +35,7 @@ public class RabbitAvailableCTORInjectionTests {
 
 	private final ConnectionFactory connectionFactory;
 
-	public RabbitAvailableCTORInjectionTests(BrokerRunning brokerRunning) {
+	public RabbitAvailableCTORInjectionTests(BrokerRunningSupport brokerRunning) {
 		this.connectionFactory = brokerRunning.getConnectionFactory();
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactoryTests.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.amqp.utils.test.TestUtils;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachePropertiesTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachePropertiesTests.java
@@ -21,18 +21,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.CacheMode;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.rabbitmq.client.Channel;
 
@@ -41,13 +38,10 @@ import com.rabbitmq.client.Channel;
  * @since 1.6
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
+@RabbitAvailable
 public class CachePropertiesTests {
-
-	@ClassRule
-	public static BrokerRunning br = BrokerRunning.isRunning();
 
 	@Autowired
 	private CachingConnectionFactory channelCf;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -65,8 +65,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.logging.Log;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -1711,7 +1711,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 	}
 
 	@Test
-	@Ignore // Test to verify log message is suppressed after patch to CCF
+	@Disabled // Test to verify log message is suppressed after patch to CCF
 	public void testReturnsNormalCloseDeferredClose() throws Exception {
 		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ClientRecoveryCompatibilityTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ClientRecoveryCompatibilityTests.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ExecutorService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryLifecycleTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryLifecycleTests.java
@@ -23,15 +23,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.AmqpApplicationContextClosedException;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.junit.BrokerTestUtils;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.SmartLifecycle;
@@ -51,10 +50,8 @@ import com.rabbitmq.client.impl.AMQImpl;
  * @since 1.5.3
  *
  */
+@RabbitAvailable
 public class ConnectionFactoryLifecycleTests {
-
-	@Rule
-	public BrokerRunning brokerRunning = BrokerRunning.isRunning();
 
 	@Test
 	public void testConnectionFactoryAvailableDuringStop() {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtilsTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtilsTests.java
@@ -19,7 +19,7 @@ package org.springframework.amqp.rabbit.connection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryIntegrationTests.java
@@ -20,31 +20,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 
 
 /**
  *
  * @author Gary Russell
  */
+@RabbitAvailable(management = true)
 public class LocalizedQueueConnectionFactoryIntegrationTests {
-
-	@ClassRule
-	public static BrokerRunning brokerRunning = BrokerRunning.isBrokerAndManagementRunning();
 
 	private LocalizedQueueConnectionFactory lqcf;
 
 	private CachingConnectionFactory defaultConnectionFactory;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		this.defaultConnectionFactory = new CachingConnectionFactory("localhost");
 		String[] addresses = new String[] { "localhost:9999", "localhost:5672" };
@@ -57,7 +54,7 @@ public class LocalizedQueueConnectionFactoryIntegrationTests {
 				adminUris, nodes, vhost, username, password, false, null);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		this.lqcf.destroy();
 		this.defaultConnectionFactory.destroy();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryTests.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RabbitReconnectProblemTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RabbitReconnectProblemTests.java
@@ -22,9 +22,8 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 
 import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.AmqpTemplate;
@@ -35,8 +34,7 @@ import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.rabbitmq.client.ConnectionFactory;
 
@@ -46,9 +44,8 @@ import com.rabbitmq.client.ConnectionFactory;
  * @since 1.5.6
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-@Ignore("Requires user interaction")
+@SpringJUnitConfig
+@Disabled("Requires user interaction")
 public class RabbitReconnectProblemTests {
 
 	@Autowired

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactoryTests.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -29,8 +29,8 @@ import java.util.Collections;
 import javax.net.ssl.SSLContext;
 
 import org.apache.commons.logging.Log;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -55,7 +55,7 @@ import com.rabbitmq.client.ConnectionFactory;
 public class SSLConnectionTests {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void test() throws Exception {
 		RabbitConnectionFactoryBean fb = new RabbitConnectionFactoryBean();
 		fb.setUseSSL(true);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SingleConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SingleConnectionFactoryTests.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ConnectionFactory;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/FixedReplyQueueDeadLetterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/FixedReplyQueueDeadLetterTests.java
@@ -38,7 +38,7 @@ import org.springframework.amqp.core.QueueBuilder.MasterLocator;
 import org.springframework.amqp.core.QueueBuilder.Overflow;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
+import org.springframework.amqp.rabbit.junit.BrokerRunningSupport;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
@@ -64,7 +64,7 @@ import com.rabbitmq.http.client.domain.QueueInfo;
 @RabbitAvailable(management = true)
 public class FixedReplyQueueDeadLetterTests {
 
-	private static BrokerRunning brokerRunning;
+	private static BrokerRunningSupport brokerRunning;
 
 	@Autowired
 	private RabbitTemplate rabbitTemplate;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitBindingIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitBindingIntegrationTests.java
@@ -30,10 +30,8 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.RabbitAccessor;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.junit.BrokerTestUtils;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
-import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
 import org.springframework.amqp.rabbit.listener.BlockingQueueConsumer;
 import org.springframework.amqp.rabbit.support.ActiveObjectCounter;
 import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
@@ -55,8 +53,6 @@ public class RabbitBindingIntegrationTests {
 
 	private RabbitTemplate template;
 
-	public BrokerRunning brokerIsRunning = RabbitAvailableCondition.getBrokerRunning();
-
 	@BeforeEach
 	public void setup() {
 		connectionFactory = new CachingConnectionFactory(BrokerTestUtils.getPort());
@@ -66,7 +62,6 @@ public class RabbitBindingIntegrationTests {
 
 	@AfterEach
 	public void cleanUp() {
-		this.brokerIsRunning.purgeTestQueues();
 		this.template.stop();
 		this.connectionFactory.destroy();
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitGatewaySupportTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitGatewaySupportTests.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Mark Pollack

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplateTests.java
@@ -31,8 +31,8 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -66,7 +66,7 @@ public class RabbitMessagingTemplateTests {
 	private RabbitMessagingTemplate messagingTemplate;
 
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
 		messagingTemplate = new RabbitMessagingTemplate(rabbitTemplate);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateHeaderTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateHeaderTests.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.amqp.core.Message;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.amqp.AmqpAuthenticationException;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/support/SimpleBatchStrategyTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/support/SimpleBatchStrategyTests.java
@@ -18,8 +18,8 @@ package org.springframework.amqp.rabbit.core.support;
 
 import java.nio.ByteBuffer;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.util.StopWatch;
 
@@ -31,7 +31,7 @@ import org.springframework.util.StopWatch;
 public class SimpleBatchStrategyTests {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testBatchingPerf() { // used to compare ByteBuffer Vs. System.arrayCopy()
 		StopWatch watch = new StopWatch();
 		byte[] bbBuff = new byte[10000];

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerIntegrationTests.java
@@ -25,18 +25,15 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.logging.log4j.Level;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.junit.BrokerTestUtils;
-import org.springframework.amqp.rabbit.junit.LogLevelAdjuster;
+import org.springframework.amqp.rabbit.junit.LogLevels;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.rabbit.listener.exception.FatalListenerStartupException;
 import org.springframework.amqp.rabbit.support.ActiveObjectCounter;
 import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
@@ -48,24 +45,20 @@ import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter
  * @since 1.0
  *
  */
+@RabbitAvailable(queues = { BlockingQueueConsumerIntegrationTests.QUEUE1_NAME,
+		BlockingQueueConsumerIntegrationTests.QUEUE2_NAME })
+@LogLevels(classes = {RabbitTemplate.class,
+			SimpleMessageListenerContainer.class, BlockingQueueConsumer.class,
+			BlockingQueueConsumerIntegrationTests.class }, level = "INFO")
 public class BlockingQueueConsumerIntegrationTests {
 
-	private static Queue queue1 = new Queue("test.queue1");
+	public static final String QUEUE1_NAME = "test.queue1.BlockingQueueConsumerIntegrationTests";
 
-	private static Queue queue2 = new Queue("test.queue2");
+	public static final String QUEUE2_NAME = "test.queue2.BlockingQueueConsumerIntegrationTests";
 
-	@Rule
-	public BrokerRunning brokerIsRunning = BrokerRunning.isRunningWithEmptyQueues(queue1.getName(), queue2.getName());
+	private static Queue queue1 = new Queue(QUEUE1_NAME);
 
-	@Rule
-	public LogLevelAdjuster logLevels = new LogLevelAdjuster(Level.INFO, RabbitTemplate.class,
-			SimpleMessageListenerContainer.class, BlockingQueueConsumer.class,
-			BlockingQueueConsumerIntegrationTests.class);
-
-	@After
-	public void tearDown() {
-		this.brokerIsRunning.removeTestQueues();
-	}
+	private static Queue queue2 = new Queue(QUEUE2_NAME);
 
 	@Test
 	public void testTransactionalLowLevel() throws Exception {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -45,9 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.logging.log4j.Level;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
@@ -55,7 +53,7 @@ import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.rabbit.connection.ChannelProxy;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.junit.LogLevelAdjuster;
+import org.springframework.amqp.rabbit.junit.LogLevels;
 import org.springframework.amqp.rabbit.support.ActiveObjectCounter;
 import org.springframework.amqp.rabbit.support.ConsumerCancelledException;
 import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
@@ -78,10 +76,8 @@ import com.rabbitmq.client.impl.recovery.AutorecoveringChannel;
  * @since 1.0.1
  *
  */
+@LogLevels(classes = BlockingQueueConsumer.class, level = "ERROR")
 public class BlockingQueueConsumerTests {
-
-	@Rule
-	public LogLevelAdjuster adjuster = new LogLevelAdjuster(Level.ERROR, BlockingQueueConsumer.class);
 
 	@Test
 	public void testRequeue() throws Exception {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerInitializationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ContainerInitializationTests.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.fail;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.Message;
@@ -32,9 +31,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.RabbitUtils;
 import org.springframework.amqp.rabbit.connection.ShutDownChannelListener;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
-import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.listener.exception.FatalListenerStartupException;
 import org.springframework.context.ApplicationContext;
@@ -54,13 +51,6 @@ public class ContainerInitializationTests {
 	public static final String TEST_MISMATCH = "test.mismatch";
 
 	public static final String TEST_MISMATCH2 = "test.mismatch2";
-
-	public BrokerRunning brokerRunning = RabbitAvailableCondition.getBrokerRunning();
-
-	@AfterEach
-	public void tearDown() {
-		brokerRunning.purgeTestQueues();
-	}
 
 	@Test
 	public void testNoAdmin() {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.amqp.core.AcknowledgeMode;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainerTests.java
@@ -22,14 +22,11 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.Address;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
-import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
 import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerContainer.ChannelHolder;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.amqp.utils.test.TestUtils;
@@ -50,13 +47,6 @@ import com.rabbitmq.client.GetResponse;
 public class DirectReplyToMessageListenerContainerTests {
 
 	public static final String TEST_RELEASE_CONSUMER_Q = "test.release.consumer";
-
-	public BrokerRunning brokerRunning = RabbitAvailableCondition.getBrokerRunning();
-
-	@AfterEach
-	public void tearDown() {
-		this.brokerRunning.purgeTestQueues();
-	}
 
 	@Test
 	public void testReleaseConsumerRace() throws Exception {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ErrorHandlerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ErrorHandlerTests.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import org.apache.commons.logging.Log;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.MessageProperties;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerErrorHandlerIntegrationTests.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,10 +51,8 @@ import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.junit.BrokerTestUtils;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
-import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
@@ -90,19 +87,12 @@ public class MessageListenerContainerErrorHandlerIntegrationTests {
 
 	private volatile CountDownLatch errorsHandled;
 
-	public BrokerRunning brokerIsRunning = RabbitAvailableCondition.getBrokerRunning();
-
 	@BeforeEach
 	public void setUp() {
 		doAnswer(invocation -> {
 			errorsHandled.countDown();
 			return null;
 		}).when(errorHandler).handleError(any(Throwable.class));
-	}
-
-	@AfterEach
-	public void tearDown() {
-		this.brokerIsRunning.purgeTestQueues();
 	}
 
 	@Test // AMQP-385

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerMultipleQueueIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerMultipleQueueIntegrationTests.java
@@ -24,18 +24,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.logging.log4j.Level;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.junit.BrokerTestUtils;
-import org.springframework.amqp.rabbit.junit.LogLevelAdjuster;
+import org.springframework.amqp.rabbit.junit.LogLevels;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 
@@ -44,25 +41,21 @@ import org.springframework.amqp.support.converter.SimpleMessageConverter;
  * @author Gunnar Hillert
  * @author Gary Russell
  */
+@RabbitAvailable(queues = { MessageListenerContainerMultipleQueueIntegrationTests.TEST_QUEUE_1,
+		MessageListenerContainerMultipleQueueIntegrationTests.TEST_QUEUE_2 })
+@LogLevels(level = "INFO", classes = { RabbitTemplate.class,
+			SimpleMessageListenerContainer.class, BlockingQueueConsumer.class })
 public class MessageListenerContainerMultipleQueueIntegrationTests {
+
+	public static final String TEST_QUEUE_1 = "test.queue.1.MessageListenerContainerMultipleQueueIntegrationTests";
+
+	public static final String TEST_QUEUE_2 = "test.queue.2.MessageListenerContainerMultipleQueueIntegrationTests";
 
 	private static Log logger = LogFactory.getLog(MessageListenerContainerMultipleQueueIntegrationTests.class);
 
-	private static Queue queue1 = new Queue("test.queue.1");
+	private static Queue queue1 = new Queue(TEST_QUEUE_1);
 
-	private static Queue queue2 = new Queue("test.queue.2");
-
-	@Rule
-	public BrokerRunning brokerIsRunning = BrokerRunning.isRunningWithEmptyQueues(queue1.getName(), queue2.getName());
-
-	@Rule
-	public LogLevelAdjuster logLevels = new LogLevelAdjuster(Level.INFO, RabbitTemplate.class,
-			SimpleMessageListenerContainer.class, BlockingQueueConsumer.class);
-
-	@After
-	public void tearDown() {
-		this.brokerIsRunning.removeTestQueues();
-	}
+	private static Queue queue2 = new Queue(TEST_QUEUE_2);
 
 	@Test
 	public void testMultipleQueues() {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerManualAckIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerManualAckIntegrationTests.java
@@ -23,20 +23,18 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.logging.log4j.Level;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
 import org.springframework.amqp.rabbit.junit.BrokerTestUtils;
-import org.springframework.amqp.rabbit.junit.LogLevelAdjuster;
+import org.springframework.amqp.rabbit.junit.LogLevels;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.beans.factory.DisposableBean;
@@ -51,11 +49,16 @@ import com.rabbitmq.client.Channel;
  * @since 1.0
  *
  */
+@RabbitAvailable(queues = MessageListenerManualAckIntegrationTests.TEST_QUEUE)
+@LogLevels(level = "ERROR", classes = { RabbitTemplate.class,
+			SimpleMessageListenerContainer.class, BlockingQueueConsumer.class })
 public class MessageListenerManualAckIntegrationTests {
+
+	public static final String TEST_QUEUE = "test.queue.MessageListenerManualAckIntegrationTests";
 
 	private static Log logger = LogFactory.getLog(MessageListenerManualAckIntegrationTests.class);
 
-	private final Queue queue = new Queue("test.queue");
+	private final Queue queue = new Queue(TEST_QUEUE);
 
 	private final RabbitTemplate template = new RabbitTemplate();
 
@@ -69,14 +72,7 @@ public class MessageListenerManualAckIntegrationTests {
 
 	private SimpleMessageListenerContainer container;
 
-	@Rule
-	public LogLevelAdjuster logLevels = new LogLevelAdjuster(Level.ERROR, RabbitTemplate.class,
-			SimpleMessageListenerContainer.class, BlockingQueueConsumer.class);
-
-	@Rule
-	public BrokerRunning brokerIsRunning = BrokerRunning.isRunningWithEmptyQueues(queue.getName());
-
-	@Before
+	@BeforeEach
 	public void createConnectionFactory() {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
 		connectionFactory.setHost("localhost");
@@ -85,7 +81,7 @@ public class MessageListenerManualAckIntegrationTests {
 		template.setConnectionFactory(connectionFactory);
 	}
 
-	@After
+	@AfterEach
 	public void clear() throws Exception {
 		// Wait for broker communication to finish before trying to stop container
 		Thread.sleep(300L);
@@ -93,7 +89,6 @@ public class MessageListenerManualAckIntegrationTests {
 		if (container != null) {
 			container.shutdown();
 		}
-		this.brokerIsRunning.removeTestQueues();
 		((DisposableBean) template.getConnectionFactory()).destroy();
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpointTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MethodRabbitListenerEndpointTests.java
@@ -31,10 +31,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.amqp.core.Address;
@@ -72,36 +71,35 @@ import com.rabbitmq.client.Channel;
  */
 public class MethodRabbitListenerEndpointTests {
 
-	@Rule
-	public final TestName name = new TestName();
-
 	private final DefaultMessageHandlerMethodFactory factory = new DefaultMessageHandlerMethodFactory();
 
 	private final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 
 	private final RabbitEndpointSampleBean sample = new RabbitEndpointSampleBean();
 
+	public String testName;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	public void setup(TestInfo info) {
 		initializeFactory(factory);
+		this.testName = info.getTestMethod().get().getName();
 	}
 
 	@Test
-	public void createMessageListenerNoFactory() {
+	public void createMessageListenerNoFactory(TestInfo info) {
 		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
 		endpoint.setBean(this);
-		endpoint.setMethod(getTestMethod());
+		endpoint.setMethod(info.getTestMethod().get());
 
 		assertThatIllegalStateException()
 			.isThrownBy(() -> endpoint.createMessageListener(container));
 	}
 
 	@Test
-	public void createMessageListener() {
+	public void createMessageListener(TestInfo info) {
 		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
 		endpoint.setBean(this);
-		endpoint.setMethod(getTestMethod());
+		endpoint.setMethod(info.getTestMethod().get());
 		endpoint.setMessageHandlerMethodFactory(factory);
 
 		assertThat(endpoint.createMessageListener(container)).isNotNull();
@@ -418,11 +416,11 @@ public class MethodRabbitListenerEndpointTests {
 	}
 
 	private Method getDefaultListenerMethod(Class<?>... parameterTypes) {
-		return getListenerMethod(name.getMethodName(), parameterTypes);
+		return getListenerMethod(this.testName, parameterTypes);
 	}
 
 	private void assertDefaultListenerMethodInvocation() {
-		assertListenerMethodInvocation(sample, name.getMethodName());
+		assertListenerMethodInvocation(this.sample, this.testName);
 	}
 
 	private void assertListenerMethodInvocation(RabbitEndpointSampleBean bean, String methodName) {
@@ -449,10 +447,6 @@ public class MethodRabbitListenerEndpointTests {
 				}
 			}
 		};
-	}
-
-	private Method getTestMethod() {
-		return ReflectionUtils.findMethod(MethodRabbitListenerEndpointTests.class, name.getMethodName());
 	}
 
 	static class RabbitEndpointSampleBean {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistrarTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistrarTests.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
@@ -41,7 +41,7 @@ public class RabbitListenerEndpointRegistrarTests {
 	private final RabbitListenerContainerTestFactory containerFactory = new RabbitListenerContainerTestFactory();
 
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		registrar.setEndpointRegistry(registry);
 		registrar.setBeanFactory(new StaticListableBeanFactory());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistryTests.java
@@ -19,7 +19,7 @@ package org.springframework.amqp.rabbit.listener;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.Log;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 import org.springframework.amqp.AmqpAuthenticationException;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/UnackedRawIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/UnackedRawIntegrationTests.java
@@ -23,10 +23,10 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.rabbit.junit.BrokerTestUtils;
 import org.springframework.amqp.rabbit.support.Delivery;
@@ -45,7 +45,7 @@ import com.rabbitmq.client.GetResponse;
  * @author Dave Syer
  *
  */
-@Ignore
+@Disabled
 public class UnackedRawIntegrationTests {
 
 	private final ConnectionFactory factory = new ConnectionFactory();
@@ -53,7 +53,7 @@ public class UnackedRawIntegrationTests {
 	private Channel noTxChannel;
 	private Channel txChannel;
 
-	@Before
+	@BeforeEach
 	public void init() throws Exception {
 
 		factory.setHost("localhost");
@@ -74,7 +74,7 @@ public class UnackedRawIntegrationTests {
 
 	}
 
-	@After
+	@AfterEach
 	public void clear() throws Exception {
 		if (txChannel != null) {
 			try {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapterTests.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Address;
@@ -65,7 +65,7 @@ public class MessageListenerAdapterTests {
 
 	private final SimpleService simpleService = new SimpleService();
 
-	@Before
+	@BeforeEach
 	public void init() {
 		this.messageProperties = new MessageProperties();
 		this.messageProperties.setContentType(MessageProperties.CONTENT_TYPE_TEXT_PLAIN);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -28,8 +28,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
@@ -59,7 +59,7 @@ public class MessagingMessageListenerAdapterTests {
 	private final SampleBean sample = new SampleBean();
 
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initializeFactory(factory);
 	}

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -522,10 +522,11 @@ Version 2.0.2 introduced support for JUnit5.
 This class-level annotation is similar to the `BrokerRunning` `@Rule` discussed in <<junit-rules>>.
 It is processed by the `RabbitAvailableCondition`.
 
-The annotation has two properties:
+The annotation has three properties:
 
 * `queues`: An array of queues that are declared (and purged) before each test and deleted when all tests are complete.
 * `management`: Set this to `true` if your tests also require the management plugin installed on the broker.
+* `purgeAfterEach`: (Since version 2.2) when `true` (default), the `queues` will be purged between tests.
 
 It is used to check whether the broker is available and skip the tests if not.
 As discussed in <<brokerRunning-configure>>, the environment variable called `RABBITMQ_SERVER_REQUIRED`, if `true`, causes the tests to fail fast if there is no broker.
@@ -534,8 +535,8 @@ You can configure the condition by using environment variables as discussed in <
 In addition, the `RabbitAvailableCondition` supports argument resolution for parameterized test constructors and methods.
 Two argument types are supported:
 
-* `BrokerRunning`: The instance
-* `ConnectionFactory`: The `BrokerRunning` instance's RabbitMQ connection factory
+* `BrokerRunningSupport`: The instance (before 2.2, this was a JUnit 4 `BrokerRunning` instance)
+* `ConnectionFactory`: The `BrokerRunningSupport` instance's RabbitMQ connection factory
 
 The following example shows both:
 
@@ -547,7 +548,7 @@ public class RabbitAvailableCTORInjectionTests {
 
     private final ConnectionFactory connectionFactory;
 
-    public RabbitAvailableCTORInjectionTests(BrokerRunning brokerRunning) {
+    public RabbitAvailableCTORInjectionTests(BrokerRunningSupport brokerRunning) {
         this.connectionFactory = brokerRunning.getConnectionFactory();
     }
 
@@ -578,7 +579,7 @@ public class RabbitAvailableCTORInjectionTests {
 
     private final CachingConnectionFactory connectionFactory;
 
-    public RabbitAvailableCTORInjectionTests(BrokerRunning brokerRunning) {
+    public RabbitAvailableCTORInjectionTests(BrokerRunningSupport brokerRunning) {
         this.connectionFactory =
             new CachingConnectionFactory(brokerRunning.getConnectionFactory());
     }
@@ -593,6 +594,10 @@ public class RabbitAvailableCTORInjectionTests {
 ====
 
 When you use a Spring annotation application context within a test class, you can get a reference to the condition's connection factory through a static method called `RabbitAvailableCondition.getBrokerRunning()`.
+
+IMPORTANT: Starting with version 2.2, `getBrokerRunning()` returns a `BrokerRunningSupport` object; previously, the JUnit 4 `BrokerRunnning` instance was returned.
+The new class has the same API as `BrokerRunning`.
+
 The following test comes from the framework and demonstrates the usage:
 
 ====

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -19,6 +19,12 @@ In addition, `ListenerExecutionFailedException` has been moved from `org.springf
 
 JUnit (4) is now an optional dependency and will no longer appear as a transitive dependency.
 
+===== "Breaking" API Changes
+
+the JUnit (5) `RabbitAvailableCondition.getBrokerRunning()` now returns a `BrokerRunningSupport` instance instead of a `BrokerRunning`, which depends on JUnit 4.
+It has the same API so it's just a matter of changing the class name of any references.
+See <<junit5-conditions>> for more information.
+
 ===== ListenerContainer Changes
 
 Messages with fatal exceptions are now rejected and NOT requeued, by default, even if the acknowledge mode is manual.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1071

- Remove JUnit4 dependency from `RabbitAvailableCondition` (minor breaking API change)
- Add `purgeAfterEach` to `@RabbitAvailable`
- tabs not spaces in `RabbitAvailableCondition` (review with `?w=1`)
- `@LogLevels` now requires `level`
