### PR TITLE
Fix typo in amqp.adoc

### DIFF
--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -514,7 +514,7 @@ You can use this exception in the `RetryPolicy` to recover the operation after s
 ===== Configuring the Underlying Client Connection Factory
 
 The `CachingConnectionFactory` uses an instance of the Rabbit client `ConnectionFactory`.
-A number of configuration properties are passed through (`host, port, userName, password, requestedHeartBeat, and connectionTimeout` for example) when setting the equivalent property on the `CachingConnectionFactory`.
+A number of configuration properties are passed through (`host`, `port`, `userName`, `password`, `requestedHeartBeat`, and `connectionTimeout` for example) when setting the equivalent property on the `CachingConnectionFactory`.
 To set other properties (`clientProperties`, for example), you can define an instance of the Rabbit factory and provide a reference to it by using the appropriate constructor of the `CachingConnectionFactory`.
 When using the namespace (<<connections,as described earlier>>), you need to provide a reference to the configured factory in the `connection-factory` attribute.
 For convenience, a factory bean is provided to assist in configuring the connection factory in a Spring application context, as discussed in <<rabbitconnectionfactorybean-configuring-ssl,the next section>>.

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -364,7 +364,7 @@ A `ConnectionFactory` can be created quickly and conveniently by using the rabbi
 In most cases, this approach is preferable, since the framework can choose the best defaults for you.
 The created instance is a `CachingConnectionFactory`.
 Keep in mind that the default cache size for channels is 25.
-If you want more channels to be cachedm, set a larger value by setting the 'channelCacheSize' property.
+If you want more channels to be cached, set a larger value by setting the 'channelCacheSize' property.
 In XML it would look like as follows:
 
 ====


### PR DESCRIPTION
<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
Fixes a typo in the reference documentation.