### PR TITLE
GH-1087: improvement debug logging

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -2290,9 +2290,8 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 		if (rKey == null) {
 			rKey = this.routingKey;
 		}
-		if (logger.isDebugEnabled()) {
-			logger.debug("Publishing message " + message
-					+ "on exchange [" + exch + "], routingKey = [" + rKey + "]");
+		if (logger.isTraceEnabled()) {
+			logger.trace("Original message " + message);
 		}
 
 		Message messageToUse = message;
@@ -2304,6 +2303,10 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 			for (MessagePostProcessor processor : this.beforePublishPostProcessors) {
 				messageToUse = processor.postProcessMessage(messageToUse, correlationData);
 			}
+		}
+		if (logger.isDebugEnabled()) {
+			logger.debug("Publishing message " + messageToUse
+					+ " on exchange [" + exch + "], routingKey = [" + rKey + "]");
 		}
 		setupConfirm(channel, messageToUse, correlationData);
 		if (this.userIdExpression != null && messageProperties.getUserId() == null) {


### PR DESCRIPTION
Closes #1087 

Debug information about the sent message was recorded in the log before processing by MessagePostProcessors, so the information on the console might not coincide with reality.
Added log of the message after processing by MessagePostProcessor
