### PR TITLE
Log error when direct message listener fails

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1129,6 +1129,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 				}
 			}
 			catch (Error e) { // NOSONAR
+				this.logger.error("Failed to invoke listener", e);
 				getJavaLangErrorHandler().handle(e);
 				throw e;
 			}


### PR DESCRIPTION
Currently when `Error` is encountered while invoking direct message listener, default error handler terminates JVM without any information about the issue. My Spring application was shutdown and I had no clue why that happened. During debugging I discovered an exception which was caused by incorrect project dependencies:
`java.lang.NoSuchMethodError: 'com.fasterxml.jackson.core.util.JacksonFeatureSet com.fasterxml.jackson.core.JsonParser.getReadCapabilities()'`

I'm suggesting to log an error message before JVM is terminated.

@pivotal-issuemaster This is an Obvious Fix