### PR TITLE
GH-1106: Fix Use Publisher CF with RT.invoke()

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -205,6 +205,7 @@ public final class ConnectionFactoryUtils {
 	 */
 	public static Connection createConnection(final ConnectionFactory connectionFactory,
 			final boolean publisherConnectionIfPossible) {
+
 		if (publisherConnectionIfPossible) {
 			ConnectionFactory publisherFactory = connectionFactory.getPublisherConnectionFactory();
 			if (publisherFactory != null) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -518,6 +518,47 @@ public class RabbitTemplateTests {
 		assertThat(afterReceivePostProcessors).containsExactly(mpp2, mpp3);
 	}
 
+	@Test
+	public void testPublisherConnWithInvoke() {
+		org.springframework.amqp.rabbit.connection.ConnectionFactory cf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		org.springframework.amqp.rabbit.connection.ConnectionFactory pcf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		given(cf.getPublisherConnectionFactory()).willReturn(pcf);
+		RabbitTemplate template = new RabbitTemplate(cf);
+		template.setUsePublisherConnection(true);
+		org.springframework.amqp.rabbit.connection.Connection conn = mock(
+				org.springframework.amqp.rabbit.connection.Connection.class);
+		Channel channel = mock(Channel.class);
+		given(pcf.createConnection()).willReturn(conn);
+		given(conn.isOpen()).willReturn(true);
+		given(conn.createChannel(false)).willReturn(channel);
+		template.invoke(t -> null);
+		verify(pcf).createConnection();
+		verify(conn).createChannel(false);
+	}
+
+	@Test
+	public void testPublisherConnWithInvokeInTx() {
+		org.springframework.amqp.rabbit.connection.ConnectionFactory cf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		org.springframework.amqp.rabbit.connection.ConnectionFactory pcf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		given(cf.getPublisherConnectionFactory()).willReturn(pcf);
+		RabbitTemplate template = new RabbitTemplate(cf);
+		template.setUsePublisherConnection(true);
+		template.setChannelTransacted(true);
+		org.springframework.amqp.rabbit.connection.Connection conn = mock(
+				org.springframework.amqp.rabbit.connection.Connection.class);
+		Channel channel = mock(Channel.class);
+		given(pcf.createConnection()).willReturn(conn);
+		given(conn.isOpen()).willReturn(true);
+		given(conn.createChannel(true)).willReturn(channel);
+		template.invoke(t -> null);
+		verify(pcf).createConnection();
+		verify(conn).createChannel(true);
+	}
+
 	@SuppressWarnings("serial")
 	private class TestTransactionManager extends AbstractPlatformTransactionManager {
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1106

`RabbitTemplate.invoke()` did not honor `usePublisherConnection`.

**cherry-pick to 2.1.x**