### PR TITLE
GH-1215: Allow Abstract Class Deserialization

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,9 +112,7 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper implem
 	@Override
 	public JavaType toJavaType(MessageProperties properties) {
 		JavaType inferredType = getInferredType(properties);
-		if (inferredType != null
-			 && ((!inferredType.isAbstract() && !inferredType.isInterface()
-					|| inferredType.getRawClass().getPackage().getName().startsWith("java.util")))) {
+		if (inferredType != null && canConvert(inferredType)) {
 			return inferredType;
 		}
 
@@ -129,6 +127,19 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper implem
 		}
 
 		return TypeFactory.defaultInstance().constructType(Object.class);
+	}
+
+	private boolean canConvert(JavaType inferredType) {
+		if (inferredType.isAbstract()) {
+			return false;
+		}
+		if (inferredType.isContainerType() && inferredType.getContentType().isAbstract()) {
+			return false;
+		}
+		if (inferredType.getKeyType() != null && inferredType.getKeyType().isAbstract()) {
+			return false;
+		}
+		return true;
 	}
 
 	private JavaType fromTypeHeader(MessageProperties properties, String typeIdHeader) {
@@ -151,7 +162,7 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper implem
 	@Override
 	@Nullable
 	public JavaType getInferredType(MessageProperties properties) {
-		if (hasInferredTypeHeader(properties) && this.typePrecedence.equals(TypePrecedence.INFERRED)) {
+		if (this.typePrecedence.equals(TypePrecedence.INFERRED) && hasInferredTypeHeader(properties)) {
 			return fromInferredTypeHeader(properties);
 		}
 		return null;

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3608,6 +3608,15 @@ converter to determine the type.
 IMPORTANT: Starting with version 1.6.11, `Jackson2JsonMessageConverter` and, therefore, `DefaultJackson2JavaTypeMapper` (`DefaultClassMapper`) provide the `trustedPackages` option to overcome https://pivotal.io/security/cve-2017-4995[Serialization Gadgets] vulnerability.
 By default and for backward compatibility, the `Jackson2JsonMessageConverter` trusts all packages -- that is, it uses `*` for the option.
 
+[[jackson-abstract]]
+====== Deserializing Abstract Classes
+
+Prior to version 2.2.8, if the inferred type of a `@RabbitListener` was an abstract class (including interfaces), the converter would fall back to looking for type information in the headers and, if present, used that information; if that was not present, it would try to create the abstract class.
+This caused a problem when a custom `ObjectMapper` that is configured with a custom deserializer to handle the abstract class is used, but the incoming message has invalid type headers.
+
+Starting with version 2.2.8, the previous behavior is retained by default. If you have such a custom `ObjectMapper` and you want to ignore type headers, and always use the inferred type for conversion, set the `alwaysConvertToInferredType` to `true`.
+This is needed for backwards compatibility and to avoid the overhead of an attempted conversion when it would fail (with a standard `ObjectMapper`).
+
 [[data-projection]]
 ====== Using Spring Data Projection Interfaces
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -11,6 +11,11 @@ See <<change-history>> for changes in previous versions.
 Two additional connection factories are now provided.
 See <<choosing-factory>> for more information.
 
+==== Message Converter Changes
+
+The `Jackson2JMessageConverter` s can now deserialize abstract classes (including interfaces) if the `ObjectMapper` is configured with a custom deserializer.
+See <<jackson-abstract>> for more information.
+
 ==== Testing Changes
 
 A new annotation `@SpringRabbitTest` is provided to automatically configure some infrastructure beans for when you are not using `SpringBootTest`.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1215

Previously, the message converter would fall back to header type info
if the inferred type was abstract.

Furthermore, we did not examine container type content being abstract.

With a custom deserializer, abstract classes can be deserialized.

