### PR TITLE
chore: remove redundant space is string representation

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/SimpleConnection.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/SimpleConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ public class SimpleConnection implements Connection, NetworkConnection {
 	public String toString() {
 		return "SimpleConnection@"
 				+ ObjectUtils.getIdentityHexString(this)
-				+ " [delegate=" + this.delegate + ", localPort= " + getLocalPort() + "]";
+				+ " [delegate=" + this.delegate + ", localPort=" + getLocalPort() + "]";
 	}
 
 }


### PR DESCRIPTION
Just a tiny fix of `toString`