### PR TITLE
GH-1312: Correlation on Channel with Direct Reply

### DIFF
--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -4223,6 +4223,10 @@ If you want to revert to the previous behavior, set the `useDirectReplyToContain
 The `AsyncRabbitTemplate` has no such option.
 It always used a `DirectReplyToContainer` for replies when direct reply-to is used.
 
+Starting with version 2.3.7, the template has a new property `useChannelForCorrelation`.
+When this is `true`, the server does not have to copy the correlation id from the request message headers to the reply message.
+Instead, the channel used to send the request is used to correlate the reply to the request.
+
 ===== Message Correlation With A Reply Queue
 
 When using a fixed reply queue (other than `amq.rabbitmq.reply-to`), you must provide correlation data so that replies can be correlated to requests.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -35,7 +35,7 @@ When using returns and correlated confirms, the `CorrelationData` now requires a
 See <<template-confirms>> for more information.
 
 When using direct reply-to, you can now configure the template such that the server does not need to return correlation data with the reply.
-See <<>> for more information.
+See <<direct-reply-to>> for more information.
 
 ==== Listener Container Changes
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -34,6 +34,9 @@ See <<template-confirms>> for more information.
 When using returns and correlated confirms, the `CorrelationData` now requires a unique `id` property.
 See <<template-confirms>> for more information.
 
+When using direct reply-to, you can now configure the template such that the server does not need to return correlation data with the reply.
+See <<>> for more information.
+
 ==== Listener Container Changes
 
 A new listener container property `consumeDelay` is now available; it is helpful when using the https://github.com/rabbitmq/rabbitmq-sharding[RabbitMQ Sharding Plugin].


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1312

With Direct Reply-To we can correlate the reply using the channel
instead of requiring the server to echo back the correlation id.
