### PR TITLE
GH-1201: Native BatchMessageListener Support

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -2631,6 +2631,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 			future.completeExceptionally(
 					new ConsumeOkNotReceivedException("Blocking receive, consumer failed to consume within "
 							+ timeoutMillis + " ms: " + consumer));
+			RabbitUtils.setPhysicalCloseRequired(channel, true);
 		}
 		return consumer;
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -42,6 +42,7 @@ import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.ImmediateAcknowledgeAmqpException;
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.core.BatchMessageListener;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.core.MessagePostProcessor;
@@ -1918,6 +1919,17 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 				logger.debug("No global properties bean");
 			}
 		}
+	}
+
+	@Nullable
+	protected List<Message> debatch(Message message) {
+		if (isDeBatchingEnabled() && getBatchingStrategy().canDebatch(message.getMessageProperties())
+				&& getMessageListener() instanceof BatchMessageListener) {
+			final List<Message> messageList = new ArrayList<>();
+			getBatchingStrategy().deBatch(message, fragment -> messageList.add(fragment));
+			return messageList;
+		}
+		return null;
 	}
 
 	@FunctionalInterface

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -945,6 +945,10 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				}
 			}
 			else {
+				messages = debatch(message);
+				if (messages != null) {
+					break;
+				}
 				try {
 					executeListener(channel, message);
 				}
@@ -994,7 +998,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				}
 			}
 		}
-		if (this.consumerBatchEnabled && messages != null) {
+		if (messages != null) {
 			executeWithList(channel, messages, deliveryTag, consumer);
 		}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1996,11 +1996,12 @@ Batched messages (created by a producer) are automatically de-batched by listene
 Rejecting any message from a batch causes the entire batch to be rejected.
 See <<template-batching>> for more information about batching.
 
-Starting with version 2.2, the `SimpleMessageListeneContainer` can be use to create batches on the consumer side (where the producer sent discrete messages).
+Starting with version 2.2, the `SimpleMessageListenerContainer` can be use to create batches on the consumer side (where the producer sent discrete messages).
 
 Set the container property `consumerBatchEnabled` to enable this feature.
 `deBatchingEnabled` must also be true so that the container is responsible for processing batches of both types.
 Implement `BatchMessageListener` or `ChannelAwareBatchMessageListener` when `consumerBatchEnabled` is true.
+Starting with version 2.2.7 both the `SimpleMessageListenerContainer` and `DirectMessageListenerContainer` can debatch <<template-batching,producer created batches>> as `List<Message>`.
 See <<receiving-batch>> for information about using this feature with `@RabbitListener`.
 
 [[consumer-events]]
@@ -5467,6 +5468,8 @@ a|image::images/tickmark.png[]
 (N/A)
 
 |When true, the listener container will debatch batched messages and invoke the listener with each message from the batch.
+Starting with version 2.2.7, <<template-batching,producer created batches>> will be debatched as a `List<Message>` if the listener is a `BatchMessageListener` or `ChannelAwareBatchMessageListener`.
+Otherwise messages from the batch are presented one-at-a-time.
 Default true.
 See <<template-batching>> and <<receiving-batch>>.
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1201

Support de-batching producer batches to a `List<Meessage>` with native
`BatchMessageListener`s; previously this was only possible with
`@RabbitListener` which does the debatching itself.

**cherry-pick to 2.2.x**