### PR TITLE
GH-1439: Fix Memory Leak with Misconfiguration

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
@@ -867,9 +867,11 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 	}
 
 	@Test
-	void justReturns() {
+	void justReturns() throws InterruptedException {
 		CorrelationData correlationData = new CorrelationData();
+		CountDownLatch latch = new CountDownLatch(1);
 		this.templateWithReturnsEnabled.setReturnsCallback(returned -> {
+			latch.countDown();
 		});
 		this.templateWithReturnsEnabled.setConfirmCallback((correlationData1, ack, cause) -> {
 			// has callback but factory is not enabled
@@ -887,6 +889,9 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 				.extracting(map -> map.values().iterator().next())
 				.asInstanceOf(InstanceOfAssertFactories.MAP)
 				.isEmpty();
+
+		this.templateWithReturnsEnabled.convertAndSend("", "___JUNK___", "foo", correlationData);
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 }


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1439

Do not store pending confirms/returns if `RabbitTemplate` has confirms
enabled but the factory does not support confirms.

**cherry-pick to 2.4.x, 2.3.x**

Suggest review with `?w=1`