### PR TITLE
GH-1252: Jackson Converter Polishing

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJackson2MessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJackson2MessageConverter.java
@@ -84,7 +84,7 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 
 	private ProjectingMessageConverter projectingConverter;
 
-	private boolean standardCharset;
+	private boolean charsetIsUtf8 = true;
 
 	private boolean assumeSupportedContentType = true;
 
@@ -125,9 +125,7 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 	public void setDefaultCharset(@Nullable String defaultCharset) {
 		this.defaultCharset = (defaultCharset != null) ? Charset.forName(defaultCharset)
 				: DEFAULT_CHARSET;
-		if (this.defaultCharset.equals(StandardCharsets.UTF_8)) {
-			this.standardCharset = true;
-		}
+		this.charsetIsUtf8 = this.defaultCharset.equals(StandardCharsets.UTF_8);
 	}
 
 	public String getDefaultCharset() {
@@ -371,7 +369,7 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 
 		byte[] bytes;
 		try {
-			if (this.standardCharset) {
+			if (this.charsetIsUtf8) {
 				bytes = this.objectMapper.writeValueAsBytes(objectToConvert);
 			}
 			else {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1253

Misleading field name `standardCharset`. It was meant to convey that Jackson's default
charset (UTF-8) is being used and so we can convert directly to `byte[]`. Otherwise
we convert to `String` and then to `byte[]` using the configured charset.

Also, it was not set to `true` by default.
