### PR TITLE
GH-1080: SMLC: Fix concurrency configuration order

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -214,11 +214,13 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 * @since 2.0
 	 */
 	public void setConcurrency(String concurrency) {
+		this.maxConcurrentConsumers = null;
+		this.concurrentConsumers = 1;
 		try {
 			int separatorIndex = concurrency.indexOf('-');
 			if (separatorIndex != -1) {
-				setMaxConcurrentConsumers(Integer.parseInt(concurrency.substring(separatorIndex + 1)));
 				setConcurrentConsumers(Integer.parseInt(concurrency.substring(0, separatorIndex)));
+				setMaxConcurrentConsumers(Integer.parseInt(concurrency.substring(separatorIndex + 1)));
 			}
 			else {
 				setConcurrentConsumers(Integer.parseInt(concurrency));

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -214,13 +214,15 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 * @since 2.0
 	 */
 	public void setConcurrency(String concurrency) {
-		this.maxConcurrentConsumers = null;
-		this.concurrentConsumers = 1;
 		try {
 			int separatorIndex = concurrency.indexOf('-');
 			if (separatorIndex != -1) {
-				setConcurrentConsumers(Integer.parseInt(concurrency.substring(0, separatorIndex)));
-				setMaxConcurrentConsumers(Integer.parseInt(concurrency.substring(separatorIndex + 1)));
+				int concurrentConsumers = Integer.parseInt(concurrency.substring(0, separatorIndex));
+				int maxConcurrentConsumers = Integer.parseInt(concurrency.substring(separatorIndex + 1));
+				Assert.isTrue(maxConcurrentConsumers >= concurrentConsumers,
+						"'maxConcurrentConsumers' value must be at least 'concurrentConsumers'");
+				this.concurrentConsumers = concurrentConsumers;
+				this.maxConcurrentConsumers = maxConcurrentConsumers;
 			}
 			else {
 				setConcurrentConsumers(Integer.parseInt(concurrency));

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -217,9 +217,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		try {
 			int separatorIndex = concurrency.indexOf('-');
 			if (separatorIndex != -1) {
+				setMaxConcurrentConsumers(Integer.parseInt(concurrency.substring(separatorIndex + 1)));
 				setConcurrentConsumers(Integer.parseInt(concurrency.substring(0, separatorIndex)));
-				setMaxConcurrentConsumers(
-						Integer.parseInt(concurrency.substring(separatorIndex + 1, concurrency.length())));
 			}
 			else {
 				setConcurrentConsumers(Integer.parseInt(concurrency));

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -221,8 +221,10 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				int maxConcurrentConsumers = Integer.parseInt(concurrency.substring(separatorIndex + 1));
 				Assert.isTrue(maxConcurrentConsumers >= concurrentConsumers,
 						"'maxConcurrentConsumers' value must be at least 'concurrentConsumers'");
-				this.concurrentConsumers = concurrentConsumers;
-				this.maxConcurrentConsumers = maxConcurrentConsumers;
+				this.concurrentConsumers = 1;
+				this.maxConcurrentConsumers = null;
+				setConcurrentConsumers(concurrentConsumers);
+				setMaxConcurrentConsumers(maxConcurrentConsumers);
 			}
 			else {
 				setConcurrentConsumers(Integer.parseInt(concurrency));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerLifecycleIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerLifecycleIntegrationTests.java
@@ -472,6 +472,16 @@ public class MessageListenerContainerLifecycleIntegrationTests {
 		((DisposableBean) template.getConnectionFactory()).destroy();
 	}
 
+	@Test
+	public void testConcurrencyConfiguration() {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConcurrentConsumers(1);
+		container.setMaxConcurrentConsumers(1);
+		container.setConcurrency("2-5");
+
+		assertThat(TestUtils.getPropertyValue(container, "concurrentConsumers")).isEqualTo(2);
+		assertThat(TestUtils.getPropertyValue(container, "maxConcurrentConsumers")).isEqualTo(5);
+	}
 
 	@Configuration
 	static class LongLiveConsumerConfig {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1080

When we have a configuration like this:
```
container.setConcurrentConsumers(1);
container.setMaxConcurrentConsumers(1);
container.setConcurrency("2-5");
```
we fail with an assertion like
`'concurrentConsumers' cannot be more than 'maxConcurrentConsumers'`

* Change the order in the `SimpleMessageListenerContainer.setConcurrency()`
how we populate `maxConcurrentConsumers` and `concurrentConsumers`

**Cherry-pick to 2.1.x and 1.7.x**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
