### PR TITLE
GH-1293: Fix regression

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CorrelationData.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CorrelationData.java
@@ -106,7 +106,12 @@ public class CorrelationData implements Correlation {
 	@Deprecated
 	@Nullable
 	public Message getReturnedMessage() {
-		return this.returnedMessage.getMessage();
+		if (this.returnedMessage == null) {
+			return null;
+		}
+		else {
+			return this.returnedMessage.getMessage();
+		}
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,13 @@ import com.rabbitmq.client.ShutdownSignalException;
  */
 @RabbitAvailable
 public class PublisherCallbackChannelTests {
+
+	@SuppressWarnings("deprecation")
+	@Test
+	void correlationData() {
+		CorrelationData cd = new CorrelationData();
+		assertThat(cd.getReturnedMessage()).isNull();
+	}
 
 	@Test
 	void shutdownWhileCreate() throws IOException, TimeoutException {


### PR DESCRIPTION
- NPE in deprecated `CorrelationData.getReturnedMessage()`.
