### PR TITLE
Fix close errors on PooledChannelConnectionFactory

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ChannelProxy.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ChannelProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.amqp.rabbit.connection;
 
+import org.springframework.aop.RawTargetAccess;
+
 import com.rabbitmq.client.Channel;
 
 /**
@@ -24,9 +26,10 @@ import com.rabbitmq.client.Channel;
  *
  * @author Mark Pollack
  * @author Gary Russell
+ * @author Leonardo Ferreira
  * @see CachingConnectionFactory
  */
-public interface ChannelProxy extends Channel {
+public interface ChannelProxy extends Channel, RawTargetAccess {
 
 	/**
 	 * Return the target Channel of this proxy.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PooledChannelConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/PooledChannelConnectionFactory.java
@@ -292,7 +292,12 @@ public class PooledChannelConnectionFactory extends AbstractConnectionFactory im
 
 			@Override
 			public void destroyObject(PooledObject<Channel> p) throws Exception {
-				p.getObject().close();
+				Channel channel = p.getObject();
+				if (channel instanceof ChannelProxy) {
+					channel = ((ChannelProxy) channel).getTargetChannel();
+				}
+
+				ConnectionWrapper.this.physicalClose(channel);
 			}
 
 			@Override


### PR DESCRIPTION
Hey guys, there is a bug in the `PooledChannelConnectionFactory::ConnectionWrapper::ChannelFactory#destroyObject` that this PR aims to solve.

The method `destroyObject` is called by the eviction process of Apache Pool2, but it tries to do a logical close that puts it back on the pool causing a `java.lang.IllegalStateException: Returned object not currently part of this pool` and object lost (abandoned).
