### PR TITLE
Update setUsePublisherConnection javadocs

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -245,7 +245,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 
 	private boolean userCorrelationId;
 
-	private boolean usePublisherConnection = true;
+	private boolean usePublisherConnection;
 
 	private boolean noLocalReplyConsumer;
 
@@ -794,8 +794,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 	/**
 	 * To avoid deadlocked connections, it is generally recommended to use
 	 * a separate connection for publishers and consumers (except when a publisher
-	 * is participating in a consumer transaction). Default 'false'; will change
-	 * to 'true' in 2.1.
+	 * is participating in a consumer transaction). Default 'false'.
 	 * @param usePublisherConnection true to use a publisher connection.
 	 * @since 2.0.2
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -245,7 +245,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 
 	private boolean userCorrelationId;
 
-	private boolean usePublisherConnection;
+	private boolean usePublisherConnection = true;
 
 	private boolean noLocalReplyConsumer;
 


### PR DESCRIPTION
Docs in setUsePublisherConnection say this defaults to true since version 2.1 what, in my opinion, is not true

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
