### PR TITLE
GH-1422: @RabbitListener: Fix Broker-Named Queues

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,6 +148,8 @@ public @interface RabbitListener {
 	 * application context, the queue will be declared on the broker with default
 	 * binding (default exchange with the queue name as the routing key).
 	 * Mutually exclusive with {@link #bindings()} and {@link #queues()}.
+	 * NOTE: Broker-named queues cannot be declared this way, they must be defined
+	 * as beans (with an empty string for the name).
 	 * @return the queue(s) to declare.
 	 * @see org.springframework.amqp.rabbit.listener.MessageListenerContainer
 	 * @since 2.0
@@ -186,6 +188,8 @@ public @interface RabbitListener {
 	 * Array of {@link QueueBinding}s providing the listener's queue names, together
 	 * with the exchange and optional binding information.
 	 * Mutually exclusive with {@link #queues()} and {@link #queuesToDeclare()}.
+	 * NOTE: Broker-named queues cannot be declared this way, they must be defined
+	 * as beans (with an empty string for the name).
 	 * @return the bindings.
 	 * @see org.springframework.amqp.rabbit.listener.MessageListenerContainer
 	 * @since 1.5

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,9 +187,9 @@ public class RabbitListenerAnnotationBeanPostProcessorTests {
 		RabbitListenerContainerTestFactory factory = context.getBean(RabbitListenerContainerTestFactory.class);
 		assertThat(factory.getListenerContainers().size()).as("one container should have been registered").isEqualTo(1);
 		RabbitListenerEndpoint endpoint = factory.getListenerContainers().get(0).getEndpoint();
-		final Iterator<String> iterator = ((AbstractRabbitListenerEndpoint) endpoint).getQueueNames().iterator();
-		assertThat(iterator.next()).isEqualTo("testQueue");
-		assertThat(iterator.next()).isEqualTo("secondQueue");
+		final Iterator<Queue> iterator = ((AbstractRabbitListenerEndpoint) endpoint).getQueues().iterator();
+		assertThat(iterator.next().getName()).isEqualTo("testQueue");
+		assertThat(iterator.next().getName()).isEqualTo("secondQueue");
 
 		context.close();
 	}
@@ -218,9 +218,9 @@ public class RabbitListenerAnnotationBeanPostProcessorTests {
 		RabbitListenerContainerTestFactory factory = context.getBean(RabbitListenerContainerTestFactory.class);
 		assertThat(factory.getListenerContainers().size()).as("one container should have been registered").isEqualTo(1);
 		RabbitListenerEndpoint endpoint = factory.getListenerContainers().get(0).getEndpoint();
-		final Iterator<String> iterator = ((AbstractRabbitListenerEndpoint) endpoint).getQueueNames().iterator();
-		assertThat(iterator.next()).isEqualTo("testQueue");
-		assertThat(iterator.next()).isEqualTo("secondQueue");
+		final Iterator<Queue> iterator = ((AbstractRabbitListenerEndpoint) endpoint).getQueues().iterator();
+		assertThat(iterator.next().getName()).isEqualTo("testQueue");
+		assertThat(iterator.next().getName()).isEqualTo("secondQueue");
 
 		context.close();
 	}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -2340,7 +2340,8 @@ public class MyService {
 
 In the first example, a queue `myQueue` is declared automatically (durable) together with the exchange, if needed,
 and bound to the exchange with the routing key.
-In the second example, an anonymous (exclusive, auto-delete) queue is declared and bound.
+In the second example, an anonymous (exclusive, auto-delete) queue is declared and bound; the queue name is created by the framework using the `Base64UrlNamingStrategy`.
+You cannot declare broker-named queues using this technique; they need to be declared as bean definitions; see <<containers-and-broker-named-queues>>.
 Multiple `QueueBinding` entries can be provided, letting the listener listen to multiple queues.
 In the third example, a queue with the name retrieved from property `my.queue` is declared, if necessary, with the default binding to the default exchange using the queue name as the routing key.
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1422

Broker-named queues did not work with `@RabbitListener` because the BPP
only passed the name of the queue bean, not the bean itself, into the
endpoint.

Support bean injection; fall back to the previous behavior if a mixture
of beans and names are encountered (the containers don't support both
types of configuration).

Add a note to the javadoc to indicate that broker-named queues are not
supported via `queuesToDeclare` and `bindings` properties; such queues
must be declared as discrete beans.

<!--
Thanks for contributing to Spring AMQP. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
