### PR TITLE
Add managed dependency versions to generated POM

### DIFF
--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -14,6 +14,16 @@ install {
 
 def customizePom(pom, gradleProject) {
 	pom.whenConfigured { generatedPom ->
+
+		// sort to make pom dependencies order consistent to ease comparison of older poms
+		generatedPom.dependencies = generatedPom.dependencies.sort { dep ->
+			"$dep.scope:$dep.groupId:$dep.artifactId"
+		}
+
+		def managedVersions = dependencyManagement.managedVersions
+		generatedPom.dependencies.findAll{dep -> !dep.version }.each { dep ->
+			dep.version = managedVersions["${dep.groupId}:${dep.artifactId}"]
+		}
 		// respect 'optional' and 'provided' dependencies
 		gradleProject.optionalDeps.each { dep ->
 			generatedPom.dependencies.find { it.artifactId == dep.name }?.optional = true


### PR DESCRIPTION
Since the dependendency management Gradle plugin is applied and the
Jackson BOM is used, versions for this artifact are resolved by the
plugin.

The plugin configuration in this build disables POM customization, as
otherwise it would add `<dependendencyManagement>` sections in the
generated POMs.

This commit adds a missing script in the 2.1.x branch that checks the
generated POM for missing versions in dependencies and uses the
information provided by the dependency management plugin to add those
back.

Fixes #1082