### PR TITLE
fix multi-rabbit example

### DIFF
--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -6728,7 +6728,7 @@ public class Application {
     }
 
     @Bean
-    RabbitTemplate template(RoutingConnectionFactory rcf) {
+    RabbitTemplate template(SimpleRoutingConnectionFactory rcf) {
         return new RabbitTemplate(rcf);
     }
 


### PR DESCRIPTION
RoutingConnectionFactory is not a ConnectionFactory

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
