### PR TITLE
GH-1339: Fix RLErrorHandler with Conversion Ex.

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/api/RabbitListenerErrorHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/api/RabbitListenerErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.amqp.rabbit.listener.api;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
+import org.springframework.lang.Nullable;
 
 /**
  * An error handler which is called when a {code @RabbitListener} method
@@ -35,13 +36,13 @@ public interface RabbitListenerErrorHandler {
 	 * Handle the error. If an exception is not thrown, the return value is returned to
 	 * the sender using normal {@code replyTo/@SendTo} semantics.
 	 * @param amqpMessage the raw message received.
-	 * @param message the converted spring-messaging message.
+	 * @param message the converted spring-messaging message (if available).
 	 * @param exception the exception the listener threw, wrapped in a
 	 * {@link ListenerExecutionFailedException}.
 	 * @return the return value to be sent to the sender.
 	 * @throws Exception an exception which may be the original or different.
 	 */
-	Object handleError(Message amqpMessage, org.springframework.messaging.Message<?> message,
+	Object handleError(Message amqpMessage, @Nullable org.springframework.messaging.Message<?> message,
 			ListenerExecutionFailedException exception) throws Exception; // NOSONAR
 
 }

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3276,7 +3276,7 @@ static class TxServiceImpl implements TxService<Foo> {
 
     @Override
     @RabbitListener(...)
-    public String handle(Foo foo, String rk) {
+    public String handle(Thing thing, String rk) {
          ...
     }
 
@@ -3358,6 +3358,10 @@ public Object handleError(Message amqpMessage, org.springframework.messaging.Mes
           }
 ----
 ====
+
+Starting with version 2.2.18, if a message conversion exception is thrown, the error handler will be called, with `null` in the `message` argument.
+This allows the application to send some result to the caller, indicating that a badly-formed message was received.
+Previously, such errors were thrown and handled by the container.
 
 ====== Container Management
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1339

Error handler was not called for conversion exceptions, preventing
the application frm returning some error to the caller for request/reply
processing.

**cherry-pick to 2.2.x**
