### PR TITLE
GH-1236: Handle non-String contentType

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessagingMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/MessagingMessageConverter.java
@@ -114,9 +114,9 @@ public class MessagingMessageConverter implements MessageConverter, Initializing
 				input.getPayload(), messageProperties);
 		// Default previous behavior of mapper wins for backwards compatibility.
 		if (!Boolean.TRUE.equals(input.getHeaders().get(AmqpHeaders.CONTENT_TYPE_CONVERTER_WINS))) {
-			String contentType = input.getHeaders().get(MessageHeaders.CONTENT_TYPE, String.class);
+			Object contentType = input.getHeaders().get(MessageHeaders.CONTENT_TYPE);
 			if (contentType != null) {
-				messageProperties.setContentType(contentType);
+				messageProperties.setContentType(contentType.toString());
 			}
 		}
 		return amqpMessage;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/ContentTypeDelegatingMessageConverterIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/ContentTypeDelegatingMessageConverterIntegrationTests.java
@@ -45,6 +45,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.MimeType;
 
 /**
  * @author Gary Russell
@@ -166,7 +167,7 @@ public class ContentTypeDelegatingMessageConverterIntegrationTests {
 		@SendTo("#{@queue2.name}")
 		public org.springframework.messaging.Message<String> listen1(String in) {
 			MessageBuilder<String> builder = MessageBuilder.withPayload(in)
-					.setHeader(MessageHeaders.CONTENT_TYPE, "baz/qux");
+					.setHeader(MessageHeaders.CONTENT_TYPE, MimeType.valueOf("baz/qux"));
 			if ("bar".equals(in)) {
 				builder.setHeader(AmqpHeaders.CONTENT_TYPE_CONVERTER_WINS, true);
 			}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1236

The user may set the contentType to a `MimeType`.

Always use `toString()` when replacing the `contentType`.

**cherry-pick to 2.2.x, 2.1.x, 1.7.x**
