### PR TITLE
Remove Incorrect Doc Re Prefetch with MANUAL Acks

### DIFF
--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1918,8 +1918,6 @@ There are, nevertheless, scenarios where the prefetch value should be low:
 * Other special cases
 
 Also, with low-volume messaging and multiple consumers (including concurrency within a single listener container instance), you may wish to reduce the prefetch to get a more even distribution of messages across consumers.
-We also recommend using `prefetch = 1` with the `MANUAL` `ack` mode.
-The `basicAck` is an asynchronous operation and, if something wrong happens on the Broker (double `ack` for the same delivery tag, for example), you end up with processed subsequent messages in the batch that are unacknowledged on the Broker, and other consumers may see them.
 
 See <<containerAttributes>>.
 


### PR DESCRIPTION
This commit https://github.com/spring-projects/spring-amqp/commit/b945d1cc0216fc1a8a8af8c1f8f5a7d234d2543e
incorrectly added text about reducing the prefetch to 1 when using manual acks.

While changing it to 1 fixed a test case (`testListenerRecoversFromBogusDoubleAck`) it should
not have been a general recommendation since acking the same message twice is not a valid
situation.

**cherry-pick to all supported branches**
