### PR TITLE
GH-1412: Fix Messaging Template

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,10 +111,9 @@ public class RabbitMessagingTemplate extends AbstractMessagingTemplate<String>
 	}
 
 	/**
-	 * When true, use the underlying {@link RabbitTemplate}'s defaultReceiveQueue property (if configured)
-	 * for receive only methods
-	 * instead of the {@link #setDefaultDestination(String) defaultDestination} configured
-	 * in this template. Set this to true to use the template's queue instead.
+	 * When true, use the underlying {@link RabbitTemplate}'s defaultReceiveQueue property
+	 * (if configured) for receive only methods instead of the {@code defaultDestination}
+	 * configured in this template. Set this to true to use the template's queue instead.
 	 * Default false, but will be true in a future release.
 	 * @param useTemplateDefaultReceiveQueue true to use the template's queue.
 	 * @since 2.2.22

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -349,6 +349,16 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 	}
 
 	/**
+	 * Return the configured default receive queue.
+	 * @return the queue or null if not configured.
+	 * @since 2.2.22
+	 */
+	@Nullable
+	public String getDefaultReceiveQueue() {
+		return this.defaultReceiveQueue;
+	}
+
+	/**
 	 * The encoding to use when converting between byte arrays and Strings in message properties.
 	 *
 	 * @param encoding the encoding to set

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitMessagingTemplateTests.java
@@ -257,6 +257,20 @@ public class RabbitMessagingTemplateTests {
 	}
 
 	@Test
+	public void receiveDefaultDestinationOverride() {
+		messagingTemplate.setDefaultDestination("defaultDest");
+		messagingTemplate.setUseTemplateDefaultReceiveQueue(true);
+
+		org.springframework.amqp.core.Message amqpMsg = createAmqpTextMessage();
+		given(rabbitTemplate.getDefaultReceiveQueue()).willReturn("default");
+		given(rabbitTemplate.receive("default")).willReturn(amqpMsg);
+
+		Message<?> message = messagingTemplate.receive();
+		verify(rabbitTemplate).receive("default");
+		assertTextMessage(message);
+	}
+
+	@Test
 	public void receiveNoDefaultSet() {
 		assertThatIllegalStateException()
 			.isThrownBy(() -> messagingTemplate.receive());


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1412

The use of the `defaultDestination` is not correct when the template is
used for both sends and receives because it is a queue name for receives
and a routing key for sends.

Add a new option to use the template's configured default receive queue
for receive only methods. False by default to avoid a breaking change;
it should be true by default in a future release.

**cherry-pick to 2.3.x, 2.2.x**