### PR TITLE
GH-1108: @QueueBinding.key recursive resolution

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
@@ -197,7 +197,7 @@ public class RabbitListenerAnnotationBeanPostProcessorTests {
 		}
 		catch (BeanCreationException e) {
 			assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
-			assertThat(e.getMessage()).contains("@RabbitListener.queuesToDeclare can't resolve")
+			assertThat(e.getMessage()).contains("@RabbitListener.queues can't resolve")
 					.contains("as a String[] or a String or a Queue");
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1108

`@RabbitListener.queues()` resolves `String[]` recursively.
AMQP-722 added support for multiple routing keys to `@queueBinding` but
did not add support for recursive resolution. This is required to support
constructs like `key = "#{'${my-app.amqp.routing-key}'.split(',')}"`.

**cherry-pick to 2.1.x**
