### PR TITLE
Fix the wrong method return type in documentation

### DIFF
--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1562,9 +1562,9 @@ Object receiveAndConvert() throws AmqpException;
 
 Object receiveAndConvert(String queueName) throws AmqpException;
 
-Message receiveAndConvert(long timeoutMillis) throws AmqpException;
+Object receiveAndConvert(long timeoutMillis) throws AmqpException;
 
-Message receiveAndConvert(String queueName, long timeoutMillis) throws AmqpException;
+Object receiveAndConvert(String queueName, long timeoutMillis) throws AmqpException;
 ----
 ====
 


### PR DESCRIPTION
The return type for the following methods in documentation should be `Object` instead of `Message`.

```java
Message receiveAndConvert(long timeoutMillis) throws AmqpException;
Message receiveAndConvert(String queueName, long timeoutMillis) throws AmqpException;
```