### PR TITLE
Add isConsumerBatchEnabled() to listener container

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/MessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,16 @@ public interface MessageListenerContainer extends SmartLifecycle {
 	 */
 	default void lazyLoad() {
 		// no-op
+	}
+
+	/**
+	 * Return true if this container is capable of (and configured to) create batches
+	 * of consumed messages.
+	 * @return true if enabled.
+	 * @since 2.2.4
+	 */
+	default boolean isConsumerBatchEnabled() {
+		return false;
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -376,6 +376,11 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 */
 	public void setConsumerBatchEnabled(boolean consumerBatchEnabled) {
 		this.consumerBatchEnabled = consumerBatchEnabled;
+	}
+
+	@Override
+	public boolean isConsumerBatchEnabled() {
+		return this.consumerBatchEnabled;
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerRetryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/MessageListenerContainerRetryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,6 +112,7 @@ public class MessageListenerContainerRetryIntegrationTests {
 		});
 		container.setAcknowledgeMode(AcknowledgeMode.AUTO);
 		container.setConsumerBatchEnabled(true);
+		assertThat(container.isConsumerBatchEnabled()).isTrue();
 		container.setBatchSize(2);
 
 		final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
In preparation for https://github.com/spring-projects/spring-integration/issues/3172

Allow the inbound endpoint to detect if its listener container is configured
to return batches.
