### PR TITLE
add checkConfirmsAndReturns in addTargetConnectionFactory

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactory.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Josh Chappelle
  * @author Gary Russell
+ * @author Leonardo Ferreira
  * @since 1.3
  */
 public abstract class AbstractRoutingConnectionFactory implements ConnectionFactory, RoutingConnectionFactory,

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,6 +238,8 @@ public abstract class AbstractRoutingConnectionFactory implements ConnectionFact
 		for (ConnectionListener listener : this.connectionListeners) {
 			connectionFactory.addConnectionListener(listener);
 		}
+
+		checkConfirmsAndReturns(connectionFactory);
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactoryTests.java
@@ -17,7 +17,7 @@
 package org.springframework.amqp.rabbit.connection;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
@@ -52,6 +52,7 @@ import com.rabbitmq.client.Channel;
  * @author Artem Bilan
  * @author Josh Chappelle
  * @author Gary Russell
+ * @author Leonardo Ferreira
  * @since 1.3
  */
 public class RoutingConnectionFactoryTests {
@@ -335,12 +336,8 @@ public class RoutingConnectionFactoryTests {
 
 		routingFactory.addTargetConnectionFactory("1", Mockito.mock(ConnectionFactory.class));
 
-		try {
-			routingFactory.afterPropertiesSet();
-		}
-		catch (Exception e) {
-			fail("afterPropertiesSet should not throw any exception after addTargetConnectionFactory", e);
-		}
+		assertThatNoException()
+				.isThrownBy(routingFactory::afterPropertiesSet);
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RoutingConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.connection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
@@ -321,6 +322,25 @@ public class RoutingConnectionFactoryTests {
 		assertThat(connectionMakerKey.get()).isEqualTo("xxx[amq.rabbitmq.reply-to]");
 		assertThat(connectionMakerKey2.get()).isEqualTo("xxx[amq.rabbitmq.reply-to]");
 		assertThat(SimpleResourceHolder.unbind(connectionFactory)).isEqualTo("foo");
+	}
+
+	@Test
+	void afterPropertiesSetShouldNotThrowAnyExceptionAfterAddTargetConnectionFactory() throws Exception {
+		AbstractRoutingConnectionFactory routingFactory = new AbstractRoutingConnectionFactory() {
+			@Override
+			protected Object determineCurrentLookupKey() {
+				return null;
+			}
+		};
+
+		routingFactory.addTargetConnectionFactory("1", Mockito.mock(ConnectionFactory.class));
+
+		try {
+			routingFactory.afterPropertiesSet();
+		}
+		catch (Exception e) {
+			fail("afterPropertiesSet should not throw any exception after addTargetConnectionFactory", e);
+		}
 	}
 
 }


### PR DESCRIPTION
There is a little inconsistency in `AbstractRoutingConnectionFactory` that this PR aims to fix.

```
@Bean
ConnectionFactory connectionFactory() {
    return new MyAbstractRoutingConnectionFactory(new HashMap<>() {{
        put("first", newPooledChannelConnectionFactory());
        put("second", newCachingConnectionFactory());
    }});
}

static class MyAbstractRoutingConnectionFactory extends AbstractRoutingConnectionFactory {

    MyAbstractRoutingConnectionFactory(final Map<Object, ConnectionFactory> factories) {
        factories.forEach(this::addTargetConnectionFactory);
    }

    @Override
    protected Object determineCurrentLookupKey() {
        return null;
    }

}
```

in this case, `AbstractRoutingConnectionFactory#afterPropertiesSet` throw a `java.lang.IllegalArgumentException: At least one target factory (or default) is required` because the propety `confirms` is null (the method `addTargetConnectionFactory` doesn't call `checkConfirmsAndReturns` that fill this field);