### PR TITLE
GH-1494: Fix Test Harness with @Repeatable

### DIFF
--- a/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
+++ b/spring-rabbit-test/src/main/java/org/springframework/amqp/rabbit/test/RabbitListenerTestHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import org.springframework.amqp.rabbit.test.mockito.LambdaAnswer.ValueToReturn;
 import org.springframework.amqp.rabbit.test.mockito.LatchCountDownAndCallRealMethodAnswer;
 import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.core.annotation.AnnotationAttributes;
-import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.util.Assert;
@@ -172,9 +172,9 @@ public class RabbitListenerTestHarness extends RabbitListenerAnnotationBeanPostP
 
 		@Override
 		public Object invoke(MethodInvocation invocation) throws Throwable {
-			boolean isListenerMethod =
-					AnnotationUtils.findAnnotation(invocation.getMethod(), RabbitListener.class) != null
-					|| AnnotationUtils.findAnnotation(invocation.getMethod(), RabbitHandler.class) != null;
+			MergedAnnotations annotations = MergedAnnotations.from(invocation.getMethod());
+			boolean isListenerMethod = annotations.isPresent(RabbitListener.class)
+					|| annotations.isPresent(RabbitHandler.class);
 			try {
 				Object result = invocation.proceed();
 				if (isListenerMethod) {

--- a/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/ExampleRabbitListenerCaptureTest.java
+++ b/spring-rabbit-test/src/test/java/org/springframework/amqp/rabbit/test/examples/ExampleRabbitListenerCaptureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,6 +140,11 @@ public class ExampleRabbitListenerCaptureTest {
 		}
 
 		@Bean
+		public Queue queue3() {
+			return new AnonymousQueue();
+		}
+
+		@Bean
 		public RabbitAdmin admin(ConnectionFactory cf) {
 			return new RabbitAdmin(cf);
 		}
@@ -168,6 +173,7 @@ public class ExampleRabbitListenerCaptureTest {
 		}
 
 		@RabbitListener(id = "bar", queues = "#{queue2.name}")
+		@RabbitListener(id = "bar2", queues = "#{queue3.name}")
 		public void foo(@Payload String foo, @Header("amqp_receivedRoutingKey") String rk) {
 			if (!failed && foo.equals("ex")) {
 				failed = true;


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1494

Capture mode failed to capture arguments/result/exception if multiple
`@RabbitListener` annotations present.

**cherry-pick to 2.4.x**
