### PR TITLE
Add ReturnsCallback XML Configuration

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/TemplateParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,8 @@ class TemplateParser extends AbstractSingleBeanDefinitionParser {
 
 	private static final String RETURN_CALLBACK_ATTRIBUTE = "return-callback";
 
+	private static final String RETURNS_CALLBACK_ATTRIBUTE = "returns-callback";
+
 	private static final String CONFIRM_CALLBACK_ATTRIBUTE = "confirm-callback";
 
 	private static final String CORRELATION_KEY = "correlation-key";
@@ -122,6 +124,7 @@ class TemplateParser extends AbstractSingleBeanDefinitionParser {
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, USE_TEMPORARY_REPLY_QUEUES_ATTRIBUTE);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, REPLY_ADDRESS_ATTRIBUTE);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, RETURN_CALLBACK_ATTRIBUTE);
+		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, RETURNS_CALLBACK_ATTRIBUTE);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, CONFIRM_CALLBACK_ATTRIBUTE);
 		NamespaceUtils.setValueIfAttributeDefined(builder, element, CORRELATION_KEY);
 		NamespaceUtils.setReferenceIfAttributeDefined(builder, element, RETRY_TEMPLATE);

--- a/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit.xsd
+++ b/spring-rabbit/src/main/resources/org/springframework/amqp/rabbit/config/spring-rabbit.xsd
@@ -1285,7 +1285,7 @@
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 	When 'true' sets the mandatory flag on basic.publish; only applies if
-	a 'return-callback' is provided. Mutually exclusive with 'mandatory-expression'.
+	a 'return-callback' or a 'returns-callback' is provided. Mutually exclusive with 'mandatory-expression'.
 	Defaults to 'false'.
 					]]></xsd:documentation>
 				</xsd:annotation>
@@ -1299,7 +1299,7 @@
 	A SpEL expression to be evaluated against each request message to determine a 'mandatory' boolean value.
 	The BeanFactoryResolver is available too, if the RabbitTemplate is used from Spring Context,
 	allowing for expressions such as '@myBean.isMandatory(#root)`.
-	Only applies if a 'return-callback' is provided. Mutually exclusive with 'mandatory'.
+	Only applies if a 'return-callback' or 'returns-callback' is provided. Mutually exclusive with 'mandatory'.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -1309,10 +1309,26 @@
 	A reference to an implementation of RabbitTemplate.ReturnCallback - invoked if
 	a return is received for a message published with mandatory set
 	that couldn't be delivered according to the semantics of that option.
+	Please do not use this with 'returns-callback' attribute at the same time.
 					]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.amqp.core.RabbitTemplate.ReturnCallback" />
+							<tool:expected-type type="org.springframework.amqp.core.RabbitTemplate.ReturnCallback"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="returns-callback" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to an implementation of RabbitTemplate.ReturnsCallback - invoked if
+	a return is received for a message published with mandatory set
+	that couldn't be delivered according to the semantics of that option.
+	Please do not use this with 'return-callback' attribute at the same time.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.amqp.core.RabbitTemplate.ReturnsCallback"/>
 						</tool:annotation>
 					</xsd:appinfo>
 				</xsd:annotation>
@@ -1326,7 +1342,7 @@
 					]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.amqp.core.RabbitTemplate.ConfirmCallback" />
+							<tool:expected-type type="org.springframework.amqp.core.RabbitTemplate.ConfirmCallback"/>
 						</tool:annotation>
 					</xsd:appinfo>
 				</xsd:annotation>

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/config/TemplateParserTests-context.xml
@@ -34,7 +34,7 @@
 
 	<rabbit:template id="withCallbacks" connection-factory="connectionFactory"
 					 direct-reply-to-container="false"
-					 mandatory="true" return-callback="rcb" confirm-callback="ccb"/>
+					 mandatory="true" returns-callback="rcb" confirm-callback="ccb"/>
 
 	<rabbit:template id="withMandatoryExpression" connection-factory="connectionFactory"
 					 mandatory-expression="'true'"
@@ -42,7 +42,7 @@
 					 receive-connection-factory-selector-expression="'foo'"/>
 
 	<bean id="rcb" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.amqp.rabbit.core.RabbitTemplate$ReturnCallback"/>
+		<constructor-arg value="org.springframework.amqp.rabbit.core.RabbitTemplate$ReturnsCallback"/>
 	</bean>
 
 	<bean id="ccb" class="org.mockito.Mockito" factory-method="mock">


### PR DESCRIPTION
I made this modification because of the RabbitTemplate.ReturnCallback has been deprecated, and the ```<rabbit:template/>``` element did not have the attribute of  RabbitTemplate.ReturnsCallback.