### PR TITLE
Getter For MessageListener Tuned With Its Setter

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -455,7 +455,7 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 	/**
 	 * @return The message listener object to register.
 	 */
-	public Object getMessageListener() {
+	public MessageListener getMessageListener() {
 		return this.messageListener;
 	}
 


### PR DESCRIPTION
Getter For MessageListener Tuned With Its Setter

Now that we have removed deprecated setMessageListener which used to accept an argument of type 'Object' and now that we have only one setter which accepts an argument of type MessageListener, it now makes sense to return MessageListener from getter method. This not only makes getter and setter tuned but would fix the problem wherein the getter and setter required to be working on the same parameter type. e.g. in jxm library.

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
