### PR TITLE
GH-1359: After Receive Post Processor Invoked x2

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1980,10 +1980,6 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 				if (this.taskExecutor != null) {
 					container.setTaskExecutor(this.taskExecutor);
 				}
-				if (this.afterReceivePostProcessors != null) {
-					container.setAfterReceivePostProcessors(this.afterReceivePostProcessors
-							.toArray(new MessagePostProcessor[this.afterReceivePostProcessors.size()]));
-				}
 				container.setNoLocal(this.noLocalReplyConsumer);
 				if (this.replyErrorHandler != null) {
 					container.setErrorHandler(this.replyErrorHandler);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1359

When the `RabbitTemplate` is configured with `afterReceivePostProcessors`
and uses the default internal `DirectReplyToMessageListenerContainer`, the
postprocessors are applied twice, once by the container and once by the
template.

The template should not propagate the post processors into the container.

**cherry-pick to 2.3.x, 2.2.x**
