### PR TITLE
GH-1415: Fix Use of Routing Connection Factory

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1078,10 +1078,10 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 					(AbstractRoutingConnectionFactory) getConnectionFactory();
 			Object lookupKey;
 			if (rootObject != null) {
-				lookupKey = this.sendConnectionFactorySelectorExpression.getValue(this.evaluationContext, rootObject);
+				lookupKey = expression.getValue(this.evaluationContext, rootObject);
 			}
 			else {
-				lookupKey = this.sendConnectionFactorySelectorExpression.getValue(this.evaluationContext);
+				lookupKey = expression.getValue(this.evaluationContext);
 			}
 			if (lookupKey != null) {
 				ConnectionFactory connectionFactory = routingConnectionFactory.getTargetConnectionFactory(lookupKey);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -371,24 +371,33 @@ public class RabbitTemplateTests {
 	@SuppressWarnings("unchecked")
 	public void testRoutingConnectionFactory() throws Exception {
 		org.springframework.amqp.rabbit.connection.ConnectionFactory connectionFactory1 =
-				Mockito.mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+				mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
 		org.springframework.amqp.rabbit.connection.ConnectionFactory connectionFactory2 =
-				Mockito.mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+				mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		org.springframework.amqp.rabbit.connection.ConnectionFactory connectionFactory3 =
+				mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		org.springframework.amqp.rabbit.connection.ConnectionFactory connectionFactory4 =
+				mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
 		Map<Object, org.springframework.amqp.rabbit.connection.ConnectionFactory> factories =
 				new HashMap<Object, org.springframework.amqp.rabbit.connection.ConnectionFactory>(2);
 		factories.put("foo", connectionFactory1);
 		factories.put("bar", connectionFactory2);
+		factories.put("baz", connectionFactory3);
+		factories.put("qux", connectionFactory4);
 
 
 		AbstractRoutingConnectionFactory connectionFactory = new SimpleRoutingConnectionFactory();
 		connectionFactory.setTargetConnectionFactories(factories);
 
 		final RabbitTemplate template = new RabbitTemplate(connectionFactory);
-		Expression expression = new SpelExpressionParser()
+		Expression sendExpression = new SpelExpressionParser()
 				.parseExpression("T(org.springframework.amqp.rabbit.core.RabbitTemplateTests)" +
 						".LOOKUP_KEY_COUNT.getAndIncrement() % 2 == 0 ? 'foo' : 'bar'");
-		template.setSendConnectionFactorySelectorExpression(expression);
-		template.setReceiveConnectionFactorySelectorExpression(expression);
+		template.setSendConnectionFactorySelectorExpression(sendExpression);
+		Expression receiveExpression = new SpelExpressionParser()
+				.parseExpression("T(org.springframework.amqp.rabbit.core.RabbitTemplateTests)" +
+						".LOOKUP_KEY_COUNT.getAndIncrement() % 2 == 0 ? 'baz' : 'qux'");
+		template.setReceiveConnectionFactorySelectorExpression(receiveExpression);
 
 		for (int i = 0; i < 3; i++) {
 			try {
@@ -411,8 +420,10 @@ public class RabbitTemplateTests {
 			}
 		}
 
-		Mockito.verify(connectionFactory1, Mockito.times(5)).createConnection();
-		Mockito.verify(connectionFactory2, Mockito.times(4)).createConnection();
+		Mockito.verify(connectionFactory1, times(2)).createConnection();
+		Mockito.verify(connectionFactory2, times(1)).createConnection();
+		Mockito.verify(connectionFactory3, times(3)).createConnection();
+		Mockito.verify(connectionFactory4, times(3)).createConnection();
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1415

The `sendConnectionFactorySelectorExpression` was being used for
receive methods instead of `receiveConnectionFactorySelectorExpression`.

**cherry-pick to 2.3.x, 2.2.x**
