### PR TITLE
GH-1732: Fix Listener Container Parser

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,21 +179,21 @@ class ListenerContainerParser implements BeanDefinitionParser {
 
 		String queueNames = listenerEle.getAttribute(QUEUE_NAMES_ATTRIBUTE);
 		if (StringUtils.hasText(queueNames)) {
-			String[] names = StringUtils.commaDelimitedListToStringArray(queueNames);
-			List<TypedStringValue> values = new ManagedList<TypedStringValue>();
-			for (int i = 0; i < names.length; i++) {
-				values.add(new TypedStringValue(names[i].trim()));
-			}
-			containerDef.getPropertyValues().add("queueNames", values);
+			containerDef.getPropertyValues().add("queueNames", queueNames);
 		}
 		String queues = listenerEle.getAttribute(QUEUES_ATTRIBUTE);
 		if (StringUtils.hasText(queues)) {
-			String[] names = StringUtils.commaDelimitedListToStringArray(queues);
-			List<RuntimeBeanReference> values = new ManagedList<RuntimeBeanReference>();
-			for (int i = 0; i < names.length; i++) {
-				values.add(new RuntimeBeanReference(names[i].trim()));
+			if (queues.startsWith("#{")) {
+				containerDef.getPropertyValues().add("queues", queues);
 			}
-			containerDef.getPropertyValues().add("queues", values);
+			else {
+				String[] names = StringUtils.commaDelimitedListToStringArray(queues);
+				List<RuntimeBeanReference> values = new ManagedList<RuntimeBeanReference>();
+				for (int i = 0; i < names.length; i++) {
+					values.add(new RuntimeBeanReference(names[i].trim()));
+				}
+				containerDef.getPropertyValues().add("queues", values);
+			}
 		}
 
 		ManagedMap<String, TypedStringValue> args = new ManagedMap<String, TypedStringValue>();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 the original author or authors.
+ * Copyright 2010-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,23 @@ public final class ListenerContainerPlaceholderParserTests {
 		assertThat(listenerAccessor.getPropertyValue("defaultListenerMethod")).isEqualTo("handle");
 		Queue queue = this.context.getBean("bar", Queue.class);
 		assertThat(Arrays.asList(container.getQueueNames()).toString()).isEqualTo("[foo, " + queue.getName() + "]");
+	}
+
+	@Test
+	public void commasInPropertyNames() {
+		SimpleMessageListenerContainer container = this.context.getBean("commaProps1",
+				SimpleMessageListenerContainer.class);
+		assertThat(container.getQueueNames()).containsExactly("foo", "bar");
+	}
+
+	@Test
+	public void commasInPropertyQueues() {
+		SimpleMessageListenerContainer container = this.context.getBean("commaProps2",
+				SimpleMessageListenerContainer.class);
+		String[] queueNames = container.getQueueNames();
+		assertThat(queueNames).hasSize(2);
+		assertThat(queueNames[0]).isEqualTo("foo");
+		assertThat(queueNames[1]).startsWith("spring.gen");
 	}
 
 }

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/rabbit-listener.properties
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/rabbit-listener.properties
@@ -4,3 +4,5 @@ rabbit.listener.queue=queue1
 rabbit.listener.priority=34
 rabbit.listener.responseRoutingKey=routing-123
 rabbit.listener.admin=rabbitAdmin
+
+foo.and.bar=foo, bar

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/ListenerContainerPlaceholderParserTests-context.xml
@@ -11,6 +11,7 @@
 				<prop key="five">5</prop>
 				<prop key="one">1</prop>
 				<prop key="false">false</prop>
+				<prop key="foo.and.bar">foo, bar</prop>
 			</props>
 		</property>
 	</bean>
@@ -27,5 +28,14 @@
 	<bean id="connectionFactory" class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory"/>
 
 	<bean id="testBean" class="org.springframework.amqp.rabbit.config.ListenerContainerParserTests$TestBean"/>
+
+	<rabbit:listener-container connection-factory="connectionFactory" auto-startup="false">
+		<rabbit:listener id="commaProps1" queue-names="${foo.and.bar}" ref="testBean" method="handle"/>
+	</rabbit:listener-container>
+
+	<rabbit:listener-container connection-factory="connectionFactory" auto-startup="false">
+		<rabbit:listener id="commaProps2" queues="#{T(java.util.Arrays).asList(@foo, @bar).toArray()}"
+				ref="testBean" method="handle"/>
+	</rabbit:listener-container>
 
 </beans>


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1372

Do not split `queue-names` in the parser - leave it to Spring's type converter.
Also support SpEL in `queues`; a more elegant solution would require major
refactoring of the parser; so this is just a compromise.

**cherry-pick to 2.3.x, 2.2.x**
