### PR TITLE
Fix DEBUG Logging for Projection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,6 +242,9 @@ subprojects { subproject ->
     compileKotlin.dependsOn updateCopyrights
 
 	test {
+		maxHeapSize = '2g'
+		jvmArgs '-XX:+HeapDumpOnOutOfMemoryError'
+
 		testLogging {
 			events "skipped", "failed"
 			showStandardStreams = project.hasProperty("showStandardStreams") ?: false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 version=2.4.0-SNAPSHOT
+org.gradle.jvmargs=-Xms512m -Xmx4g -XX:MaxPermSize=1024m -XX:MaxMetaspaceSize=1g
 org.gradlee.caching=true
 org.gradle.daemon=true
 org.gradle.parallel=true

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -128,6 +128,8 @@ public class MessageProperties implements Serializable {
 
 	private boolean lastInBatch;
 
+	private boolean projectionUsed;
+
 	private transient Type inferredArgumentType;
 
 	private transient Method targetMethod;
@@ -550,6 +552,26 @@ public class MessageProperties implements Serializable {
 	 */
 	public void setLastInBatch(boolean lastInBatch) {
 		this.lastInBatch = lastInBatch;
+	}
+
+	/**
+	 * Get an internal flag used to communicate that conversion used projection; always
+	 * false at the application level.
+	 * @return true if projection was used.
+	 * @since 2.2.20
+	 */
+	public boolean isProjectionUsed() {
+		return this.projectionUsed;
+	}
+
+	/**
+	 * Set an internal flag used to communicate that conversion used projection; always false
+	 * at the application level.
+	 * @param projectionUsed true for projection.
+	 * @since 2.2.20
+	 */
+	public void setProjectionUsed(boolean projectionUsed) {
+		this.projectionUsed = projectionUsed;
 	}
 
 	/**

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJackson2MessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJackson2MessageConverter.java
@@ -305,6 +305,7 @@ public abstract class AbstractJackson2MessageConverter extends AbstractMessageCo
 		if (inferredType != null && this.useProjectionForInterfaces && inferredType.isInterface()
 				&& !inferredType.getRawClass().getPackage().getName().startsWith("java.util")) { // List etc
 			content = this.projectingConverter.convert(message, inferredType.getRawClass());
+			properties.setProjectionUsed(true);
 		}
 		else if (inferredType != null && this.alwaysConvertToInferredType) {
 			content = tryConverType(message, encoding, inferredType);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -30,7 +30,6 @@ import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.MessageConversionException;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.MessagingMessageConverter;
-import org.springframework.amqp.support.converter.ProjectingMessageConverter;
 import org.springframework.core.MethodParameter;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
@@ -188,7 +187,11 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	protected void invokeHandlerAndProcessResult(@Nullable org.springframework.amqp.core.Message amqpMessage,
 			Channel channel, Message<?> message) throws Exception { // NOSONAR
 
-		if (logger.isDebugEnabled() && !(getMessageConverter() instanceof ProjectingMessageConverter)) {
+		boolean projectionUsed = amqpMessage.getMessageProperties().isProjectionUsed();
+		if (projectionUsed) {
+			amqpMessage.getMessageProperties().setProjectionUsed(false);
+		}
+		if (logger.isDebugEnabled() && !projectionUsed) {
 			logger.debug("Processing [" + message + "]");
 		}
 		InvocationResult result = null;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -30,6 +30,7 @@ import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.MessageConversionException;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.MessagingMessageConverter;
+import org.springframework.amqp.support.converter.ProjectingMessageConverter;
 import org.springframework.core.MethodParameter;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
@@ -187,7 +188,7 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	protected void invokeHandlerAndProcessResult(@Nullable org.springframework.amqp.core.Message amqpMessage,
 			Channel channel, Message<?> message) throws Exception { // NOSONAR
 
-		if (logger.isDebugEnabled()) {
+		if (logger.isDebugEnabled() && !(getMessageConverter() instanceof ProjectingMessageConverter)) {
 			logger.debug("Processing [" + message + "]");
 		}
 		InvocationResult result = null;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -187,7 +187,7 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	protected void invokeHandlerAndProcessResult(@Nullable org.springframework.amqp.core.Message amqpMessage,
 			Channel channel, Message<?> message) throws Exception { // NOSONAR
 
-		boolean projectionUsed = amqpMessage.getMessageProperties().isProjectionUsed();
+		boolean projectionUsed = amqpMessage == null ? false : amqpMessage.getMessageProperties().isProjectionUsed();
 		if (projectionUsed) {
 			amqpMessage.getMessageProperties().setProjectionUsed(false);
 		}

--- a/x
+++ b/x
@@ -1,0 +1,3 @@
+https://github.com/spring-projects/spring-kafka/blob/bd154520a5cc7454748b4ca24e692d82594edd6a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java#L2743-L2754
+
+

--- a/x
+++ b/x
@@ -1,3 +1,0 @@
-https://github.com/spring-projects/spring-kafka/blob/bd154520a5cc7454748b4ca24e692d82594edd6a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java#L2743-L2754
-
-


### PR DESCRIPTION
Don't Log Converted Message With Projection

`toString()` cannot be invoked on the payload proxy created by
the projection factory.

Increase memory for builds.
