### PR TITLE
Fix possibleAuthenticationFailureFatal

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1820,7 +1820,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	}
 
 	private void checkPossibleAuthenticationFailureFatalFromProperty() {
-		if (!isPossibleAuthenticationFailureFatal()) {
+		if (!isPossibleAuthenticationFailureFatalSet()) {
 			try {
 				ApplicationContext context = getApplicationContext();
 				if (context != null) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AsyncListenerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AsyncListenerTests.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,8 +43,10 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -98,6 +101,9 @@ public class AsyncListenerTests {
 	@Autowired
 	private Listener listener;
 
+	@Autowired
+	private RabbitListenerEndpointRegistry registry;
+
 	@Test
 	public void testAsyncListener() throws Exception {
 		assertThat(this.rabbitTemplate.convertSendAndReceive(this.queue1.getName(), "foo")).isEqualTo("FOO");
@@ -126,6 +132,12 @@ public class AsyncListenerTests {
 	@Test
 	public void testOverrideDontRequeue() throws Exception {
 		assertThat(this.rabbitTemplate.convertSendAndReceive(this.queue7.getName(), "foo")).isEqualTo("listen7");
+	}
+
+	@Test
+	public void testAuthByProps() {
+		assertThat(TestUtils.getPropertyValue(this.registry.getListenerContainer("foo"),
+				"possibleAuthenticationFailureFatal", Boolean.class)).isFalse();
 	}
 
 	@Configuration
@@ -245,6 +257,13 @@ public class AsyncListenerTests {
 		@Bean
 		public Listener listener() {
 			return new Listener();
+		}
+
+		@Bean("spring.amqp.global.properties")
+		public Properties properties() {
+			Properties props = new Properties();
+			props.setProperty("mlc.possible.authentication.failure.fatal", "false");
+			return props;
 		}
 
 	}


### PR DESCRIPTION
This property can be set via a global property bean but the wrong boolean
was being tested to enable the check.

It should perform the check if the boolean has not already been explicitly
set.

**cherry-pick to 2.1.x**

See https://stackoverflow.com/questions/57912448/rabbithandler-to-create-consumer-and-retry-on-fatal-exception-in-spring-for-queu/57914663#57914663