### PR TITLE
Issue 1450: avoid NullPointerException which occurs during shutdown o…

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -212,7 +212,7 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	@Override
 	public void onApplicationEvent(ContextClosedEvent event) {
-		if (getApplicationContext() != null && getApplicationContext().equals(event.getApplicationContext())) {
+		if (event.getApplicationContext().equals(getApplicationContext())) {
 			this.contextStopped = true;
 		}
 		if (this.publisherConnectionFactory != null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -212,7 +212,7 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	@Override
 	public void onApplicationEvent(ContextClosedEvent event) {
-		if (getApplicationContext().equals(event.getApplicationContext())) {
+		if (getApplicationContext() != null && getApplicationContext().equals(event.getApplicationContext())) {
 			this.contextStopped = true;
 		}
 		if (this.publisherConnectionFactory != null) {


### PR DESCRIPTION
This is a proposal for fixing the issue described in issue [#1450 NullPointerException in org.springframework.amqp.rabbit.connection.AbstractConnectionFactory during shutdown of SpringBoot application](https://github.com/spring-projects/spring-amqp/issues/1450)