### PR TITLE
GH-1190: Remove reference to Junit4 Assume

### DIFF
--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCondition.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCondition.java
@@ -84,7 +84,7 @@ public class RabbitAvailableCondition
 				if (BrokerRunningSupport.fatal()) {
 					throw new IllegalStateException("Required RabbitMQ is not available", e);
 				}
-				return ConditionEvaluationResult.disabled("RabbitMQ is not available");
+				return ConditionEvaluationResult.disabled("Tests Ignored: RabbitMQ is not available");
 			}
 		}
 		return ENABLED;

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/ExampleRabbitListenerCaptureTest.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/ExampleRabbitListenerCaptureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,17 @@
  * limitations under the License.
  */
 
-package org.springframework.amqp.rabbit.test;
+package org.springframework.amqp.rabbit.test.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Queue;
-import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
@@ -35,14 +32,19 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
-import org.springframework.amqp.rabbit.test.mockito.LatchCountDownAndCallRealMethodAnswer;
+import org.springframework.amqp.rabbit.test.RabbitListenerTest;
+import org.springframework.amqp.rabbit.test.RabbitListenerTestHarness;
+import org.springframework.amqp.rabbit.test.RabbitListenerTestHarness.InvocationData;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 /**
  * @author Gary Russell
@@ -51,10 +53,11 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * @since 1.6
  *
  */
-@SpringJUnitConfig
+@ContextConfiguration(loader = ExampleRabbitListenerCaptureTest.NoBeansOverrideAnnotationConfigContextLoader.class)
+@ExtendWith(SpringExtension.class)
 @DirtiesContext
 @RabbitAvailable
