### PR TITLE
Upgrade checkstyle; fix violations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,7 +288,7 @@ subprojects { subproject ->
 
 	checkstyle {
 		configDirectory.set(rootProject.file("src/checkstyle"))
-		toolVersion = '8.24'
+		toolVersion = '9.0'
 	}
 
 	jar {

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Message.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Message.java
@@ -72,9 +72,9 @@ public class Message implements Serializable {
 
 	/**
 	 * No longer used.
-	 * @deprecated toString() no longer deserializes the body.
 	 * @param patterns the patterns.
 	 * @since 1.5.7
+	 * @deprecated toString() no longer deserializes the body.
 	 */
 	@Deprecated
 	public static void addAllowedListPatterns(String... patterns) {

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,8 +52,8 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper implem
 	/**
 	 * Return the precedence.
 	 * @return the precedence.
-	 * @see #setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence)
 	 * @since 1.6.
+	 * @see #setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence)
 	 */
 	@Override
 	public TypePrecedence getTypePrecedence() {

--- a/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/mockito/LatchCountDownAndCallRealMethodAnswer.java
+++ b/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/mockito/LatchCountDownAndCallRealMethodAnswer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,9 @@ public class LatchCountDownAndCallRealMethodAnswer extends ForwardsInvocations {
 
 	/**
 	 * Get an instance with no delegate.
+	 * @param count to set in a {@link CountDownLatch}.
 	 * @deprecated in favor of
 	 * {@link #LatchCountDownAndCallRealMethodAnswer(int, Object)}.
-	 * @param count to set in a {@link CountDownLatch}.
 	 */
 	@Deprecated
 	public LatchCountDownAndCallRealMethodAnswer(int count) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -529,8 +529,8 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	 * connection to the broker will be attempted in random order.
 	 * @param shuffleAddresses true to shuffle the list.
 	 * @since 2.1.8
-	 * @see Collections#shuffle(List)
 	 * @deprecated since 2.3 in favor of
+	 * @see Collections#shuffle(List)
 	 * {@link #setAddressShuffleMode(AddressShuffleMode)}.
 	 */
 	@Deprecated

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CorrelationData.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CorrelationData.java
@@ -99,9 +99,9 @@ public class CorrelationData implements Correlation {
 	 * Return a returned message, if any; requires a unique
 	 * {@link #CorrelationData(String) id}. Guaranteed to be populated before the future
 	 * is set.
-	 * @deprecated in favor of {@link #getReturned()}.
 	 * @return the message or null.
 	 * @since 2.1
+	 * @deprecated in favor of {@link #getReturned()}.
 	 */
 	@Deprecated
 	@Nullable
@@ -117,8 +117,8 @@ public class CorrelationData implements Correlation {
 	/**
 	 * Set a returned message for this correlation data.
 	 * @param returnedMessage the returned message.
-	 * @deprecated in favor of {@link #setReturned(ReturnedMessage)}.
 	 * @since 1.7.13
+	 * @deprecated in favor of {@link #setReturned(ReturnedMessage)}.
 	 */
 	@Deprecated
 	public void setReturnedMessage(Message returnedMessage) {

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -100,9 +100,6 @@
 		<module name="JavadocType">
 			<property name="scope" value="package"/>
 		</module>
-		<module name="JavadocMethod">
-			<property name="allowMissingJavadoc" value="true"/>
-		</module>
 		<module name="JavadocVariable">
 			<property name="scope" value="public"/>
 			<property name="ignoreNamePattern" value="[A-Z_0-9]*"/>


### PR DESCRIPTION
- a checkstyle bug prevented detection of javadoc tag ordering
- `allowMissingJavadoc` is no longer available on `JavadocMethod`
  (replaced by `MissingJavadocMethod`)

