### PR TITLE
GH-1474: Fix MessageProperties.lastInBatch

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,6 +138,15 @@ public class MessageProperties implements Serializable {
 
 	public void setHeader(String key, Object value) {
 		this.headers.put(key, value);
+	}
+
+	/**
+	 * Set headers.
+	 * @param headers the headers.
+	 * @since 2.4.7
+	 */
+	public void setHeaders(Map<String, Object> headers) {
+		this.headers.putAll(headers);
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/BatchingRabbitTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -261,8 +261,8 @@ public class BatchingRabbitTemplateTests {
 		if (asList) {
 			container.setMessageListener((BatchMessageListener) messages -> {
 				received.addAll(messages);
-				lastInBatch.add(false);
-				lastInBatch.add(true);
+				lastInBatch.add(messages.get(0).getMessageProperties().isLastInBatch());
+				lastInBatch.add(messages.get(1).getMessageProperties().isLastInBatch());
 				batchSize.set(messages.size());
 				latch.countDown();
 			});


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1474

When consuming the whole debatched batch as a list, all messages
had the `lastInBatch` property set to true.

Clone the message properties for the last record.

**cherry-pick to 2.4.x**
