### PR TITLE
Catch exception when EventSender stopped

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -925,6 +925,9 @@ public class AmqpAppender extends AppenderBase<ILoggingEvent> {
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 			}
+			catch (Exception e) {
+				addError("Could not send log message, appender is stopped", e);
+			}
 		}
 
 		private void sendOneEncoderPatternMessage(RabbitTemplate rabbitTemplate, String routingKey) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/logback/AmqpAppender.java
@@ -97,6 +97,7 @@ import com.rabbitmq.client.ConnectionFactory;
  * @author Dominique Villard
  * @author Nicolas Ristock
  * @author Eugene Gusev
+ * @author Wayne Chu
  *
  * @since 1.4
  */


### PR DESCRIPTION
<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
`org.springframework.amqp.rabbit.logback.AmqpAppender.java`
```java
protected class EventSender implements Runnable {
	@Override
	public void run() {
		try {
			RabbitTemplate rabbitTemplate = new RabbitTemplate(AmqpAppender.this.connectionFactory)
			while (true) {
				final Event event = AmqpAppender.this.events.take();

				MessageProperties amqpProps = prepareMessageProperties(event);

				String routingKey = AmqpAppender.this.routingKeyLayout.doLayout(event.getEvent());

				sendOneEncoderPatternMessage(rabbitTemplate, routingKey);

				doSend(rabbitTemplate, event, event.getEvent(), name, amqpProps, routingKey);
			}
		}
		catch (InterruptedException e) {
			Thread.currentThread().interrupt();
		}
	}
}
...
```
Any exceptions in this `while(true){}` code block will be lost (except `InterruptedException`).

For example, when sending a message using a custom LoggingLayout to encodeMessage, any exceptions thrown from `doLayout()` will not be caught. The sending thread will stop and we have no way of knowing what went wrong.