### PR TITLE
Fix PublishCallCh.afterAckCallback race condition

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelImpl.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PublisherCallbackChannelImpl.java
@@ -1026,9 +1026,18 @@ public class PublisherCallbackChannelImpl
 			}
 			finally {
 				try {
-					if (this.afterAckCallback != null && getPendingConfirmsCount() == 0) {
-						this.afterAckCallback.accept(this);
-						this.afterAckCallback = null;
+					if (this.afterAckCallback != null) {
+						java.util.function.Consumer<Channel> callback = null;
+						synchronized (this) {
+							if (getPendingConfirmsCount() == 0) {
+								callback = this.afterAckCallback;
+								this.afterAckCallback = null;
+							}
+						}
+						if (callback != null) {
+							callback.accept(this);
+						}
+
 					}
 				}
 				catch (Exception e) {


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/66071476/impossible-nullpointerexception-springframework-rabbitmq-failed-to-invoke

When we have several pending confirms, we handle them concurrently
in the `doHandleConfirm()`.
The `afterAckCallback` can be set `null` in one thread and
another will fail with NPE after acquiring a monitor from the
`getPendingConfirmsCount()`.

* Extract a local variable for the `callback` inside an `if` block
* Initialize it with `this.afterAckCallback` only if
`getPendingConfirmsCount() == 0` is true,
and set `this.afterAckCallback` to null inside `synchronized (this)`
block
* Call `callback.accept(this)` when local variable is not `null`
and outside of `synchronized` for better performance on end-user callback

**Cherry-pick to 2.2.x**

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc).
-->
