### PR TITLE
GH-1409: Fix Nacks for Async Replies

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageListener.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,16 @@ public interface MessageListener {
 	 */
 	default void containerAckMode(AcknowledgeMode mode) {
 		// NOSONAR - empty
+	}
+
+	/**
+	 * Return true if this listener is request/reply and the replies are
+	 * async.
+	 * @return true for async replies.
+	 * @since 2.2.21
+	 */
+	default boolean isAsyncReplies() {
+		return false;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1227,7 +1227,6 @@ public abstract class AbstractMessageListenerContainer extends RabbitAccessor
 		}
 		if (this.isAsyncReplies() && !AcknowledgeMode.MANUAL.equals(this.acknowledgeMode)) {
 			this.acknowledgeMode = AcknowledgeMode.MANUAL;
-			logger.warn("Async replies require AcknowledgeMode.MANUAL, forced");
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -777,9 +777,7 @@ public class BlockingQueueConsumer {
 	/**
 	 * Perform a rollback, handling rollback exceptions properly.
 	 * @param ex the thrown application exception or error
-	 * @deprecated in favor of {@link #rollbackOnExceptionIfNecessary(Throwable, long)}
 	 */
-	@Deprecated
 	public void rollbackOnExceptionIfNecessary(Throwable ex) {
 		rollbackOnExceptionIfNecessary(ex, -1);
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1214,7 +1214,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 							}
 						}
 					}
-					getChannel().basicNack(deliveryTag, true,
+					getChannel().basicNack(deliveryTag, !isAsyncReplies(),
 							ContainerUtils.shouldRequeue(isDefaultRequeueRejected(), e, this.logger));
 				}
 				catch (IOException e1) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -982,6 +982,9 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 						}
 						break;
 					}
+					long tagToRollback = isAsyncReplies()
+							? message.getMessageProperties().getDeliveryTag()
+							: -1;
 					if (getTransactionManager() != null) {
 						if (getTransactionAttribute().rollbackOn(ex)) {
 							RabbitResourceHolder resourceHolder = (RabbitResourceHolder) TransactionSynchronizationManager
@@ -994,7 +997,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 								 * If we don't actually have a transaction, we have to roll back
 								 * manually. See prepareHolderForRollback().
 								 */
-								consumer.rollbackOnExceptionIfNecessary(ex);
+								consumer.rollbackOnExceptionIfNecessary(ex, tagToRollback);
 							}
 							throw ex; // encompassing transaction will handle the rollback.
 						}
@@ -1006,7 +1009,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 						}
 					}
 					else {
-						consumer.rollbackOnExceptionIfNecessary(ex);
+						consumer.rollbackOnExceptionIfNecessary(ex, tagToRollback);
 						throw ex;
 					}
 				}
@@ -1054,7 +1057,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 						 * If we don't actually have a transaction, we have to roll back
 						 * manually. See prepareHolderForRollback().
 						 */
-						consumer.rollbackOnExceptionIfNecessary(ex);
+						consumer.rollbackOnExceptionIfNecessary(ex, -1);
 					}
 					throw ex; // encompassing transaction will handle the rollback.
 				}
@@ -1065,7 +1068,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				}
 			}
 			else {
-				consumer.rollbackOnExceptionIfNecessary(ex);
+				consumer.rollbackOnExceptionIfNecessary(ex, -1);
 				throw ex;
 			}
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1057,7 +1057,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 						 * If we don't actually have a transaction, we have to roll back
 						 * manually. See prepareHolderForRollback().
 						 */
-						consumer.rollbackOnExceptionIfNecessary(ex, -1);
+						consumer.rollbackOnExceptionIfNecessary(ex);
 					}
 					throw ex; // encompassing transaction will handle the rollback.
 				}
@@ -1068,7 +1068,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 				}
 			}
 			else {
-				consumer.rollbackOnExceptionIfNecessary(ex, -1);
+				consumer.rollbackOnExceptionIfNecessary(ex);
 				throw ex;
 			}
 		}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -21,7 +21,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
-import java.util.function.Consumer;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -56,7 +55,6 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.concurrent.ListenableFuture;
 
 import com.rabbitmq.client.Channel;
