### PR TITLE
Allow @RL.containerFactory to be an instance

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -171,12 +171,14 @@ public @interface RabbitListener {
 	String priority() default "";
 
 	/**
-	 * Reference to a {@link org.springframework.amqp.rabbit.core.RabbitAdmin
-	 * RabbitAdmin}. Required if the listener is using auto-delete
-	 * queues and those queues are configured for conditional declaration. This
-	 * is the admin that will (re)declare those queues when the container is
-	 * (re)started. See the reference documentation for more information.
-	 * @return the {@link org.springframework.amqp.rabbit.core.RabbitAdmin} bean name.
+	 * Reference to a {@link org.springframework.amqp.rabbit.core.AmqpAdmin AmqpAdmin}.
+	 * Required if the listener is using auto-delete queues and those queues are
+	 * configured for conditional declaration. This is the admin that will (re)declare
+	 * those queues when the container is (re)started. See the reference documentation for
+	 * more information. If a SpEL expression is provided {@code #{...}} the expression
+	 * can evaluate to an {@link org.springframework.amqp.rabbit.core.AmqpAdmin} instance
+	 * or bean name.
+	 * @return the {@link org.springframework.amqp.rabbit.core.AmqpAdmin} bean name.
 	 */
 	String admin() default "";
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -116,10 +116,15 @@ public @interface RabbitListener {
 	String id() default "";
 
 	/**
-	 * The bean name of the {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory}
-	 * to use to create the message listener container responsible to serve this endpoint.
-	 * <p>If not specified, the default container factory is used, if any.
-	 * @return the {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory}
+	 * The bean name of the
+	 * {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory} to
+	 * use to create the message listener container responsible to serve this endpoint.
+	 * <p>
+	 * If not specified, the default container factory is used, if any. If a SpEL
+	 * expression is provided {@code #{...}}, the expression can either evaluate to a
+	 * container factory instance or a bean name.
+	 * @return the
+	 * {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory}
 	 * bean name.
 	 */
 	String containerFactory() default "";

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -38,6 +38,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.Base64UrlNamingStrategy;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Binding.DestinationType;
@@ -482,6 +483,11 @@ public class RabbitListenerAnnotationBeanPostProcessor
 	}
 
 	private void resolveAdmin(MethodRabbitListenerEndpoint endpoint, RabbitListener rabbitListener, Object adminTarget) {
+		Object resolved = resolveExpression(rabbitListener.admin());
+		if (resolved instanceof AmqpAdmin) {
+			endpoint.setAdmin((AmqpAdmin) resolved);
+			return;
+		}
 		String rabbitAdmin = resolveExpressionAsString(rabbitListener.admin(), "admin");
 		if (StringUtils.hasText(rabbitAdmin)) {
 			Assert.state(this.beanFactory != null, "BeanFactory must be set to resolve RabbitAdmin by bean name");

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -501,6 +501,10 @@ public class RabbitListenerAnnotationBeanPostProcessor
 			Object factoryTarget, String beanName) {
 
 		RabbitListenerContainerFactory<?> factory = null;
+		Object resolved = resolveExpression(rabbitListener.containerFactory());
+		if (resolved instanceof RabbitListenerContainerFactory) {
+			return (RabbitListenerContainerFactory<?>) resolved;
+		}
 		String containerFactoryBeanName = resolveExpressionAsString(rabbitListener.containerFactory(),
 				"containerFactory");
 		if (StringUtils.hasText(containerFactoryBeanName)) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitReturnTypesTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitReturnTypesTests.java
@@ -122,7 +122,8 @@ public class EnableRabbitReturnTypesTests {
 			return new Jackson2JsonMessageConverter();
 		}
 
-		@RabbitListener(queues = "EnableRabbitReturnTypesTests.1")
+		@RabbitListener(queues = "EnableRabbitReturnTypesTests.1",
+				containerFactory = "#{@rabbitListenerContainerFactory}")
 		public One listen1(String in) {
 			if ("3".equals(in)) {
 				return new Three();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitReturnTypesTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitReturnTypesTests.java
@@ -27,6 +27,7 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
@@ -118,11 +119,16 @@ public class EnableRabbitReturnTypesTests {
 		}
 
 		@Bean
+		public RabbitAdmin admin(CachingConnectionFactory cf) {
+			return new RabbitAdmin(cf);
+		}
+
+		@Bean
 		public Jackson2JsonMessageConverter converter() {
 			return new Jackson2JsonMessageConverter();
 		}
 
-		@RabbitListener(queues = "EnableRabbitReturnTypesTests.1",
+		@RabbitListener(queues = "EnableRabbitReturnTypesTests.1", admin = "#{admin}",
 				containerFactory = "#{@rabbitListenerContainerFactory}")
 		public One listen1(String in) {
 			if ("3".equals(in)) {


### PR DESCRIPTION
- previously, an expression must resolve to a bean name.
