### PR TITLE
GH-1269: @RabbitListener: Allow other Annotations

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -34,6 +34,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.remoting.support.RemoteInvocationResult;
@@ -333,12 +334,21 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 			for (int i = 0; i < this.method.getParameterCount(); i++) {
 				MethodParameter methodParameter = new MethodParameter(this.method, i);
 				/*
-				 * We're looking for a single non-annotated parameter, or one annotated with @Payload.
+				 * We're looking for a single parameter, or one annotated with @Payload.
 				 * We ignore parameters with type Message because they are not involved with conversion.
 				 */
+				boolean isHeader = methodParameter.hasParameterAnnotation(Header.class);
+				boolean isPayload = methodParameter.hasParameterAnnotation(Payload.class);
+				if (isHeader && isPayload) {
+					if (MessagingMessageListenerAdapter.this.logger.isWarnEnabled()) {
+						MessagingMessageListenerAdapter.this.logger.warn(this.method.getName()
+							+ ": Cannot annotate a parameter with both @Header and @Payload; "
+							+ "ignored for payload conversion");
+					}
+				}
 				if (isEligibleParameter(methodParameter)
-						&& (methodParameter.getParameterAnnotations().length == 0
-						|| methodParameter.hasParameterAnnotation(Payload.class))) {
+						&& (!isHeader || isPayload) && !(isHeader && isPayload)) {
+
 					if (genericParameterType == null) {
 						genericParameterType = extractGenericParameterTypFromMethodParameter(methodParameter);
 					}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1269

Previously, a parameter annotated with a "foreign" annoation (e.g. `@Validated`)
would not be considered as an eligible payload conversion target; it must also
have been annotated with `@Payload`.

- remove the check for zero annotations
- add a check that the method is not annotated with both `@Payload` and `@Header`
  - ignore if it does, with a warn log, to be consistent with previous behavior.
  - in a future release we might consider this to be fatal.

**cherry-pick to 2.2.x**

