### PR TITLE
Message toString() Improvement

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Message.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Message.java
@@ -43,7 +43,11 @@ public class Message implements Serializable {
 
 	private static final String DEFAULT_ENCODING = Charset.defaultCharset().name();
 
+	private static final int DEFAULT_MAX_BODY_LENGTH = 50;
+
 	private static String bodyEncoding = DEFAULT_ENCODING;
+
+	private static int maxBodyLength = DEFAULT_MAX_BODY_LENGTH;
 
 	private final MessageProperties messageProperties;
 
@@ -91,6 +95,16 @@ public class Message implements Serializable {
 		bodyEncoding = encoding;
 	}
 
+	/**
+	 * Set the maximum length of a test message body to render as a String in
+	 * {@link #toString()}. Default 50.
+	 * @param length the length to render.
+	 * @since 2.2.20
+	 */
+	public static void setMaxBodyLength(int length) {
+		maxBodyLength = length;
+	}
+
 	public byte[] getBody() {
 		return this.body; //NOSONAR
 	}
@@ -116,10 +130,11 @@ public class Message implements Serializable {
 				return "[serialized object]";
 			}
 			String encoding = encoding();
-			if (MessageProperties.CONTENT_TYPE_TEXT_PLAIN.equals(contentType)
+			if (this.body.length <= maxBodyLength
+					&& (MessageProperties.CONTENT_TYPE_TEXT_PLAIN.equals(contentType)
 					|| MessageProperties.CONTENT_TYPE_JSON.equals(contentType)
 					|| MessageProperties.CONTENT_TYPE_JSON_ALT.equals(contentType)
-					|| MessageProperties.CONTENT_TYPE_XML.equals(contentType)) {
+					|| MessageProperties.CONTENT_TYPE_XML.equals(contentType))) {
 				return new String(this.body, encoding);
 			}
 		}

--- a/spring-amqp/src/test/java/org/springframework/amqp/core/MessageTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/core/MessageTests.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -108,6 +109,24 @@ public class MessageTests {
 		assertThat(listMessage.toString()).doesNotContainPattern("aFoo");
 		assertThat(message.toString()).contains("[serialized object]");
 		assertThat(listMessage.toString()).contains("[serialized object]");
+	}
+
+	@Test
+	void dontToStringLongBody() {
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType(MessageProperties.CONTENT_TYPE_TEXT_PLAIN);
+		StringBuilder builder1 = new StringBuilder();
+		IntStream.range(0, 50).forEach(i -> builder1.append("x"));
+		String bodyAsString = builder1.toString();
+		Message message = new Message(bodyAsString.getBytes(), messageProperties);
+		assertThat(message.toString()).contains(bodyAsString);
+		StringBuilder builder2 = new StringBuilder();
+		IntStream.range(0, 51).forEach(i -> builder2.append("x"));
+		bodyAsString = builder2.toString();
+		message = new Message(bodyAsString.getBytes(), messageProperties);
+		assertThat(message.toString()).contains("[51]");
+		Message.setMaxBodyLength(100);
+		assertThat(message.toString()).contains(bodyAsString);
 	}
 
 	@SuppressWarnings("serial")


### PR DESCRIPTION
Don't convert large message bodies to a `String` in `toString()`.

Set a limit (50) that can be modified by users.

Avoid possible OOM Errors.

**cherry-pick to 2.3.x, 2.2.x**
