### PR TITLE
Add links to alternate documentation formats

### DIFF
--- a/src/reference/asciidoc/index.adoc
+++ b/src/reference/asciidoc/index.adoc
@@ -12,6 +12,12 @@ Mark Pollack; Mark Fisher; Oleg Zhurakousky; Dave Syer; Gary Russell; Gunnar Hil
 
 ifdef::backend-html5[]
 *{project-version}*
+
+NOTE: This documentation is also available as https://docs.spring.io/spring-amqp/docs/current/reference/pdf/spring-integration-amqp.pdf[PDF].
+endif::[]
+
+ifdef::backend-pdf[]
+NOTE: This documentation is also available as https://docs.spring.io/spring-amqp/docs/current/reference/html/index.html[HTML].
 endif::[]
 
 (C) 2010 - 2021 by VMware, Inc.

--- a/src/reference/asciidoc/index.adoc
+++ b/src/reference/asciidoc/index.adoc
@@ -13,7 +13,7 @@ Mark Pollack; Mark Fisher; Oleg Zhurakousky; Dave Syer; Gary Russell; Gunnar Hil
 ifdef::backend-html5[]
 *{project-version}*
 
-NOTE: This documentation is also available as https://docs.spring.io/spring-amqp/docs/current/reference/pdf/spring-integration-amqp.pdf[PDF].
+NOTE: This documentation is also available as https://docs.spring.io/spring-amqp/docs/current/reference/pdf/spring-amqp-reference.pdf[PDF].
 endif::[]
 
 ifdef::backend-pdf[]


### PR DESCRIPTION
Link the HTML to the PDF and vice-versa.

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
