### PR TITLE
Fix missing class-level `@SendTo` for CGLib proxy

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,8 +164,9 @@ public class DelegatingInvocableHandler {
 			replyTo = extractSendTo(method.toString(), ann);
 		}
 		if (replyTo == null) {
-			SendTo ann = AnnotationUtils.getAnnotation(this.bean.getClass(), SendTo.class);
-			replyTo = extractSendTo(getBean().getClass().getSimpleName(), ann);
+			Class<?> beanType = handler.getBeanType();
+			SendTo ann = AnnotationUtils.getAnnotation(beanType, SendTo.class);
+			replyTo = extractSendTo(beanType.getSimpleName(), ann);
 		}
 		if (replyTo != null) {
 			this.handlerSendTo.put(handler, PARSER.parseExpression(replyTo, PARSER_CONTEXT));


### PR DESCRIPTION
Similar to https://github.com/spring-projects/spring-kafka/issues/1631

The `DelegatingInvocableHandler` doesn't take into account a possible proxy
nature of the listener class.

* Fix `DelegatingInvocableHandler.setupReplyTo()` to deal with user class
which is origin for possible CGLib proxy for the proper annotations search

**Cherry-pick to 2.2.x**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
