### PR TITLE
GH-1331: ThreadChannelConnFactory Improvements

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,32 @@
 package org.springframework.amqp.rabbit.connection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ConnectionFactory;
 
@@ -39,7 +51,7 @@ import com.rabbitmq.client.ConnectionFactory;
  * @since 2.3
  *
  */
-@RabbitAvailable
+@RabbitAvailable(queues = "ThreadChannelConnectionFactoryTests.q1")
 @SpringJUnitConfig
 @DirtiesContext
 public class ThreadChannelConnectionFactoryTests {
@@ -48,8 +60,8 @@ public class ThreadChannelConnectionFactoryTests {
 	void testBasic() throws Exception {
 		ConnectionFactory rabbitConnectionFactory = new ConnectionFactory();
 		rabbitConnectionFactory.setHost("localhost");
-		ThreadChannelConnectionFactory scf = new ThreadChannelConnectionFactory(rabbitConnectionFactory);
-		Connection conn = scf.createConnection();
+		ThreadChannelConnectionFactory tccf = new ThreadChannelConnectionFactory(rabbitConnectionFactory);
+		Connection conn = tccf.createConnection();
 		Channel chann1 = conn.createChannel(false);
 		chann1.close();
 		Channel chann2 = conn.createChannel(false);
@@ -78,12 +90,12 @@ public class ThreadChannelConnectionFactoryTests {
 		chann2 = conn.createChannel(false);
 		RabbitUtils.setPhysicalCloseRequired(chann2, true);
 		chann2.close();
-		scf.setSimplePublisherConfirms(true);
+		tccf.setSimplePublisherConfirms(true);
 		chann1 = conn.createChannel(false);
 		assertThat(chann1).isNotSameAs(chann2);
 		assertThat(((ChannelProxy) chann1).isConfirmSelected()).isTrue();
 		chann1.close();
-		scf.destroy();
+		tccf.destroy();
 		assertThat(((Channel) TestUtils.getPropertyValue(conn, "channels", ThreadLocal.class).get()).isOpen())
 				.isFalse();
 		assertThat(((Channel) TestUtils.getPropertyValue(conn, "txChannels", ThreadLocal.class).get()).isOpen())
@@ -102,6 +114,98 @@ public class ThreadChannelConnectionFactoryTests {
 		admin.deleteQueue("ThreadChannelConnectionFactoryTests.q");
 		tccf.destroy();
 		assertThat(config.closed).isTrue();
+	}
+
+	@Test
+	void contextSwitch() throws Exception {
+		ConnectionFactory rabbitConnectionFactory = new ConnectionFactory();
+		rabbitConnectionFactory.setHost("localhost");
+		rabbitConnectionFactory.setAutomaticRecoveryEnabled(false);
+		ThreadChannelConnectionFactory tccf = new ThreadChannelConnectionFactory(rabbitConnectionFactory);
+		TaskExecutor exec = new SimpleAsyncTaskExecutor();
+		AtomicReference<Channel> nonTx = new AtomicReference<>();
+		AtomicReference<Channel> tx = new AtomicReference<>();
+		BlockingQueue<Object> context = new LinkedBlockingQueue<>();
+		exec.execute(() -> {
+			Connection conn = tccf.createConnection();
+			nonTx.set(conn.createChannel(false));
+			tx.set(conn.createChannel(true));
+			Object ctx = tccf.prepareSwitchContext();
+			assertThat(TestUtils.getPropertyValue(conn, "channels", ThreadLocal.class).get()).isNull();
+			assertThat(TestUtils.getPropertyValue(conn, "txChannels", ThreadLocal.class).get()).isNull();
+			context.add(ctx);
+		});
+		Object ctx = context.poll(10, TimeUnit.SECONDS);
+		assertThat(ctx).isNotNull();
+		tccf.switchContext(ctx);
+		assertThatIllegalStateException().isThrownBy(() -> tccf.switchContext(ctx));
+		Connection conn = tccf.createConnection();
+		Channel chann1 = conn.createChannel(false);
+		assertThat(chann1).isSameAs(nonTx.get());
+		Channel chann2 = conn.createChannel(true);
+		assertThat(chann2).isSameAs(tx.get());
+		tccf.destroy();
+	}
+
+	@Test
+	void contextSwitchViaTemplate() throws Exception {
+		// Template uses the nested publisher factory
+		ConnectionFactory rabbitConnectionFactory = new ConnectionFactory();
+		rabbitConnectionFactory.setHost("localhost");
+		rabbitConnectionFactory.setAutomaticRecoveryEnabled(false);
+		ThreadChannelConnectionFactory tccf = new ThreadChannelConnectionFactory(rabbitConnectionFactory);
+		RabbitTemplate template = new RabbitTemplate(tccf);
+		TaskExecutor exec = new SimpleAsyncTaskExecutor();
+		AtomicReference<Channel> nonTx = new AtomicReference<>();
+		AtomicReference<Channel> tx = new AtomicReference<>();
+		BlockingQueue<Object> context = new LinkedBlockingQueue<>();
+		exec.execute(() -> {
+			template.execute(this::sendChannelNameAsBody);
+			context.add(tccf.prepareSwitchContext());
+		});
+		Object ctx = context.poll(10, TimeUnit.SECONDS);
+		assertThat(ctx).isNotNull();
+		tccf.switchContext(ctx);
+		template.execute(this::sendChannelNameAsBody);
+		Message received1 = template.receive("ThreadChannelConnectionFactoryTests.q1", 10_000);
+		Message received2 = template.receive("ThreadChannelConnectionFactoryTests.q1", 10_000);
+		assertThat(new String(received1.getBody())).isEqualTo(new String(received2.getBody()));
+		tccf.destroy();
+	}
+
+	@Test
+	void orphanClosed() throws Exception {
+		ConnectionFactory rabbitConnectionFactory = new ConnectionFactory();
+		rabbitConnectionFactory.setHost("localhost");
+		rabbitConnectionFactory.setAutomaticRecoveryEnabled(false);
+		ThreadChannelConnectionFactory tccf = new ThreadChannelConnectionFactory(rabbitConnectionFactory);
+		RabbitTemplate template = new RabbitTemplate(tccf);
+		TaskExecutor exec = new SimpleAsyncTaskExecutor();
+		AtomicReference<Channel> nonTx = new AtomicReference<>();
+		AtomicReference<Channel> tx = new AtomicReference<>();
+		BlockingQueue<Object> context = new LinkedBlockingQueue<>();
+		Runnable task = () -> {
+			template.execute(channel -> null);
+			context.add(tccf.prepareSwitchContext());
+		};
+		exec.execute(task);
+		Object ctx = context.poll(10, TimeUnit.SECONDS);
+		assertThat(ctx).isNotNull();
+		tccf.switchContext(ctx);
+		Channel toBeOrphaned = template.execute(channel -> null);
+		exec.execute(task);
+		ctx = context.poll(10, TimeUnit.SECONDS);
+		assertThat(ctx).isNotNull();
+		tccf.switchContext(ctx);
+		template.execute(channel -> null);
+		assertThat(toBeOrphaned.isOpen()).isFalse();
+		tccf.destroy();
+	}
+
+	Channel sendChannelNameAsBody(Channel channel) throws IOException {
+		channel.basicPublish("", "ThreadChannelConnectionFactoryTests.q1", new BasicProperties(),
+				channel.toString().getBytes());
+		return channel;
 	}
 
 	@Configuration

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -66,7 +66,6 @@ import org.springframework.amqp.rabbit.connection.PublisherCallbackChannel;
 import org.springframework.amqp.rabbit.connection.RabbitUtils;
 import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.SingleConnectionFactory;
-import org.springframework.amqp.rabbit.core.RabbitTemplate.ReturnCallback;
 import org.springframework.amqp.rabbit.core.RabbitTemplate.ReturnsCallback;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.amqp.utils.SerializationUtils;
@@ -576,7 +575,8 @@ public class RabbitTemplateTests {
 		assertThatIllegalStateException().isThrownBy(() ->
 				template.setReturnCallback(mock(RabbitTemplate.ReturnCallback.class)));
 		RabbitTemplate template2 = new RabbitTemplate();
-		ReturnCallback callback = mock(RabbitTemplate.ReturnCallback.class);
+		org.springframework.amqp.rabbit.core.RabbitTemplate.ReturnCallback callback =
+				mock(org.springframework.amqp.rabbit.core.RabbitTemplate.ReturnCallback.class);
 		template2.setReturnCallback(callback);
 		template2.setReturnCallback(callback);
 	}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -257,6 +257,8 @@ This factory manages a single connection and two `ThreadLocal` s, one for transa
 This factory ensures that all operations on the same thread use the same channel (as long as it remains open).
 This facilitates strict message ordering without the need for <<scoped-operations>>.
 To avoid memory leaks, if your application uses many short-lived threads, you must call the factory's `closeThreadChannel()` to release the channel resource.
+Starting with version 2.3.7, a thread can transfer its channel(s) to another thread.
+See <<multi-strict>> for more information.
 
 ====== `CachingConnectionFactory`
 
@@ -1385,6 +1387,97 @@ class Service {
 ====
 
 Even though the publishing is performed on two different threads, they will both use the same channel because the cache is capped at a single channel.
+
+Starting with version 2.3.7, the `ThreadChannelConnectionFactory` supports transferring a thread's channel(s) to another thread, using the `prepareContextSwitch` and `switchContext` methods.
+The first method returns a context which is passed to the second thread which calls the second method.
+A thread can have either a non-transactional channel or a transactional channel (or one of each) bound to it; you cannot transfer them individually, unless you use two connection factories.
+An example follows:
+
+====
+[source, java]
+----
+@SpringBootApplication
+public class Application {
+
+	private static final Logger log = LoggerFactory.getLogger(Application.class);
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
+
+	@Bean
+	TaskExecutor exec() {
+		ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+		exec.setCorePoolSize(10);
+		return exec;
+	}
+
+	@Bean
+	ThreadChannelConnectionFactory tccf() {
+		ConnectionFactory rabbitConnectionFactory = new ConnectionFactory();
+		rabbitConnectionFactory.setHost("localhost");
+		return new ThreadChannelConnectionFactory(rabbitConnectionFactory);
+	}
+
+	@RabbitListener(queues = "queue")
+	void listen(String in) {
+		log.info(in);
+	}
+
+	@Bean
+	Queue queue() {
+		return new Queue("queue");
+	}
+
+
+	@Bean
+	public ApplicationRunner runner(Service service, TaskExecutor exec) {
+		return args -> {
+			exec.execute(() -> service.mainService("test"));
+		};
+	}
+
+}
+
+@Component
+class Service {
+
+	private static final Logger LOG = LoggerFactory.getLogger(Service.class);
+
+	private final RabbitTemplate template;
+
+	private final TaskExecutor exec;
+
+	private final ThreadChannelConnectionFactory connFactory;
+
+	Service(RabbitTemplate template, TaskExecutor exec,
+			ThreadChannelConnectionFactory tccf) {
+
+		this.template = template;
+		this.exec = exec;
+		this.connFactory = tccf;
+	}
+
+	void mainService(String toSend) {
+		LOG.info("Publishing from main service");
+		this.template.convertAndSend("queue", toSend);
+		Object context = this.connFactory.prepareSwitchContext();
+		this.exec.execute(() -> secondaryService(toSend.toUpperCase(), context));
+	}
+
+	void secondaryService(String toSend, Object threadContext) {
+		LOG.info("Publishing from secondary service");
+		this.connFactory.switchContext(threadContext);
+		this.template.convertAndSend("queue", toSend);
+		this.connFactory.closeThreadChannel();
+	}
+
+}
+----
+====
+
+IMPORTANT: Once the `prepareSwitchContext` is called, if the current thread performs any more operations, they will be performed on a new channel.
+It is important to close the thread-bound channel when it is no longer needed.
 
 [[template-messaging]]
 ===== Messaging Integration


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1331

Provide a mechanism so that a thread can hand off its channel(s) to another thread.
Add protection to close a channel that would be orphaned if a second channel is transferred
to the thread and the thread failed to close its channel beforehand.

Other improvements:

- only call the channel listener when a channel is actually created
- physically close a transactional channel that is no longer in the thread local because
  `closeThreadChannel` was called
- move reset of physical close flag to the actual close