-import reactor.core.publisher.Mono;
 
 /**
  * An abstract {@link org.springframework.amqp.core.MessageListener} adapter providing the
@@ -81,7 +79,7 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 
 	private static final ParserContext PARSER_CONTEXT = new TemplateParserContext("!{", "}");
 
-	private static final boolean monoPresent = // NOSONAR - lower case
+	static final boolean monoPresent = // NOSONAR - lower case, protected
 			ClassUtils.isPresent("reactor.core.publisher.Mono", ChannelAwareMessageListener.class.getClassLoader());
 
 	/**
@@ -691,21 +689,6 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 
 		public Object getResult() {
 			return this.result;
-		}
-
-	}
-
-	private static class MonoHandler { // NOSONAR - pointless to name it ..Utils|Helper
-
-		static boolean isMono(Object result) {
-			return result instanceof Mono;
-		}
-
-		@SuppressWarnings("unchecked")
-		static void subscribe(Object returnValue, Consumer<? super Object> success,
-				Consumer<? super Throwable> failure, Runnable completeConsumer) {
-
-			((Mono<? super Object>) returnValue).subscribe(success, failure, completeConsumer);
 		}
 
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -107,6 +107,11 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 		return this.handlerAdapter;
 	}
 
+	@Override
+	public boolean isAsyncReplies() {
+		return this.handlerAdapter.isAsyncReplies();
+	}
+
 	/**
 	 * Set the {@link AmqpHeaderMapper} implementation to use to map the standard
 	 * AMQP headers. By default, a {@link org.springframework.amqp.support.SimpleAmqpHeaderMapper

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MonoHandler.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MonoHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import java.util.function.Consumer;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Class to prevent direct links to {@link Mono}.
+ * @author Gary Russell
+ * @since 2.2.21
+ */
+final class MonoHandler { // NOSONAR - pointless to name it ..Utils|Helper
+
+	private MonoHandler() {
+	}
+
+	static boolean isMono(Object result) {
+		return result instanceof Mono;
+	}
+
+	@SuppressWarnings("unchecked")
+	static void subscribe(Object returnValue, Consumer<? super Object> success,
+			Consumer<? super Throwable> failure, Runnable completeConsumer) {
+
+		((Mono<? super Object>) returnValue).subscribe(success, failure, completeConsumer);
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/AsyncReplyToTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/AsyncReplyToTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessagePropertiesBuilder;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.config.DirectRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.SettableListenableFuture;
+
+import com.rabbitmq.client.Channel;
+
+/**
+ * @author Gary Russell
+ * @since 2.2.21
+ *
+ */
+@SpringJUnitConfig
+@RabbitAvailable(queues = { "async1", "async2" })
+public class AsyncReplyToTests {
+
+	@Test
+	void ackSingleWhenFatalSMLC(@Autowired Config config, @Autowired RabbitListenerEndpointRegistry registry,
+			@Autowired RabbitTemplate template, @Autowired RabbitAdmin admin) throws IOException, InterruptedException {
+
+		template.send("async1", MessageBuilder.withBody("\"foo\"".getBytes()).andProperties(
+				MessagePropertiesBuilder.newInstance()
+						.setContentType("application/json")
+						.setReplyTo("nowhere")
+						.build())
+				.build());
+		template.send("async1", MessageBuilder.withBody("junk".getBytes()).andProperties(
+				MessagePropertiesBuilder.newInstance()
+						.setContentType("application/json")
+						.setReplyTo("nowhere")
+						.build())
+				.build());
+		assertThat(config.smlcLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		registry.getListenerContainer("smlc").stop();
+		assertThat(admin.getQueueInfo("async1").getMessageCount()).isEqualTo(1);
+	}
+
+	 @Test
+	 void ackSingleWhenFatalDMLC(@Autowired Config config, @Autowired RabbitListenerEndpointRegistry registry,
+			@Autowired RabbitTemplate template, @Autowired RabbitAdmin admin) throws IOException, InterruptedException {
+
+		template.send("async2", MessageBuilder.withBody("\"foo\"".getBytes()).andProperties(
+				MessagePropertiesBuilder.newInstance()
+						.setContentType("application/json")
+						.setReplyTo("nowhere")
+						.build())
+				.build());
+		template.send("async2", MessageBuilder.withBody("junk".getBytes()).andProperties(
+				MessagePropertiesBuilder.newInstance()
+						.setContentType("application/json")
+						.setReplyTo("nowhere")
+						.build())
+				.build());
+		assertThat(config.dmlcLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		registry.getListenerContainer("dmlc").stop();
+		assertThat(admin.getQueueInfo("async2").getMessageCount()).isEqualTo(1);
+	 }
+
+	@Configuration
+	@EnableRabbit
+	static class Config {
+
+		volatile CountDownLatch smlcLatch = new CountDownLatch(1);
+
+		volatile CountDownLatch dmlcLatch = new CountDownLatch(1);
+
+		@RabbitListener(id = "smlc", queues = "async1", containerFactory = "smlcf")
+		ListenableFuture<String> listen1(String in, Channel channel) {
+			return new SettableListenableFuture<>();
+		}
+
+		@RabbitListener(id = "dmlc", queues = "async2", containerFactory = "dmlcf")
+		ListenableFuture<String> listen2(String in, Channel channel) {
+			return new SettableListenableFuture<>();
+		}
+
+		@Bean
+		MessageConverter converter() {
+			return new Jackson2JsonMessageConverter();
+		}
+
+		@Bean
+		ConnectionFactory cf() throws IOException, TimeoutException {
+			return new CachingConnectionFactory(RabbitAvailableCondition.getBrokerRunning().getConnectionFactory());
+		}
+
+		@Bean
+		SimpleRabbitListenerContainerFactory smlcf(ConnectionFactory cf, MessageConverter converter) {
+			SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+			factory.setConnectionFactory(cf);
+			factory.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+			factory.setMessageConverter(converter);
+			factory.setErrorHandler(new ConditionalRejectingErrorHandler() {
+
+				@Override
+				public void handleError(Throwable t) {
+					smlcLatch.countDown();
+					super.handleError(t);
+				}
+
+			});
+			return factory;
+		}
+
+		@Bean
+		DirectRabbitListenerContainerFactory dmlcf(ConnectionFactory cf, MessageConverter converter) {
+			DirectRabbitListenerContainerFactory factory = new DirectRabbitListenerContainerFactory();
+			factory.setConnectionFactory(cf);
+			factory.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+			factory.setMessageConverter(converter);
+			factory.setErrorHandler(new ConditionalRejectingErrorHandler() {
+
+				@Override
+				public void handleError(Throwable t) {
+					dmlcLatch.countDown();
+					super.handleError(t);
+				}
+
+			});
+			return factory;
+		}
+
+		@Bean
+		RabbitTemplate template(ConnectionFactory cf) {
+			return new RabbitTemplate(cf);
+		}
+
+		@Bean
+		RabbitAdmin admin(ConnectionFactory cf) {
+			return new RabbitAdmin(cf);
+		}
+
+	}
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -258,7 +258,7 @@ public class BlockingQueueConsumerTests {
 		Set<Long> deliveryTags = new HashSet<Long>();
 		deliveryTags.add(1L);
 		dfa.setPropertyValue("deliveryTags", deliveryTags);
-		blockingQueueConsumer.rollbackOnExceptionIfNecessary(ex, -1);
+		blockingQueueConsumer.rollbackOnExceptionIfNecessary(ex);
 		verify(channel).basicNack(1L, true, expectedRequeue);
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -258,7 +258,7 @@ public class BlockingQueueConsumerTests {
 		Set<Long> deliveryTags = new HashSet<Long>();
 		deliveryTags.add(1L);
 		dfa.setPropertyValue("deliveryTags", deliveryTags);
-		blockingQueueConsumer.rollbackOnExceptionIfNecessary(ex);
+		blockingQueueConsumer.rollbackOnExceptionIfNecessary(ex, -1);
 		verify(channel).basicNack(1L, true, expectedRequeue);
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -727,6 +727,7 @@ public class SimpleMessageListenerContainerTests {
 		verify(channel).basicAck(2, true);
 		container.stop();
 		verify(listener).containerAckMode(AcknowledgeMode.AUTO);
+		verify(listener).isAsyncReplies();
 		verifyNoMoreInteractions(listener);
 	}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3535,6 +3535,9 @@ If the async result is completed with an `AmqpRejectAndDontRequeueException`, th
 If the container's `defaultRequeueRejected` property is `false`, you can override that by setting the future's exception to a `ImmediateRequeueException` and the message will be requeued.
 If some exception occurs within the listener method that prevents creation of the async result object, you MUST catch that exception and return an appropriate return object that will cause the message to be acknowledged or requeued.
 
+Starting with versions 2.2.21, 2.3.13, 2.4.1, the `AcknowledgeMode` will be automatically set the `MANUAL` when async return types are detected.
+In addition, incoming messages with fatal exceptions will be negatively acknowledged individually, previously any prior unacknowledged message were also negatively acknowledged.
+
 [[threading]]
 ===== Threading and Asynchronous Consumers
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1409

Normally, when message has a fatal exception (such as message conversion)
`basicNack` with `multiple` true is used, to nack any previously unacked
messages (e.g. when using batch size to limit the ack traffic).
Even when using manual acks, fatal exceptions are nacked by the container
because the user does not have access to the message.

However, when using async replies, this has the side effect of nacking
unprocessed messages.

Detect whether async replies are being used and only nack individual
records that cause fatal exceptions.

Also, coerce the `AcknowledgeMode` to `MANUAL` for such listners.

Add a test for both containers; send a good message followed by a
bad one without actually completing the reply future.
After the exception occurs and the container is stopped, there should
be one messag in the queue.

**cherry-pick to 2.3.x, 2.2.x**
