### PR TITLE
GH-1467: Support Spring AOT for Native Image

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/aot/RabbitRuntimeHintsRegistrar.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/aot/RabbitRuntimeHintsRegistrar.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.aot;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.connection.ChannelProxy;
+import org.springframework.amqp.rabbit.connection.PublisherCallbackChannel;
+import org.springframework.aop.SpringProxy;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aot.hint.ProxyHints;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.aot.hint.support.RuntimeHintsUtils;
+import org.springframework.core.DecoratingProxy;
+import org.springframework.lang.Nullable;
+
+/**
+ * {@link RuntimeHintsRegistrar} for spring-rabbit.
+ *
+ * @author Gary Russell
+ * @since 3.0
+ *
+ */
+public class RabbitRuntimeHintsRegistrar implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(RuntimeHints hints, @Nullable	ClassLoader classLoader) {
+		RuntimeHintsUtils.registerAnnotation(hints, RabbitListener.class);
+		ProxyHints proxyHints = hints.proxies();
+		proxyHints.registerJdkProxy(ChannelProxy.class);
+		proxyHints.registerJdkProxy(ChannelProxy.class, PublisherCallbackChannel.class);
+		proxyHints.registerJdkProxy(builder ->
+				builder.proxiedInterfaces(TypeReference.of(
+						"org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer$ContainerDelegate"))
+						.proxiedInterfaces(SpringProxy.class, Advised.class, DecoratingProxy.class));
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/aot/package-info.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/aot/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Provides classes to support Spring AOT.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.amqp.rabbit.aot;

--- a/spring-rabbit/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-rabbit/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,1 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=org.springframework.amqp.rabbit.aot.RabbitRuntimeHintsRegistrar


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1467

Migrate proxy hints from spring-native.

Also add a proxy hint for `ChannelProxy` when it is also a `PublisherCallbackChannel`.
