### PR TITLE
Fix Async Rabbit Template documentation section

### DIFF
--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4166,7 +4166,7 @@ See the https://www.rabbitmq.com/dlx.html[RabbitMQ Dead Letter Documentation] fo
 You can also take a look at the `FixedReplyQueueDeadLetterTests` test case for an example.
 
 [[async-template]]
-===== `AsyncRabbitTemplate`
+===== Async Rabbit Template
 
 Version 1.6 introduced the `AsyncRabbitTemplate`.
 This has similar `sendAndReceive` (and `convertSendAndReceive`) methods to those on the <<amqp-template>>.


### PR DESCRIPTION
<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->

Currently AsyncRabbitTemplate's section title in documentation looks odd:

<img width="348" alt="Screenshot 2020-12-02 at 16 20 25" src="https://user-images.githubusercontent.com/2149631/100877780-51733c00-34ba-11eb-981a-4d7e9c77978e.png">

The proposed change will align styling of the section title 

