### PR TITLE
@RabbitListener property improvements

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -116,10 +116,15 @@ public @interface RabbitListener {
 	String id() default "";
 
 	/**
-	 * The bean name of the {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory}
-	 * to use to create the message listener container responsible to serve this endpoint.
-	 * <p>If not specified, the default container factory is used, if any.
-	 * @return the {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory}
+	 * The bean name of the
+	 * {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory} to
+	 * use to create the message listener container responsible to serve this endpoint.
+	 * <p>
+	 * If not specified, the default container factory is used, if any. If a SpEL
+	 * expression is provided ({@code #{...}}), the expression can either evaluate to a
+	 * container factory instance or a bean name.
+	 * @return the
+	 * {@link org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory}
 	 * bean name.
 	 */
 	String containerFactory() default "";
@@ -166,12 +171,14 @@ public @interface RabbitListener {
 	String priority() default "";
 
 	/**
-	 * Reference to a {@link org.springframework.amqp.rabbit.core.RabbitAdmin
-	 * RabbitAdmin}. Required if the listener is using auto-delete
-	 * queues and those queues are configured for conditional declaration. This
-	 * is the admin that will (re)declare those queues when the container is
-	 * (re)started. See the reference documentation for more information.
-	 * @return the {@link org.springframework.amqp.rabbit.core.RabbitAdmin} bean name.
+	 * Reference to a {@link org.springframework.amqp.core.AmqpAdmin AmqpAdmin}.
+	 * Required if the listener is using auto-delete queues and those queues are
+	 * configured for conditional declaration. This is the admin that will (re)declare
+	 * those queues when the container is (re)started. See the reference documentation for
+	 * more information. If a SpEL expression is provided ({@code #{...}}) the expression
+	 * can evaluate to an {@link org.springframework.amqp.core.AmqpAdmin} instance
+	 * or bean name.
+	 * @return the {@link org.springframework.amqp.core.AmqpAdmin} bean name.
 	 */
 	String admin() default "";
 
@@ -246,8 +253,10 @@ public @interface RabbitListener {
 	String autoStartup() default "";
 
 	/**
-	 * Set the task executor bean name to use for this listener's container; overrides
-	 * any executor set on the container factory.
+	 * Set the task executor bean name to use for this listener's container; overrides any
+	 * executor set on the container factory. If a SpEL expression is provided
+	 * ({@code #{...}}), the expression can either evaluate to a executor instance or a bean
+	 * name.
 	 * @return the executor bean name.
 	 * @since 2.2
 	 */
@@ -266,7 +275,9 @@ public @interface RabbitListener {
 	/**
 	 * The bean name of a
 	 * {@link org.springframework.amqp.rabbit.listener.adapter.ReplyPostProcessor} to post
-	 * process a response before it is sent.
+	 * process a response before it is sent. If a SpEL expression is provided
+	 * ({@code #{...}}), the expression can either evaluate to a post processor instance
+	 * or a bean name.
 	 * @return the bean name.
 	 * @since 2.2.5
 	 * @see org.springframework.amqp.rabbit.listener.adapter.AbstractAdaptableMessageListener#setReplyPostProcessor(org.springframework.amqp.rabbit.listener.adapter.ReplyPostProcessor)
@@ -275,7 +286,9 @@ public @interface RabbitListener {
 
 	/**
 	 * Override the container factory's message converter used for this listener.
-	 * @return the message converter bean name.
+	 * @return the message converter bean name. If a SpEL expression is provided
+	 * ({@code #{...}}), the expression can either evaluate to a converter instance
+	 * or a bean name.
 	 * @since 2.3
 	 */
 	String messageConverter() default "";

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitReturnTypesTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitReturnTypesTests.java
@@ -146,9 +146,9 @@ public class EnableRabbitReturnTypesTests {
 			return (amqpMessage, message, exception) -> null;
 		}
 
-		@RabbitListener(queues = "EnableRabbitReturnTypesTests.1", admin = "#{admin}",
+		@RabbitListener(queues = "EnableRabbitReturnTypesTests.1", admin = "#{@admin}",
 				containerFactory = "#{@rabbitListenerContainerFactory}",
-				executor = "#{@exec}", replyPostProcessor = "#{@rpp}", messageConverter = "#{converter}",
+				executor = "#{@exec}", replyPostProcessor = "#{@rpp}", messageConverter = "#{@converter}",
 				errorHandler = "#{@rleh}")
 		public One listen1(String in) {
 			if ("3".equals(in)) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitReturnTypesTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitReturnTypesTests.java
@@ -27,9 +27,12 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
+import org.springframework.amqp.rabbit.listener.adapter.ReplyPostProcessor;
+import org.springframework.amqp.rabbit.listener.api.RabbitListenerErrorHandler;
 import org.springframework.amqp.support.converter.ContentTypeDelegatingMessageConverter;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
@@ -37,6 +40,7 @@ import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -118,11 +122,34 @@ public class EnableRabbitReturnTypesTests {
 		}
 
 		@Bean
+		public RabbitAdmin admin(CachingConnectionFactory cf) {
+			return new RabbitAdmin(cf);
+		}
+
+		@Bean
 		public Jackson2JsonMessageConverter converter() {
 			return new Jackson2JsonMessageConverter();
 		}
 
-		@RabbitListener(queues = "EnableRabbitReturnTypesTests.1")
+		@Bean
+		public SimpleAsyncTaskExecutor exec() {
+			return new SimpleAsyncTaskExecutor();
+		}
+
+		@Bean
+		public ReplyPostProcessor rpp() {
+			return (in, out) -> out;
+		}
+
+		@Bean
+		public RabbitListenerErrorHandler rleh() {
+			return (amqpMessage, message, exception) -> null;
+		}
+
+		@RabbitListener(queues = "EnableRabbitReturnTypesTests.1", admin = "#{admin}",
+				containerFactory = "#{@rabbitListenerContainerFactory}",
+				executor = "#{@exec}", replyPostProcessor = "#{@rpp}", messageConverter = "#{converter}",
+				errorHandler = "#{@rleh}")
 		public One listen1(String in) {
 			if ("3".equals(in)) {
 				return new Three();


### PR DESCRIPTION
For bean name properties that can have an expression, allow
the expression to evaluate to an instance of the desired
type instead of a bean name.

