### PR TITLE
GH-1473: Move RabbitFutures to Top Level Classes

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitConverterFuture.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitConverterFuture.java
@@ -28,6 +28,8 @@ import org.springframework.core.ParameterizedTypeReference;
  * A {@link RabbitFuture} with a return type of the template's
  * generic parameter.
  * @param <C> the type.
+ *
+ * @author Gary Russell
  * @since 2.4.7
  */
 public class RabbitConverterFuture<C> extends RabbitFuture<C> {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitConverterFuture.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitConverterFuture.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerContainer.ChannelHolder;
+import org.springframework.core.ParameterizedTypeReference;
+
+/**
+ * A {@link RabbitFuture} with a return type of the template's
+ * generic parameter.
+ * @param <C> the type.
+ * @since 1.6
+ */
+public class RabbitConverterFuture<C> extends RabbitFuture<C> {
+
+	private volatile ParameterizedTypeReference<C> returnType;
+
+	RabbitConverterFuture(String correlationId, Message requestMessage,
+			BiConsumer<String, ChannelHolder> canceler,
+			Function<RabbitFuture<?>, ScheduledFuture<?>> timeoutTaskFunction) {
+
+		super(correlationId, requestMessage, canceler, timeoutTaskFunction);
+	}
+
+	public ParameterizedTypeReference<C> getReturnType() {
+		return this.returnType;
+	}
+
+	public void setReturnType(ParameterizedTypeReference<C> returnType) {
+		this.returnType = returnType;
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitConverterFuture.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitConverterFuture.java
@@ -28,7 +28,7 @@ import org.springframework.core.ParameterizedTypeReference;
  * A {@link RabbitFuture} with a return type of the template's
  * generic parameter.
  * @param <C> the type.
- * @since 1.6
+ * @since 2.4.7
  */
 public class RabbitConverterFuture<C> extends RabbitFuture<C> {
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitFuture.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitFuture.java
@@ -27,6 +27,8 @@ import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerCont
 /**
  * Base class for {@link CompletableFuture}s returned by {@link AsyncRabbitTemplate2}.
  * @param <T> the type.
+ *
+ * @author Gary Russell
  * @since 2.4.7
  */
 public abstract class RabbitFuture<T> extends CompletableFuture<T> {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitFuture.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitFuture.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerContainer.ChannelHolder;
+
+/**
+ * Base class for {@link CompletableFuture}s returned by {@link AsyncRabbitTemplate2}.
+ * @param <T> the type.
+ * @since 2.4.7
+ */
+public abstract class RabbitFuture<T> extends CompletableFuture<T> {
+
+	private final String correlationId;
+
+	private final Message requestMessage;
+
+	private final BiConsumer<String, ChannelHolder> canceler;
+
+	private final Function<RabbitFuture<?>, ScheduledFuture<?>> timeoutTaskFunction;
+
+	private ScheduledFuture<?> timeoutTask;
+
+	private volatile CompletableFuture<Boolean> confirm;
+
+	private String nackCause;
+
+	private ChannelHolder channelHolder;
+
+	protected RabbitFuture(String correlationId, Message requestMessage, BiConsumer<String, ChannelHolder> canceler,
+			Function<RabbitFuture<?>, ScheduledFuture<?>> timeoutTaskFunction) {
+
+		this.correlationId = correlationId;
+		this.requestMessage = requestMessage;
+		this.canceler = canceler;
+		this.timeoutTaskFunction = timeoutTaskFunction;
+	}
+
+	void setChannelHolder(ChannelHolder channel) {
+		this.channelHolder = channel;
+	}
+
+	String getCorrelationId() {
+		return this.correlationId;
+	}
+
+	ChannelHolder getChannelHolder() {
+		return this.channelHolder;
+	}
+
+	Message getRequestMessage() {
+		return this.requestMessage;
+	}
+
+	@Override
+	public boolean cancel(boolean mayInterruptIfRunning) {
+		if (this.timeoutTask != null) {
+			this.timeoutTask.cancel(true);
+		}
+		this.canceler.accept(this.correlationId, this.channelHolder);
+		return super.cancel(mayInterruptIfRunning);
+	}
+
+	/**
+	 * When confirms are enabled contains a {@link CompletableFuture}
+	 * for the confirmation.
+	 * @return the future.
+	 */
+	public CompletableFuture<Boolean> getConfirm() {
+		return this.confirm;
+	}
+
+	void setConfirm(CompletableFuture<Boolean> confirm) {
+		this.confirm = confirm;
+	}
+
+	/**
+	 * When confirms are enabled and a nack is received, contains
+	 * the cause for the nack, if any.
+	 * @return the cause.
+	 */
+	public String getNackCause() {
+		return this.nackCause;
+	}
+
+	void setNackCause(String nackCause) {
+		this.nackCause = nackCause;
+	}
+
+	void startTimer() {
+		this.timeoutTask = this.timeoutTaskFunction.apply(this);
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitMessageFuture.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitMessageFuture.java
@@ -25,6 +25,8 @@ import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerCont
 
 /**
  * A {@link RabbitFuture} with a return type of {@link Message}.
+ *
+ * @author Gary Russell
  * @since 2.4.7
  */
 public class RabbitMessageFuture extends RabbitFuture<Message> {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitMessageFuture.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/RabbitMessageFuture.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerContainer.ChannelHolder;
+
+/**
+ * A {@link RabbitFuture} with a return type of {@link Message}.
+ * @since 2.4.7
+ */
+public class RabbitMessageFuture extends RabbitFuture<Message> {
+
+	RabbitMessageFuture(String correlationId, Message requestMessage, BiConsumer<String, ChannelHolder> canceler,
+			Function<RabbitFuture<?>, ScheduledFuture<?>> timeoutTaskFunction) {
+
+		super(correlationId, requestMessage, canceler, timeoutTaskFunction);
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/TimeoutTask.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/TimeoutTask.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit;
+
+import java.util.concurrent.ConcurrentMap;
+
+import org.springframework.amqp.core.AmqpReplyTimeoutException;
+import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.DirectReplyToMessageListenerContainer.ChannelHolder;
+import org.springframework.lang.Nullable;
+
+/**
+ * A {@link Runnable} used to time out a {@link RabbitFuture}.
+ *
+ * @author Gary Russell
+ * @since 2.4.7
+ */
+public class TimeoutTask implements Runnable {
+
+	private final RabbitFuture<?> future;
+
+	private final ConcurrentMap<String, RabbitFuture<?>> pending;
+
+	private final DirectReplyToMessageListenerContainer container;
+
+	TimeoutTask(RabbitFuture<?> future, ConcurrentMap<String, RabbitFuture<?>> pending,
+			@Nullable DirectReplyToMessageListenerContainer container) {
+
+		this.future = future;
+		this.pending = pending;
+		this.container = container;
+	}
+
+	@Override
+	public void run() {
+		this.pending.remove(this.future.getCorrelationId());
+		ChannelHolder holder = this.future.getChannelHolder();
+		if (holder != null && this.container != null) {
+			this.container.releaseConsumerFor(holder, false, null); // NOSONAR
+		}
+		this.future.completeExceptionally(
+				new AmqpReplyTimeoutException("Reply timed out", this.future.getRequestMessage()));
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,6 @@ import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.core.Queue;
-import org.springframework.amqp.rabbit.AsyncRabbitTemplate2.RabbitConverterFuture2;
-import org.springframework.amqp.rabbit.AsyncRabbitTemplate2.RabbitMessageFuture2;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -253,7 +251,7 @@ public class AsyncRabbitTemplate2Tests {
 	@DirtiesContext
 	public void testConvertWithConfirm() throws Exception {
 		this.asyncTemplate.setEnableConfirms(true);
-		RabbitConverterFuture2<String> future = this.asyncTemplate.convertSendAndReceive("sleep");
+		RabbitConverterFuture<String> future = this.asyncTemplate.convertSendAndReceive("sleep");
 		CompletableFuture<Boolean> confirm = future.getConfirm();
 		assertThat(confirm).isNotNull();
 		assertThat(confirm.get(10, TimeUnit.SECONDS)).isTrue();
@@ -264,7 +262,7 @@ public class AsyncRabbitTemplate2Tests {
 	@DirtiesContext
 	public void testMessageWithConfirm() throws Exception {
 		this.asyncTemplate.setEnableConfirms(true);
-		RabbitMessageFuture2 future = this.asyncTemplate
+		RabbitMessageFuture future = this.asyncTemplate
 				.sendAndReceive(new SimpleMessageConverter().toMessage("sleep", new MessageProperties()));
 		CompletableFuture<Boolean> confirm = future.getConfirm();
 		assertThat(confirm).isNotNull();
@@ -276,7 +274,7 @@ public class AsyncRabbitTemplate2Tests {
 	@DirtiesContext
 	public void testConvertWithConfirmDirect() throws Exception {
 		this.asyncDirectTemplate.setEnableConfirms(true);
-		RabbitConverterFuture2<String> future = this.asyncDirectTemplate.convertSendAndReceive("sleep");
+		RabbitConverterFuture<String> future = this.asyncDirectTemplate.convertSendAndReceive("sleep");
 		CompletableFuture<Boolean> confirm = future.getConfirm();
 		assertThat(confirm).isNotNull();
 		assertThat(confirm.get(10, TimeUnit.SECONDS)).isTrue();
@@ -287,7 +285,7 @@ public class AsyncRabbitTemplate2Tests {
 	@DirtiesContext
 	public void testMessageWithConfirmDirect() throws Exception {
 		this.asyncDirectTemplate.setEnableConfirms(true);
-		RabbitMessageFuture2 future = this.asyncDirectTemplate
+		RabbitMessageFuture future = this.asyncDirectTemplate
 				.sendAndReceive(new SimpleMessageConverter().toMessage("sleep", new MessageProperties()));
 		CompletableFuture<Boolean> confirm = future.getConfirm();
 		assertThat(confirm).isNotNull();
@@ -321,7 +319,7 @@ public class AsyncRabbitTemplate2Tests {
 	@DirtiesContext
 	public void testReplyAfterReceiveTimeout() throws Exception {
 		this.asyncTemplate.setReceiveTimeout(100);
-		RabbitConverterFuture2<String> future = this.asyncTemplate.convertSendAndReceive("sleep");
+		RabbitConverterFuture<String> future = this.asyncTemplate.convertSendAndReceive("sleep");
 		TheCallback callback = new TheCallback();
 		future.whenComplete(callback);
 		assertThat(TestUtils.getPropertyValue(this.asyncTemplate, "pending", Map.class)).hasSize(1);
@@ -351,7 +349,7 @@ public class AsyncRabbitTemplate2Tests {
 	@DirtiesContext
 	public void testStopCancelled() throws Exception {
 		this.asyncTemplate.setReceiveTimeout(5000);
-		RabbitConverterFuture2<String> future = this.asyncTemplate.convertSendAndReceive("noReply");
+		RabbitConverterFuture<String> future = this.asyncTemplate.convertSendAndReceive("noReply");
 		TheCallback callback = new TheCallback();
 		future.whenComplete(callback);
 		assertThat(TestUtils.getPropertyValue(this.asyncTemplate, "pending", Map.class)).hasSize(1);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate2Tests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate2Tests.java
@@ -19,6 +19,7 @@ package org.springframework.amqp.rabbit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
 
 import java.util.Map;
 import java.util.UUID;
@@ -46,6 +47,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.listener.adapter.ReplyingMessageListener;
@@ -375,6 +377,48 @@ public class AsyncRabbitTemplate2Tests {
 		 */
 		future.complete("foo");
 		assertThat(callback.result).isNull();
+	}
+
+	@Test
+	void ctorCoverage() {
+		AsyncRabbitTemplate2 template = new AsyncRabbitTemplate2(mock(ConnectionFactory.class), "ex", "rk");
+		assertThat(template).extracting(t -> t.getRabbitTemplate())
+				.extracting("exchange")
+				.isEqualTo("ex");
+		assertThat(template).extracting(t -> t.getRabbitTemplate())
+				.extracting("routingKey")
+				.isEqualTo("rk");
+		template = new AsyncRabbitTemplate2(mock(ConnectionFactory.class), "ex", "rk", "rq");
+		assertThat(template).extracting(t -> t.getRabbitTemplate())
+				.extracting("exchange")
+				.isEqualTo("ex");
+		assertThat(template).extracting(t -> t.getRabbitTemplate())
+				.extracting("routingKey")
+				.isEqualTo("rk");
+		assertThat(template)
+				.extracting("replyAddress")
+				.isEqualTo("rq");
+		assertThat(template).extracting("container")
+				.extracting("queueNames")
+				.isEqualTo(new String[] { "rq" });
+		template = new AsyncRabbitTemplate2(mock(ConnectionFactory.class), "ex", "rk", "rq", "ra");
+		assertThat(template).extracting(t -> t.getRabbitTemplate())
+				.extracting("exchange")
+				.isEqualTo("ex");
+		assertThat(template).extracting(t -> t.getRabbitTemplate())
+				.extracting("routingKey")
+				.isEqualTo("rk");
+		assertThat(template)
+				.extracting("replyAddress")
+				.isEqualTo("ra");
+		assertThat(template).extracting("container")
+				.extracting("queueNames")
+				.isEqualTo(new String[] { "rq" });
+		template = new AsyncRabbitTemplate2(mock(RabbitTemplate.class), mock(AbstractMessageListenerContainer.class),
+				"rq");
+		assertThat(template)
+				.extracting("replyAddress")
+				.isEqualTo("rq");
 	}
 
 	private void checkConverterResult(CompletableFuture<String> future, String expected) throws InterruptedException {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AsyncListenerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AsyncListenerTests.java
@@ -37,7 +37,7 @@ import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.AsyncRabbitTemplate2;
-import org.springframework.amqp.rabbit.AsyncRabbitTemplate2.RabbitConverterFuture2;
+import org.springframework.amqp.rabbit.RabbitConverterFuture;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -106,7 +106,7 @@ public class AsyncListenerTests {
 	@Test
 	public void testAsyncListener() throws Exception {
 		assertThat(this.rabbitTemplate.convertSendAndReceive(this.queue1.getName(), "foo")).isEqualTo("FOO");
-		RabbitConverterFuture2<Object> future = this.asyncTemplate.convertSendAndReceive(this.queue1.getName(), "foo");
+		RabbitConverterFuture<Object> future = this.asyncTemplate.convertSendAndReceive(this.queue1.getName(), "foo");
 		assertThat(future.get(10, TimeUnit.SECONDS)).isEqualTo("FOO");
 		assertThat(this.config.typeId).isEqualTo("java.lang.String");
 		assertThat(this.rabbitTemplate.convertSendAndReceive(this.queue2.getName(), "foo")).isEqualTo("FOO");

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/ComplexTypeJsonIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/ComplexTypeJsonIntegrationTests.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.rabbit.AsyncRabbitTemplate2;
-import org.springframework.amqp.rabbit.AsyncRabbitTemplate2.RabbitConverterFuture2;
+import org.springframework.amqp.rabbit.RabbitConverterFuture;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -137,7 +137,7 @@ public class ComplexTypeJsonIntegrationTests {
 				new ParameterizedTypeReference<Foo<Bar<Baz, Qux>>>() { }));
 	}
 
-	private void verifyFooBarBazQux(RabbitConverterFuture2<Foo<Bar<Baz, Qux>>> future) throws Exception {
+	private void verifyFooBarBazQux(RabbitConverterFuture<Foo<Bar<Baz, Qux>>> future) throws Exception {
 		verifyFooBarBazQux(future.get(10, TimeUnit.SECONDS));
 	}
 


### PR DESCRIPTION
- to aid migration from 2.4.x to 3.0.x so that the return types will not change
