### PR TITLE
GH-1452: Close Connection in checkMissingQueues

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -554,7 +554,8 @@ public class BlockingQueueConsumer {
 					Connection connection = null; // NOSONAR - RabbitUtils
 					Channel channelForCheck = null;
 					try {
-						channelForCheck = this.connectionFactory.createConnection().createChannel(false);
+						connection = this.connectionFactory.createConnection();
+						channelForCheck = connection.createChannel(false);
 						channelForCheck.queueDeclarePassive(queueToCheck);
 						if (logger.isInfoEnabled()) {
 							logger.info("Queue '" + queueToCheck + "' is now available");


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1452

While not a problem with connection factories provided by the framework
(which all ignore `close()`) the code should properly close the connection
after use.

**cherry-pick to 2.4.x, 2.3.x**
