### PR TITLE
Always default to TLSv1.2

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,24 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	private static final String TRUST_STORE_TYPE = "trustStore.type";
 
-	private static final String TLS_V1_1 = "TLSv1.1";
+	private static final String DEFAULT_PROTOCOL;
+
+	static {
+		String protocol = "TLSv1.1";
+		try {
+			String[] protocols = SSLContext.getDefault().getSupportedSSLParameters().getProtocols();
+			for (String prot : protocols) {
+				if ("TLSv1.2".equals(prot)) {
+					protocol = "TLSv1.2";
+					break;
+				}
+			}
+		}
+		catch (NoSuchAlgorithmException e) {
+			// nothing
+		}
+		DEFAULT_PROTOCOL = protocol;
+	}
 
 	private static final String KEY_STORE_DEFAULT_TYPE = "PKCS12";
 
@@ -125,7 +142,7 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	private String trustStoreType;
 
-	private String sslAlgorithm = TLS_V1_1;
+	private String sslAlgorithm = DEFAULT_PROTOCOL;
 
 	private boolean sslAlgorithmSet;
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -102,6 +102,9 @@ public class SSLConnectionTests {
 		fb.afterPropertiesSet();
 		fb.getObject();
 		verify(rabbitCf, never()).useSslProtocol();
+		ArgumentCaptor<SSLContext> captor = ArgumentCaptor.forClass(SSLContext.class);
+		verify(rabbitCf).useSslProtocol(captor.capture());
+		assertThat(captor.getValue().getProtocol()).isEqualTo("TLSv1.2");
 	}
 
 	@Test
@@ -123,11 +126,11 @@ public class SSLConnectionTests {
 		ConnectionFactory rabbitCf = spy(TestUtils.getPropertyValue(fb, "connectionFactory", ConnectionFactory.class));
 		new DirectFieldAccessor(fb).setPropertyValue("connectionFactory", rabbitCf);
 		fb.setUseSSL(true);
-		fb.setSslAlgorithm("TLSv1.2");
+		fb.setSslAlgorithm("TLSv1.1");
 		fb.setSkipServerCertificateValidation(true);
 		fb.afterPropertiesSet();
 		fb.getObject();
-		verify(rabbitCf).useSslProtocol("TLSv1.2");
+		verify(rabbitCf).useSslProtocol("TLSv1.1");
 	}
 
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -523,6 +523,9 @@ If you wish to skip this validation for some reason, set the factory bean's `ski
 Starting with version 2.1, the `RabbitConnectionFactoryBean` now calls `enableHostnameVerification()` by default.
 To revert to the previous behavior, set the `enableHostnameVerification` property to `false`.
 
+IMPORTANT: Starting with version 2.2.5, the factory bean will always use TLS v1.2 by default; previously, it used v1.1 in some cases and v1.2 in others (depending on other properties).
+If you need to use v1.1 for some reason, set the `sslAlgorithm` property: `setSslAlgorithm("TLSv1.1")`.
+
 [[cluster]]
 ===== Connecting to a Cluster
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -99,6 +99,9 @@ See <<template-confirms>> for more information.
 
 Also, the publisher confirm type is now specified with the `ConfirmType` enum instead of the two mutually exclusive setter methods.
 
+The `RabbitConnectionFactoryBean` now uses TLS 1.2 by default when SSL is enabled.
+See <<rabbitconnectionfactorybean-configuring-ssl>> for more information.
+
 ==== New MessagePostProcessor Classes
 
 Classes `DeflaterPostProcessor` and `InflaterPostProcessor` were added to support compression and decompression, respectively, when the message content-encoding is set to `deflate`.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1169

Previously, the default was TLSv1.2 if the context was created by the
amqp-client, but 1.1 if the context was created by the factory bean.