-public class ExampleRabbitListenerSpyTest {
+public class ExampleRabbitListenerCaptureTest {
 
 	@Autowired
 	private RabbitTemplate rabbitTemplate;
@@ -69,33 +72,51 @@ public class ExampleRabbitListenerSpyTest {
 	private RabbitListenerTestHarness harness;
 
 	@Test
-	public void testTwoWay() {
+	public void testTwoWay() throws Exception {
 		assertThat(this.rabbitTemplate.convertSendAndReceive(this.queue1.getName(), "foo")).isEqualTo("FOO");
 
-		Listener listener = this.harness.getSpy("foo");
-		assertThat(listener).isNotNull();
-		verify(listener).foo("foo");
+		InvocationData invocationData = this.harness.getNextInvocationDataFor("foo", 10, TimeUnit.SECONDS);
+		assertThat(invocationData).isNotNull();
+		assertThat((String) invocationData.getArguments()[0]).isEqualTo("foo");
+		assertThat((String) invocationData.getResult()).isEqualTo("FOO");
 	}
 
 	@Test
 	public void testOneWay() throws Exception {
-		Listener listener = this.harness.getSpy("bar");
-		assertThat(listener).isNotNull();
-
-		LatchCountDownAndCallRealMethodAnswer answer = new LatchCountDownAndCallRealMethodAnswer(2);
-		doAnswer(answer).when(listener).foo(anyString(), anyString());
-
 		this.rabbitTemplate.convertAndSend(this.queue2.getName(), "bar");
 		this.rabbitTemplate.convertAndSend(this.queue2.getName(), "baz");
+		this.rabbitTemplate.convertAndSend(this.queue2.getName(), "ex");
 
-		assertThat(answer.getLatch().await(10, TimeUnit.SECONDS)).isTrue();
-		verify(listener).foo("bar", this.queue2.getName());
-		verify(listener).foo("baz", this.queue2.getName());
+		InvocationData invocationData = this.harness.getNextInvocationDataFor("bar", 10, TimeUnit.SECONDS);
+		assertThat(invocationData).isNotNull();
+		Object[] args = invocationData.getArguments();
+		assertThat((String) args[0]).isEqualTo("bar");
+		assertThat((String) args[1]).isEqualTo(queue2.getName());
+
+		invocationData = this.harness.getNextInvocationDataFor("bar", 10, TimeUnit.SECONDS);
+		assertThat(invocationData).isNotNull();
+		args = invocationData.getArguments();
+		assertThat((String) args[0]).isEqualTo("baz");
+		assertThat((String) args[1]).isEqualTo(queue2.getName());
+
+		invocationData = this.harness.getNextInvocationDataFor("bar", 10, TimeUnit.SECONDS);
+		assertThat(invocationData).isNotNull();
+		args = invocationData.getArguments();
+		assertThat((String) args[0]).isEqualTo("ex");
+		assertThat((String) args[1]).isEqualTo(queue2.getName());
+		assertThat(invocationData.getThrowable()).isNotNull();
+		assertThat(invocationData.getThrowable().getMessage()).isEqualTo("ex");
+
+		invocationData = this.harness.getNextInvocationDataFor("bar", 10, TimeUnit.SECONDS);
+		assertThat(invocationData).isNotNull();
+		args = invocationData.getArguments();
+		assertThat((String) args[0]).isEqualTo("ex");
+		assertThat((String) args[1]).isEqualTo(queue2.getName());
+		assertThat(invocationData.getThrowable()).isNull();
 	}
 
 	@Configuration
-	@EnableRabbit
-	@RabbitListenerTest
+	@RabbitListenerTest(spy = false, capture = true)
 	public static class Config {
 
 		@Bean
@@ -139,6 +160,8 @@ public class ExampleRabbitListenerSpyTest {
 
 	public static class Listener {
 
+		private boolean failed;
+
 		@RabbitListener(id = "foo", queues = "#{queue1.name}")
 		public String foo(String foo) {
 			return foo.toUpperCase();
@@ -146,8 +169,24 @@ public class ExampleRabbitListenerSpyTest {
 
 		@RabbitListener(id = "bar", queues = "#{queue2.name}")
 		public void foo(@Payload String foo, @Header("amqp_receivedRoutingKey") String rk) {
+			if (!failed && foo.equals("ex")) {
+				failed = true;
+				throw new RuntimeException(foo);
+			}
+			failed = false;
+		}
+
+	}
+
+
+	public static class NoBeansOverrideAnnotationConfigContextLoader extends AnnotationConfigContextLoader {
+
+		@Override
+		protected void customizeBeanFactory(DefaultListableBeanFactory beanFactory) {
+			beanFactory.setAllowBeanDefinitionOverriding(false);
 		}
 
 	}
 
 }
+

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/ExampleRabbitListenerSpyTest.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/ExampleRabbitListenerSpyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package org.springframework.amqp.rabbit.test;
+package org.springframework.amqp.rabbit.test.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
-import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
@@ -35,7 +35,8 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
-import org.springframework.amqp.rabbit.test.RabbitListenerTestHarness.InvocationData;
+import org.springframework.amqp.rabbit.test.RabbitListenerTest;
+import org.springframework.amqp.rabbit.test.RabbitListenerTestHarness;
 import org.springframework.amqp.rabbit.test.mockito.LatchCountDownAndCallRealMethodAnswer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -47,13 +48,15 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.6
  *
  */
 @SpringJUnitConfig
 @DirtiesContext
 @RabbitAvailable
-public class ExampleRabbitListenerSpyAndCaptureTest {
+public class ExampleRabbitListenerSpyTest {
 
 	@Autowired
 	private RabbitTemplate rabbitTemplate;
@@ -68,17 +71,12 @@ public class ExampleRabbitListenerSpyAndCaptureTest {
 	private RabbitListenerTestHarness harness;
 
 	@Test
-	public void testTwoWay() throws Exception {
+	public void testTwoWay() {
 		assertThat(this.rabbitTemplate.convertSendAndReceive(this.queue1.getName(), "foo")).isEqualTo("FOO");
 
 		Listener listener = this.harness.getSpy("foo");
 		assertThat(listener).isNotNull();
 		verify(listener).foo("foo");
-
-		InvocationData invocationData = this.harness.getNextInvocationDataFor("foo", 10, TimeUnit.SECONDS);
-		assertThat(invocationData).isNotNull();
-		assertThat((String) invocationData.getArguments()[0]).isEqualTo("foo");
-		assertThat((String) invocationData.getResult()).isEqualTo("FOO");
 	}
 
 	@Test
@@ -91,46 +89,15 @@ public class ExampleRabbitListenerSpyAndCaptureTest {
 
 		this.rabbitTemplate.convertAndSend(this.queue2.getName(), "bar");
 		this.rabbitTemplate.convertAndSend(this.queue2.getName(), "baz");
-		this.rabbitTemplate.convertAndSend(this.queue2.getName(), "ex");
 
 		assertThat(answer.getLatch().await(10, TimeUnit.SECONDS)).isTrue();
 		verify(listener).foo("bar", this.queue2.getName());
 		verify(listener).foo("baz", this.queue2.getName());
-
-		InvocationData invocationData = this.harness.getNextInvocationDataFor("bar", 10, TimeUnit.SECONDS);
-		assertThat(invocationData).isNotNull();
-		Object[] args = invocationData.getArguments();
-		assertThat((String) args[0]).isEqualTo("bar");
-		assertThat((String) args[1]).isEqualTo(queue2.getName());
-
-		invocationData = this.harness.getNextInvocationDataFor("bar", 10, TimeUnit.SECONDS);
-		assertThat(invocationData).isNotNull();
-		args = invocationData.getArguments();
-		assertThat((String) args[0]).isEqualTo("baz");
-		assertThat((String) args[1]).isEqualTo(queue2.getName());
-
-		invocationData = this.harness.getNextInvocationDataFor("bar", 10, TimeUnit.SECONDS);
-		assertThat(invocationData).isNotNull();
-		args = invocationData.getArguments();
-		assertThat((String) args[0]).isEqualTo("ex");
-		assertThat((String) args[1]).isEqualTo(queue2.getName());
-		assertThat(invocationData.getThrowable()).isNotNull();
-		assertThat(invocationData.getThrowable().getMessage()).isEqualTo("ex");
-
-		invocationData = this.harness.getNextInvocationDataFor("bar", 10, TimeUnit.SECONDS);
-		assertThat(invocationData).isNotNull();
-		args = invocationData.getArguments();
-		assertThat((String) args[0]).isEqualTo("ex");
-		assertThat((String) args[1]).isEqualTo(queue2.getName());
-		assertThat(invocationData.getThrowable()).isNull();
-
-		Collection<Exception> exceptions = answer.getExceptions();
-		assertThat(exceptions).hasSize(1);
-		assertThat(exceptions.iterator().next()).isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Configuration
-	@RabbitListenerTest(capture = true)
+	@EnableRabbit
+	@RabbitListenerTest
 	public static class Config {
 
 		@Bean
@@ -174,20 +141,13 @@ public class ExampleRabbitListenerSpyAndCaptureTest {
 
 	public static class Listener {
 
-		private boolean failed;
-
 		@RabbitListener(id = "foo", queues = "#{queue1.name}")
 		public String foo(String foo) {
 			return foo.toUpperCase();
 		}
 
 		@RabbitListener(id = "bar", queues = "#{queue2.name}")
-		public void foo(@Payload String foo, @SuppressWarnings("unused") @Header("amqp_receivedRoutingKey") String rk) {
-			if (!failed && foo.equals("ex")) {
-				failed = true;
-				throw new IllegalArgumentException(foo);
-			}
-			failed = false;
+		public void foo(@Payload String foo, @Header("amqp_receivedRoutingKey") String rk) {
 		}
 
 	}

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/TestRabbitTemplateTests.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/TestRabbitTemplateTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.amqp.rabbit.test;
+package org.springframework.amqp.rabbit.test.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -31,6 +31,7 @@ import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
+import org.springframework.amqp.rabbit.test.TestRabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/package-info.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JUnit test examples.
+ */
+package org.springframework.amqp.rabbit.test.examples;


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1190

- Remove reference to `Assume` in `BrokerRunningSupport`
- Move example test cases to a new package so they can be easily copied/pasted
- Remove `assumeOnline` field - it looks like it was intended to support running
  tests only if RabbitMQ is NOT running; but there was never any way to set it
  to false

**cherry-pick to 2.2.x**

