### PR TITLE
GH-1295: Simplify Validator configuration; add payload Validation on @RabbitHandler methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ ext {
 	commonsPoolVersion = '2.9.0'
 	googleJsr305Version = '3.0.2'
 	hamcrestVersion = '2.2'
+	hibernateValidationVersion = '6.2.0.Final'
 	jacksonBomVersion = '2.11.3'
 	jaywayJsonPathVersion = '2.4.0'
 	junit4Version = '4.13.1'
@@ -362,6 +363,7 @@ project('spring-rabbit') {
 
 		testApi project(':spring-rabbit-junit')
 		testImplementation("com.willowtreeapps.assertk:assertk-jvm:$assertkVersion")
+		testImplementation "org.hibernate.validator:hibernate-validator:$hibernateValidationVersion"
 		testRuntimeOnly 'org.springframework:spring-web'
 		testRuntimeOnly "org.apache.httpcomponents:httpclient:$commonsHttpClientVersion"
 		testRuntimeOnly 'com.fasterxml.jackson.core:jackson-core'

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -92,6 +92,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.Validator;
 
 /**
  * Bean post-processor that registers methods annotated with {@link RabbitListener}
@@ -960,6 +961,10 @@ public class RabbitListenerAnnotationBeanPostProcessor
 
 		private MessageHandlerMethodFactory createDefaultMessageHandlerMethodFactory() {
 			DefaultMessageHandlerMethodFactory defaultFactory = new DefaultMessageHandlerMethodFactory();
+			Validator validator = RabbitListenerAnnotationBeanPostProcessor.this.registrar.getValidator();
+			if (validator != null) {
+				defaultFactory.setValidator(validator);
+			}
 			defaultFactory.setBeanFactory(RabbitListenerAnnotationBeanPostProcessor.this.beanFactory);
 			DefaultConversionService conversionService = new DefaultConversionService();
 			conversionService.addConverter(

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -964,6 +965,10 @@ public class RabbitListenerAnnotationBeanPostProcessor
 			conversionService.addConverter(
 					new BytesToStringConverter(RabbitListenerAnnotationBeanPostProcessor.this.charset));
 			defaultFactory.setConversionService(conversionService);
+
+			List<HandlerMethodArgumentResolver> customArgumentsResolver =
+					new ArrayList<>(RabbitListenerAnnotationBeanPostProcessor.this.registrar.getCustomMethodArgumentResolvers());
+			defaultFactory.setCustomArgumentResolvers(customArgumentsResolver);
 			defaultFactory.afterPropertiesSet();
 			return defaultFactory;
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistrar.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.amqp.rabbit.listener;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -24,6 +26,7 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.util.Assert;
 
 /**
@@ -40,6 +43,8 @@ public class RabbitListenerEndpointRegistrar implements BeanFactoryAware, Initia
 
 	private final List<AmqpListenerEndpointDescriptor> endpointDescriptors =
 			new ArrayList<AmqpListenerEndpointDescriptor>();
+
+	private List<HandlerMethodArgumentResolver> customMethodArgumentResolvers = new ArrayList<>();
 
 	@Nullable
 	private RabbitListenerEndpointRegistry endpointRegistry;
@@ -69,6 +74,27 @@ public class RabbitListenerEndpointRegistrar implements BeanFactoryAware, Initia
 	@Nullable
 	public RabbitListenerEndpointRegistry getEndpointRegistry() {
 		return this.endpointRegistry;
+	}
+
+	/**
+	 * Return the list of {@link HandlerMethodArgumentResolver}.
+	 * @return the list of {@link HandlerMethodArgumentResolver}.
+	 * @since 2.3.7
+	 */
+	public List<HandlerMethodArgumentResolver> getCustomMethodArgumentResolvers() {
+		return Collections.unmodifiableList(this.customMethodArgumentResolvers);
+	}
+
+
+	/**
+	 * Add custom methods arguments resolvers to
+	 * {@link org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor}
+	 * Default empty list.
+	 * @param methodArgumentResolvers the methodArgumentResolvers to assign.
+	 * @since 2.3.7
+	 */
+	public void setCustomMethodArgumentResolvers(HandlerMethodArgumentResolver... methodArgumentResolvers) {
+		this.customMethodArgumentResolvers = Arrays.asList(methodArgumentResolvers);
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/DelegatingInvocableHandler.java
@@ -155,7 +155,7 @@ public class DelegatingInvocableHandler {
 	public InvocationResult invoke(Message<?> message, Object... providedArgs) throws Exception { // NOSONAR
 		Class<? extends Object> payloadClass = message.getPayload().getClass();
 		InvocableHandlerMethod handler = getHandlerForPayload(payloadClass);
-		if (this.validator != null) {
+		if (this.validator != null && this.defaultHandler != null) {
 			MethodParameter parameter = this.payloadMethodParameters.get(handler);
 			if (parameter != null && this.validator.supportsParameter(parameter)) {
 				this.validator.validate(message, parameter, message.getPayload());

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2670,6 +2670,83 @@ public class AppConfig implements RabbitListenerConfigurer {
 ----
 ====
 
+[[rabbit-validation]]
+====== @RabbitListener @Payload Validation
+
+Starting with version 2.3.7, it is now easier to add a `Validator` to validate `@RabbitListener` and `@RabbitHandler` `@Payload` arguments.
+Now, you can simply add the validator to the registrar itself.
+
+====
+[source, java]
+----
+@Configuration
+@EnableRabbit
+public class Config implements RabbitListenerConfigurer {
+    ...
+    @Override
+    public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+      registrar.setValidator(new MyValidator());
+    }
+}
+----
+====
+
+NOTE: When using Spring Boot with the validation starter, a `LocalValidatorFactoryBean` is auto-configured:
+
+====
+[source, java]
+----
+@Configuration
+@EnableRabbit
+public class Config implements RabbitListenerConfigurer {
+    @Autowired
+    private LocalValidatorFactoryBean validator;
+    ...
+    @Override
+    public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+      registrar.setValidator(this.validator);
+    }
+}
+----
+====
+
+To validate:
+
+====
+[source, java]
+----
+public static class ValidatedClass {
+  @Max(10)
+  private int bar;
+  public int getBar() {
+    return this.bar;
+  }
+  public void setBar(int bar) {
+    this.bar = bar;
+  }
+}
+----
+====
+
+and
+
+====
+[source, java]
+----
+@RabbitListener(id="validated", queues = "queue1", errorHandler = "validationErrorHandler",
+      containerFactory = "jsonListenerContainerFactory")
+public void validatedListener(@Payload @Valid ValidatedClass val) {
+    ...
+}
+@Bean
+public RabbitListenerErrorHandler validationErrorHandler() {
+    return (m, e) -> {
+        ...
+    };
+}
+----
+====
+
 [[annotation-multiple-queues]]
 ====== Listening to Multiple Queues
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2521,6 +2521,44 @@ public class AppConfig implements RabbitListenerConfigurer {
 IMPORTANT: For multi-method listeners (see <<annotation-method-selection>>), the method selection is based on the payload of the message *after the message conversion*.
 The method argument converter is called only after the method has been selected.
 
+[[custom-argument-resolver]]
+====== Adding custom `HandlerMethodArgumentResolver` to @RabbitListener
+
+Starting with version 2.3.7 you are able to add your own `HandlerMethodArgumentResolver` and resolve custom method parameters.
+All you need is to implement `RabbitListenerConfigurer` and use method `setCustomMethodArgumentResolvers()` from class `RabbitListenerEndpointRegistrar`.
+
+====
+[source, java]
+----
+@Configuration
+class CustomRabbitConfig implements RabbitListenerConfigurer {
+
+    @Override
+    public void configureRabbitListeners(RabbitListenerEndpointRegistrar registrar) {
+        registrar.setCustomMethodArgumentResolvers(
+				new HandlerMethodArgumentResolver() {
+
+					@Override
+					public boolean supportsParameter(MethodParameter parameter) {
+						return CustomMethodArgument.class.isAssignableFrom(parameter.getParameterType());
+					}
+
+					@Override
+					public Object resolveArgument(MethodParameter parameter, org.springframework.messaging.Message<?> message) {
+						return new CustomMethodArgument(
+								(String) message.getPayload(),
+								message.getHeaders().get("customHeader", String.class)
+						);
+					}
+
+				}
+			);
+    }
+
+}
+----
+====
+
 [[async-annotation-driven-registration]]
 ====== Programmatic Endpoint Registration
 


### PR DESCRIPTION
based on links to spring-kafka here in the comment: https://github.com/spring-projects/spring-amqp/issues/1295#issue-783683976

While developing, i found 3 things which i didn't like or which confused me. Could you please help me with them?

1. Why  doesn't  `PayloadMethodArgumentResolver.validate` do "validator.supports()" check? I added it to `DelegatingInvocableHandler.invoke` method, which is not in spring-kafka corresponding implementation, but i'm not sure if it's correct
2. Also `@Max` annotation [here](https://github.com/spring-projects/spring-kafka/pull/824/files#diff-7a504b2b073e72009bb3d490a22504d3ff2eeb53e14ab50c0fa847ed98a88f44R1781) in tests is not needed at all. It just confused me for some time, and i didn't put it to the current MR.
3. I don't like my solution with `@DirtiesContext` in the second commit. I spent quite much time to use  `@RabbitErrorHandler` with rethrowing error and `convertSendAndRecieve` with configuring `this.rabbitTemplate.setMessageConverter(new RemoteInvocationAwareMessageConverterAdapter(new Jackson2JsonMessageConverter()));` , but didn't succeed to make it work, when validation fails for json. `toMessage` was called fine, however `fromMessage` wasn't and exception couldn't be converted to be recieved. `@DirtiesContext` in my mr helps to cleanup `errorHandlerError`, used in my new `testRabbitHandlerValidation` test and `testInvalidPojoConversion`