### PR TITLE
GH-1157: Defer spy stubs to original bean

### DIFF
--- a/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
+++ b/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
 
 import org.springframework.amqp.AmqpException;
@@ -37,6 +38,7 @@ import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.test.util.AopTestUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -77,7 +79,7 @@ public class RabbitListenerTestHarness extends RabbitListenerAnnotationBeanPostP
 		String id = rabbitListener.id();
 		if (StringUtils.hasText(id)) {
 			if (this.attributes.getBoolean("spy")) {
-				proxy = Mockito.spy(proxy);
+				proxy = Mockito.mock(AopTestUtils.getUltimateTargetObject(proxy).getClass(), AdditionalAnswers.delegatesTo(proxy));
 				this.listeners.put(id, proxy);
 			}
 			if (this.attributes.getBoolean("capture")) {

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/RabbitListenerProxyTest.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/RabbitListenerProxyTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.AnonymousQueue;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.amqp.rabbit.test.mockito.LatchCountDownAndCallRealMethodAnswer;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Miguel Gross Valle
+ *
+ * @since 2.2
+ *
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@RabbitAvailable
+public class RabbitListenerProxyTest {
+
+	@Autowired
+	private RabbitTemplate rabbitTemplate;
+
+	@Autowired
+	private Queue queue;
+
+	@Autowired
+	private RabbitListenerTestHarness harness;
+
+	@Test
+	public void testProxiedListenerSpy() throws Exception {
+		Listener listener = this.harness.getSpy("foo");
+		assertThat(listener).isNotNull();
+
+		LatchCountDownAndCallRealMethodAnswer answer = new LatchCountDownAndCallRealMethodAnswer(1);
+		doAnswer(answer).when(listener).foo(anyString());
+
+		this.rabbitTemplate.convertAndSend(this.queue.getName(), "foo");
+
+		assertThat(answer.getLatch().await(10, TimeUnit.SECONDS)).isTrue();
+		verify(listener).foo("foo");
+	}
+
+	@Configuration
+	@EnableRabbit
+	@RabbitListenerTest
+	public static class Config {
+
+		@Bean
+		public Listener listener() {
+			return (Listener) new ProxyFactory(new Listener()).getProxy();
+		}
+
+		@Bean
+		public ConnectionFactory connectionFactory() {
+			return new CachingConnectionFactory("localhost");
+		}
+
+		@Bean
+		public Queue queue() {
+			return new AnonymousQueue();
+		}
+
+		@Bean
+		public RabbitAdmin admin(ConnectionFactory cf) {
+			return new RabbitAdmin(cf);
+		}
+
+		@Bean
+		public RabbitTemplate template(ConnectionFactory cf) {
+			return new RabbitTemplate(cf);
+		}
+
+		@Bean
+		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(ConnectionFactory cf) {
+			SimpleRabbitListenerContainerFactory containerFactory = new SimpleRabbitListenerContainerFactory();
+			containerFactory.setConnectionFactory(cf);
+			return containerFactory;
+		}
+	}
+
+	public static class Listener {
+
+		@RabbitListener(id = "foo", queues = "#{queue.name}")
+		public void foo(String foo) {
+		}
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1157

CGLib proxies due to e.g. declarative transactional semantics couldn't
be spied upon due to being final. Replacing the spy, which tries to hold
the state itself, with a mock that delegates execution fixes this.

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
