### PR TITLE
Fix exception in log

### DIFF
--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/TestRabbitTemplateTests.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/TestRabbitTemplateTests.java
@@ -17,10 +17,12 @@
 package org.springframework.amqp.rabbit.test.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/TestRabbitTemplateTests.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/TestRabbitTemplateTests.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 
 
@@ -95,11 +96,18 @@ public class TestRabbitTemplateTests {
 			ConnectionFactory factory = mock(ConnectionFactory.class);
 			Connection connection = mock(Connection.class);
 			Channel channel = mock(Channel.class);
+			AMQP.Queue.DeclareOk declareOk = mock(AMQP.Queue.DeclareOk.class);
 			willReturn(connection).given(factory).createConnection();
 			willReturn(channel).given(connection).createChannel(anyBoolean());
 			given(channel.isOpen()).willReturn(true);
-			return factory;
-		}
+			try {
+				given(channel.queueDeclare(anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyMap()))
+						.willReturn(declareOk);
+			} catch (IOException e) {
+				throw new RuntimeException("Should never happen since we mocked the connection");
+			}
+				return factory;
+			}
 
 		@Bean
 		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() {

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/TestRabbitTemplateTests.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/TestRabbitTemplateTests.java
@@ -17,7 +17,9 @@
 package org.springframework.amqp.rabbit.test.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
@@ -108,8 +110,8 @@ public class TestRabbitTemplateTests {
 			} catch (IOException e) {
 				throw new RuntimeException("Should never happen since we mocked the connection");
 			}
-				return factory;
-			}
+			return factory;
+		}
 
 		@Bean
 		public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() {


### PR DESCRIPTION
During tests we had those exceptions in our log for quite a while:
```
2020-07-13 18:51:13.471 [org.springframework.amqp.rabbit.RabbitListenerEndpointContainer#2-1] ERROR o.s.a.r.l.SimpleMessageListenerContainer - Failed to check/redeclare auto-delete queue(s).
org.springframework.amqp.UncategorizedAmqpException: java.lang.NullPointerException
	at org.springframework.amqp.rabbit.support.RabbitExceptionTranslator.convertRabbitAccessException(RabbitExceptionTranslator.java:82)
	at org.springframework.amqp.rabbit.connection.RabbitAccessor.convertRabbitAccessException(RabbitAccessor.java:113)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.doExecute(RabbitTemplate.java:2116)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.execute(RabbitTemplate.java:2062)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.execute(RabbitTemplate.java:2042)
	at org.springframework.amqp.rabbit.core.RabbitAdmin.initialize(RabbitAdmin.java:604)
	at org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer.attemptDeclarations(AbstractMessageListenerContainer.java:1840)
	at org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer.redeclareElementsIfNecessary(AbstractMessageListenerContainer.java:1817)
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer$AsyncMessageProcessingConsumer.initialize(SimpleMessageListenerContainer.java:1349)
	at org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer$AsyncMessageProcessingConsumer.run(SimpleMessageListenerContainer.java:1195)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NullPointerException: null
	at org.springframework.amqp.rabbit.core.RabbitAdmin.declareQueues(RabbitAdmin.java:711)
	at org.springframework.amqp.rabbit.core.RabbitAdmin.lambda$initialize$12(RabbitAdmin.java:606)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.invokeAction(RabbitTemplate.java:2151)
	at org.springframework.amqp.rabbit.core.RabbitTemplate.doExecute(RabbitTemplate.java:2110)
```
Our tests went green anyways. That's why nobody really cared. After investing half the day digging around in the wrong corners a just figured out someone copied code from this file.
The proposed changes finally let exception disappear. 

Thanks Gary and Artem for sharing this code in first place :-)

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
