### PR TITLE
GH-1133: Add called bean/method to reply msg props

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -499,7 +499,7 @@ public class MessageProperties implements Serializable {
 	}
 
 	/**
-	 * The target method when using a method-level {@code @RabbitListener}.
+	 * The target method when using a {@code @RabbitListener}.
 	 * @return the method.
 	 * @since 1.6
 	 */
@@ -508,7 +508,7 @@ public class MessageProperties implements Serializable {
 	}
 
 	/**
-	 * Set the target method when using a method-level {@code @RabbitListener}.
+	 * Set the target method when using a {@code @RabbitListener}.
 	 * @param targetMethod the target method.
 	 * @since 1.6
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1952,6 +1952,11 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 		try {
 			reply = exchangeMessages(exchange, routingKey, message, correlationData, channel, pendingReply,
 					messageTag);
+			if (this.afterReceivePostProcessors != null) {
+				for (MessagePostProcessor processor : this.afterReceivePostProcessors) {
+					reply = processor.postProcessMessage(reply);
+				}
+			}
 		}
 		finally {
 			this.replyHolder.remove(messageTag);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -375,8 +375,10 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 					}
 				}
 			}
-			doHandleResult(new InvocationResult(deferredResult, resultArg.getSendTo(), returnType), request, channel,
-					source);
+			doHandleResult(
+					new InvocationResult(deferredResult, resultArg.getSendTo(), returnType, resultArg.getBean(),
+							resultArg.getMethod()),
+					request, channel, source);
 		}
 	}
 
@@ -407,6 +409,9 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 		}
 		try {
 			Message response = buildMessage(channel, resultArg.getReturnValue(), resultArg.getReturnType());
+			MessageProperties props = response.getMessageProperties();
+			props.setTargetBean(resultArg.getBean());
+			props.setTargetMethod(resultArg.getMethod());
 			postProcessResponse(request, response);
 			Address replyTo = getReplyToAddress(request, source, resultArg);
 			sendResponse(channel, replyTo, response);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
@@ -131,10 +131,12 @@ public class DelegatingInvocableHandler {
 		if (message.getHeaders().get(AmqpHeaders.REPLY_TO) == null) {
 			Expression replyTo = this.handlerSendTo.get(handler);
 			if (replyTo != null) {
-				return new InvocationResult(result, replyTo, handler.getMethod().getGenericReturnType());
+				return new InvocationResult(result, replyTo, handler.getMethod().getGenericReturnType(),
+						handler.getBean(), handler.getMethod());
 			}
 		}
-		return new InvocationResult(result, null, handler.getMethod().getGenericReturnType());
+		return new InvocationResult(result, null, handler.getMethod().getGenericReturnType(), handler.getBean(),
+				handler.getMethod());
 	}
 
 	/**
@@ -277,7 +279,7 @@ public class DelegatingInvocableHandler {
 		InvocableHandlerMethod handler = findHandlerForPayload(inboundPayload.getClass());
 		if (handler != null) {
 			return new InvocationResult(result, this.handlerSendTo.get(handler),
-					handler.getMethod().getGenericReturnType());
+					handler.getMethod().getGenericReturnType(), handler.getBean(), handler.getMethod());
 		}
 		return null;
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/InvocationResult.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/InvocationResult.java
@@ -16,6 +16,7 @@
 
 package org.springframework.amqp.rabbit.listener.adapter;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
 import org.springframework.expression.Expression;
@@ -37,10 +38,31 @@ public final class InvocationResult {
 	@Nullable
 	private final Type returnType;
 
-	public InvocationResult(Object result, Expression sendTo, @Nullable Type returnType) {
+	@Nullable
+	private final Object bean;
+
+	@Nullable
+	private final Method method;
+
+	/**
+	 * @deprecated in favor of {@link #InvocationResult(Object, Expression, Type, Object, Method)}.
+	 * @param result the result.
+	 * @param sendTo the sendTo expression.
+	 * @param returnType the return type.
+	 */
+	@Deprecated
+	public InvocationResult(Object result, @Nullable Expression sendTo, @Nullable Type returnType) {
+		this(result, sendTo, returnType, null, null);
+	}
+
+	public InvocationResult(Object result, @Nullable Expression sendTo, @Nullable Type returnType,
+			@Nullable Object bean, @Nullable Method method) {
+
 		this.returnValue = result;
 		this.sendTo = sendTo;
 		this.returnType = returnType;
+		this.bean = bean;
+		this.method = method;
 	}
 
 	public Object getReturnValue() {
@@ -56,11 +78,24 @@ public final class InvocationResult {
 		return this.returnType;
 	}
 
+	@Nullable
+	public Object getBean() {
+		return this.bean;
+	}
+
+	@Nullable
+	public Method getMethod() {
+		return this.method;
+	}
+
 	@Override
 	public String toString() {
 		return "InvocationResult [returnValue=" + this.returnValue
 				+ (this.sendTo != null ? ", sendTo=" + this.sendTo : "")
-				+ ", returnType=" + this.returnType + "]";
+				+ ", returnType=" + this.returnType
+				+ ", bean=" + this.bean
+				+ ", method=" + this.method
+				+ "]";
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessageListenerAdapter.java
@@ -292,7 +292,7 @@ public class MessageListenerAdapter extends AbstractAdaptableMessageListener {
 		Object[] listenerArguments = buildListenerArguments(convertedMessage, channel, message);
 		Object result = invokeListenerMethod(methodName, listenerArguments, message);
 		if (result != null) {
-			handleResult(new InvocationResult(result, null, null), message, channel);
+			handleResult(new InvocationResult(result, null, null, null, null), message, channel);
 		}
 		else {
 			logger.trace("No result object given - no result to handle");

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2213,6 +2213,8 @@ See the https://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframewor
 
 The container factories provide methods for adding `MessagePostProcessor` instances that are applied after receiving messages (before invoking the listener) and before sending replies.
 
+See <<async-annotation-driven-reply>> for information about replies.
+
 Starting with version 2.0.6, you can add a `RetryTemplate` and `RecoveryCallback` to the listener container factory.
 It is used when sending replies.
 The `RecoveryCallback` is invoked when retries are exhausted.
@@ -2544,7 +2546,7 @@ Each queue needed a separate property.
 ====== Reply Management
 
 The existing support in `MessageListenerAdapter` already lets your method have a non-void return type.
-When that is the case, the result of the invocation is encapsulated in a message sent either in the address specified in the `ReplyToAddress` header of the original message or in the default address configured on the listener.
+When that is the case, the result of the invocation is encapsulated in a message sent to the the address specified in the `ReplyToAddress` header of the original message, or to the default address configured on the listener.
 You can set that default address by using the `@SendTo` annotation of the messaging abstraction.
 
 Assuming our `processOrder` method should now return an `OrderStatus`, we can write it as follows to automatically send a reply:
@@ -2578,6 +2580,24 @@ public Message<OrderStatus> processOrder(Order order) {
 }
 ----
 ====
+
+Alternatively, you can use a `MessagePostProcessor` in the `beforeSendReplyMessagePostProcessors` container factory property to add more headers.
+Starting with version 2.2.3, the called bean/method is made avaiable in the reply message, which can be used in a message post processor to communicate the information back to the caller:
+
+====
+[source, java]
+----
+factory.setBeforeSendReplyPostProcessors(msg -> {
+    msg.getMessageProperties().setHeader("calledBean",
+            msg.getMessageProperties().getTargetBean().getClass().getSimpleName());
+    msg.getMessageProperties().setHeader("calledMethod",
+            msg.getMessageProperties().getTargetMethod().getName());
+    return m;
+});
+----
+====
+
+
 
 The `@SendTo` value is assumed as a reply `exchange` and `routingKey` pair that follws the `exchange/routingKey` pattern,
 where one of those parts can be omitted.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -59,6 +59,10 @@ See <<Jackson2JsonMessageConverter-from-message>> for more information.
 Similarly. the `Jackson2XmlMessageConverter` now assumes the content is XML if there is no `contentType` property, or it is the default (`application/octet-string`).
 See <<jackson2xml>> for more information.
 
+When a `@RabbitListener` method returns a result, the bean and `Method` are now available in the reply message properties.
+This allows configuration of a `beforeSendReplyMessagePostProcessor` to, for example, set a header in the reply to indicate which method was invoked on the server.
+See <<async-annotation-driven-reply>> for more information.
+
 ==== AMQP Logging Appenders Changes
 
 The Log4J and Logback `AmqpAppender` s now support a `verifyHostname` SSL option.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1133

Currently, the target bean and method are populated only in the request
message and then only for a method-level listener.

- Populate the properties for class-level listeners
- Populate the properties on reply messages too

- Fix `RabbitTemplate` to invoke `afterReceivePostProcessors` when using
  a reply container (bug).

**I will cherry-pick the template fix after the review/merge**