### PR TITLE
GH-1246: SMLC: Fix addQueueNames

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -399,8 +399,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 */
 	@Override
 	public void addQueueNames(String... queueName) {
-		super.addQueueNames(queueName);
-		queuesChanged();
+		super.addQueueNames(queueName); // calls addQueues() which will cycle consumers
 	}
 
 	/**
@@ -801,7 +800,13 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 					consumerIterator.remove();
 					count++;
 				}
-				this.addAndStartConsumers(count);
+				try {
+					this.cancellationLock.await(getShutdownTimeout(), TimeUnit.MILLISECONDS);
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				addAndStartConsumers(count);
 			}
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1246

- called `queuesChanged()` twice
- didn't wait for old consumers to exit, causing problems with exclusive consumers

**I will back port, as needed**