### PR TITLE
GH-1130: Repub Recoverer include ex. message size

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererIntegrationTests.java
@@ -30,8 +30,7 @@ import org.springframework.amqp.rabbit.connection.RabbitUtils;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
-
-import com.rabbitmq.client.LongString;
+import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
 
 /**
  * @author Gary Russell
@@ -43,30 +42,94 @@ public class RepublishMessageRecovererIntegrationTests {
 
 	public static final String BIG_HEADER_QUEUE = "big.header.queue";
 
-	private static final String BIG_EXCEPTION_MESSAGE = new String(new byte[10_000]).replaceAll("\u0000", "x");
+	private static final String BIG_EXCEPTION_MESSAGE1 = new String(new byte[10_000]).replace("\u0000", "x");
+
+	private static final String BIG_EXCEPTION_MESSAGE2 = new String(new byte[10_000]).replace("\u0000", "y");
 
 	private int maxHeaderSize;
 
 	@Test
 	public void testBigHeader() {
-		RabbitTemplate template = new RabbitTemplate(
-				new CachingConnectionFactory(RabbitAvailableCondition.getBrokerRunning().getConnectionFactory()));
-		this.maxHeaderSize = RabbitUtils.getMaxFrame(template.getConnectionFactory()) - 20_000;
+		CachingConnectionFactory ccf = new CachingConnectionFactory(
+				RabbitAvailableCondition.getBrokerRunning().getConnectionFactory());
+		RabbitTemplate template = new RabbitTemplate(ccf);
+		this.maxHeaderSize = RabbitUtils.getMaxFrame(template.getConnectionFactory())
+				- RepublishMessageRecoverer.DEFAULT_FRAME_MAX_HEADROOM;
 		assertThat(this.maxHeaderSize).isGreaterThan(0);
 		RepublishMessageRecoverer recoverer = new RepublishMessageRecoverer(template, "", BIG_HEADER_QUEUE);
 		recoverer.recover(new Message("foo".getBytes(), new MessageProperties()),
-				bigCause(new RuntimeException(BIG_EXCEPTION_MESSAGE)));
+				new ListenerExecutionFailedException("Listener failed",
+						bigCause(new RuntimeException(BIG_EXCEPTION_MESSAGE1))));
 		Message received = template.receive(BIG_HEADER_QUEUE, 10_000);
 		assertThat(received).isNotNull();
-		assertThat(((LongString) received.getMessageProperties().getHeaders()
-				.get(RepublishMessageRecoverer.X_EXCEPTION_STACKTRACE)).length()).isEqualTo(this.maxHeaderSize);
+		String trace = received.getMessageProperties().getHeaders()
+				.get(RepublishMessageRecoverer.X_EXCEPTION_STACKTRACE).toString();
+		assertThat(trace.length()).isEqualTo(this.maxHeaderSize - 100);
+		String truncatedMessage =
+				"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...";
+		assertThat(trace).contains(truncatedMessage);
+		assertThat((String) received.getMessageProperties().getHeader(RepublishMessageRecoverer.X_EXCEPTION_MESSAGE))
+			.isEqualTo(truncatedMessage);
+		ccf.destroy();
+	}
+
+	@Test
+	public void testSmallException() {
+		CachingConnectionFactory ccf = new CachingConnectionFactory(
+				RabbitAvailableCondition.getBrokerRunning().getConnectionFactory());
+		RabbitTemplate template = new RabbitTemplate(ccf);
+		this.maxHeaderSize = RabbitUtils.getMaxFrame(template.getConnectionFactory())
+				- RepublishMessageRecoverer.DEFAULT_FRAME_MAX_HEADROOM;
+		assertThat(this.maxHeaderSize).isGreaterThan(0);
+		RepublishMessageRecoverer recoverer = new RepublishMessageRecoverer(template, "", BIG_HEADER_QUEUE);
+		ListenerExecutionFailedException cause = new ListenerExecutionFailedException("Listener failed",
+				new RuntimeException(new String(new byte[200]).replace('\u0000', 'x')));
+		recoverer.recover(new Message("foo".getBytes(), new MessageProperties()),
+				cause);
+		Message received = template.receive(BIG_HEADER_QUEUE, 10_000);
+		assertThat(received).isNotNull();
+		String trace = received.getMessageProperties().getHeaders()
+				.get(RepublishMessageRecoverer.X_EXCEPTION_STACKTRACE).toString();
+		assertThat(trace).isEqualTo(getStackTraceAsString(cause));
+		ccf.destroy();
+	}
+
+	@Test
+	public void testBigMessageSmallTrace() {
+		CachingConnectionFactory ccf = new CachingConnectionFactory(
+				RabbitAvailableCondition.getBrokerRunning().getConnectionFactory());
+		RabbitTemplate template = new RabbitTemplate(ccf);
+		this.maxHeaderSize = RabbitUtils.getMaxFrame(template.getConnectionFactory())
+				- RepublishMessageRecoverer.DEFAULT_FRAME_MAX_HEADROOM;
+		assertThat(this.maxHeaderSize).isGreaterThan(0);
+		RepublishMessageRecoverer recoverer = new RepublishMessageRecoverer(template, "", BIG_HEADER_QUEUE);
+		ListenerExecutionFailedException cause = new ListenerExecutionFailedException("Listener failed",
+				new RuntimeException(new String(new byte[this.maxHeaderSize]).replace('\u0000', 'x'),
+						new IllegalStateException("foo")));
+		recoverer.recover(new Message("foo".getBytes(), new MessageProperties()),
+				cause);
+		Message received = template.receive(BIG_HEADER_QUEUE, 10_000);
+		assertThat(received).isNotNull();
+		String trace = received.getMessageProperties().getHeaders()
+				.get(RepublishMessageRecoverer.X_EXCEPTION_STACKTRACE).toString();
+		assertThat(trace).contains("Caused by: java.lang.IllegalStateException");
+		String exceptionMessage = received.getMessageProperties()
+				.getHeader(RepublishMessageRecoverer.X_EXCEPTION_MESSAGE).toString();
+		assertThat(trace.length() + exceptionMessage.length()).isEqualTo(this.maxHeaderSize);
+		assertThat(exceptionMessage).endsWith("...");
+		ccf.destroy();
 	}
 
 	private Throwable bigCause(Throwable cause) {
-		if (getStackTraceAsString(cause).length() > this.maxHeaderSize) {
+		int length = getStackTraceAsString(cause).length();
+		int wantThisSize = this.maxHeaderSize + RepublishMessageRecoverer.DEFAULT_FRAME_MAX_HEADROOM;
+		if (length > wantThisSize) {
 			return cause;
 		}
-		return bigCause(new RuntimeException(BIG_EXCEPTION_MESSAGE, cause));
+		String msg = length + BIG_EXCEPTION_MESSAGE1.length() > wantThisSize
+				? BIG_EXCEPTION_MESSAGE1
+				: BIG_EXCEPTION_MESSAGE2;
+		return bigCause(new RuntimeException(msg, cause));
 	}
 
 	private String getStackTraceAsString(Throwable cause) {

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -5984,6 +5984,16 @@ RepublishMessageRecoverer recoverer = new RepublishMessageRecoverer(amqpTemplate
 ----
 ====
 
+Starting with version 2.0.5, the stack trace may be truncated if it is too large; this is because all headers have to fit in a single frame.
+By default, if the stack trace would cause less than 20,000 bytes ('headroom') to be available for other headers, it will be truncated.
+This can be adjusted by setting the recoverer's `frameMaxHeadroom` property, if you need more or less space for other headers.
+Starting with versions 2.1.13, 2.2.3, the exception message is included in this calculation, and the amount of stack trace will be maximized using the following algorithm:
+
+* if the stack trace alone would exceed the limit, the exception message header will be truncated to 97 bytes plus `...` and the stack trace is truncated too.
+* if the stack trace is small, the message will be truncated (plus `...`) to fit in the available bytes (but the message within the stack trace itself is truncated to 97 bytes plus `...`).
+
+Whenever a truncation of any kind occurs, the original exception will be logged to retain the complete information.
+
 Starting with version 2.1, an `ImmediateRequeueMessageRecoverer` is  added to throw an `ImmediateRequeueAmqpException`, which notifies a listener container to requeue the current failed message.
 
 ===== Exception Classification for Spring Retry


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1130

`RepublishingMessageRecoverer` - include the exception message length in the
truncation algorithm.

Note that the message is included in the stack trace.

If the stack trace + exception message would exceed the limit
- first truncate the message within the stack trace to 100 bytes
-- if the stack trace and original message still exceed the limit
-- also truncate the `X_EXCEPTION_MESSAGE` header to 100 bytes and
   use the remaing space for stack trace

If, after truncating the message in the stack trace, there is room remaining
the full stack trace as well as the truncated message, re-truncate the
`X_EXCEPTION_MESSAGE` header to use the remaining available bytes.

examples:
  message 150 bytes, stack trace 350 bytes, available 300 bytes,
  stack trace after message truncation 300 bytes
   - truncate message to 100, trace to 200

  message 200 bytes, stack trace 250 bytes, available 300 bytes,
  stack trace after message truncation 150 bytes
   - truncate message to 100 bytes, trace to 200

  message 200 bytes, stack trace 250 bytes, available 300 bytes,
  stack trace after message truncation 150 bytes
   - truncate message to 150 bytes, trace remains at 150

These are for illustration only, the available bytes is generally must larger.

**cherry-pick to 2.1.x**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
