### PR TITLE
Add Deterministic Address Shuffling

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParser.java
@@ -42,6 +42,8 @@ class ConnectionFactoryParser extends AbstractSingleBeanDefinitionParser {
 
 	private static final String SHUFFLE_ADDRESSES = "shuffle-addresses";
 
+	private static final String SHUFFLE_MODE = "address-shuffle-mode";
+
 	private static final String ADDRESS_RESOLVER = "address-resolver";
 
 	private static final String VIRTUAL_HOST_ATTRIBUTE = "virtual-host";
@@ -103,6 +105,11 @@ class ConnectionFactoryParser extends AbstractSingleBeanDefinitionParser {
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, EXECUTOR_ATTRIBUTE);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, ADDRESSES);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, SHUFFLE_ADDRESSES);
+		if (element.hasAttribute(SHUFFLE_ADDRESSES) && element.hasAttribute(SHUFFLE_MODE)) {
+			parserContext.getReaderContext()
+					.error("You must not specify both '" + SHUFFLE_ADDRESSES + "' and '" + SHUFFLE_MODE + "'", element);
+		}
+		NamespaceUtils.setValueIfAttributeDefined(builder, element, SHUFFLE_MODE);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, ADDRESS_RESOLVER);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, PUBLISHER_RETURNS);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, REQUESTED_HEARTBEAT, "requestedHeartBeat");

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit.xsd
@@ -1417,7 +1417,7 @@
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 	List of addresses; e.g. host1,host2:4567,host3 - overrides host/port if supplied.
-	Connection will be attempted in order unless 'shuffle-addresses' is 'true'.
+	Connection will be attempted in order unless 'address-shuffle-mode' is set to other than 'NONE'.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -1425,8 +1425,22 @@
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 	Set to true when 'addresses' has more than one address to shuffle the list into a random order.
+	DEPRECATED: use 'address-shuffle-mode' instead.
 					]]></xsd:documentation>
 				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="address-shuffle-mode" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	When multiple addresses are provided, determines whether or not the addresses are shuffled before
+	or after creating a connection. NONE means no shuffling is performed. RANDOM means that the
+	addresses are randomly shuffled before each connection is created. INORDER means that the first
+	address is moved to the end after each connection is created.
+					]]></xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="shuffleModes xsd:string"/>
+				</xsd:simpleType>
 			</xsd:attribute>
 			<xsd:attribute name="address-resolver" type="xsd:string" use="optional">
 				<xsd:annotation>
@@ -1639,6 +1653,14 @@
 		<xsd:restriction base="xsd:token">
 			<xsd:enumeration value="CHANNEL"/>
 			<xsd:enumeration value="CONNECTION"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="shuffleModes">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="NONE"/>
+			<xsd:enumeration value="RANDOM"/>
+			<xsd:enumeration value="INORDER"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.amqp.rabbit.connection.AbstractConnectionFactory.AddressShuffleMode;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType;
 import org.springframework.amqp.rabbit.connection.ConnectionNameStrategy;
@@ -123,7 +124,7 @@ public final class ConnectionFactoryParserTests {
 		assertThat(addresses.get(1).getPort()).isEqualTo(-1);
 		assertThat(addresses.get(2).getHost()).isEqualTo("host3");
 		assertThat(addresses.get(2).getPort()).isEqualTo(4567);
-		assertThat(dfa.getPropertyValue("shuffleAddresses")).isEqualTo(Boolean.TRUE);
+		assertThat(dfa.getPropertyValue("addressShuffleMode")).isEqualTo(AddressShuffleMode.INORDER);
 		assertThat(TestUtils.getPropertyValue(connectionFactory,
 				"rabbitConnectionFactory.threadFactory")).isSameAs(beanFactory.getBean("tf"));
 	}

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ConnectionFactoryParserTests-context.xml
@@ -45,7 +45,7 @@
 	<bean id="execService" class="java.util.concurrent.Executors" factory-method="newSingleThreadExecutor" />
 
 	<rabbit:connection-factory id="multiHost" virtual-host="/bar" addresses="host1:1234,host2,host3:4567"
-		thread-factory="tf" shuffle-addresses="true"
+		thread-factory="tf" address-shuffle-mode="INORDER"
 		channel-cache-size="10" username="user" password="password" />
 
 	<bean id="tf" class="org.springframework.scheduling.concurrent.CustomizableThreadFactory">

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -412,11 +412,11 @@ Alternatively, if running in a clustered environment, you can use the addresses 
 [source,xml]
 ----
 <rabbit:connection-factory
-    id="connectionFactory" addresses="host1:5672,host2:5672" shuffle-addresses="true"/>
+    id="connectionFactory" addresses="host1:5672,host2:5672" address-shuffle-mode="RANDOM"/>
 ----
 ====
 
-See <<cluster>> for information about `shuffle-addresses`.
+See <<cluster>> for information about `address-shuffle-mode`.
 
 The following example with a custom thread factory that prefixes thread names with `rabbitmq-`:
 
@@ -605,7 +605,9 @@ public CachingConnectionFactory ccf() {
 ====
 
 The underlying connection factory will attempt to connect to each host, in order, whenever a new connection is established.
-Starting with version 2.1.8, the connection order can be made random by setting the `shuffleAddresses` property to true; the shuffle will be applied before creating any new connection.
+Starting with version 2.1.8, the connection order can be made random by setting the `addressShuffleMode` property to `RANDOM`; the shuffle will be applied before creating any new connection.
+Starting with version 2.6, the `INORDER` shuffle mode was added, which means the first address is moved to the end after a connection is created.
+You may wish to use this mode with the https://github.com/rabbitmq/rabbitmq-sharding[RabbitMQ Sharding Plugin] with `CacheMode.CONNECTION` and suitable concurrency if you wish to consume from all shards on all nodes.
 
 ====
 [source, java]
@@ -614,7 +616,7 @@ Starting with version 2.1.8, the connection order can be made random by setting 
 public CachingConnectionFactory ccf() {
     CachingConnectionFactory ccf = new CachingConnectionFactory();
     ccf.setAddresses("host1:5672,host2:5672,host3:5672");
-    ccf.setShuffleAddresses(true);
+    ccf.setAddressShuffleMode(AddressShuffleMode.RANDOM);
     return ccf;
 }
 ----


### PR DESCRIPTION
Previously, only random address shuffling was supported; it is useful,
for scenarios such as using the RabbitMQ Sharding Plugin, to be able
to connect to multiple nodes in a deterministic manner.
