### PR TITLE
GH-1497: Use RANDOM as default addressShuffleMode

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,7 +139,7 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	private List<Address> addresses;
 
-	private AddressShuffleMode addressShuffleMode = AddressShuffleMode.NONE;
+	private AddressShuffleMode addressShuffleMode = AddressShuffleMode.RANDOM;
 
 	private int closeTimeout = DEFAULT_CLOSE_TIMEOUT;
 
@@ -525,17 +525,20 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	/**
 	 * When {@link #setAddresses(String) addresses} are provided and there is more than
-	 * one, set to true to shuffle the list before opening a new connection so that the
-	 * connection to the broker will be attempted in random order.
+	 * one, set to true (default) to shuffle the list before opening a new connection so
+	 * that the connection to the broker will be attempted in random order.
 	 * @param shuffleAddresses true to shuffle the list.
 	 * @since 2.1.8
-	 * @deprecated since 2.3 in favor of
+	 * @deprecated since 2.3 in favor of {@link #setAddressShuffleMode(AddressShuffleMode)}.
 	 * @see Collections#shuffle(List)
-	 * {@link #setAddressShuffleMode(AddressShuffleMode)}.
 	 */
 	@Deprecated
 	public void setShuffleAddresses(boolean shuffleAddresses) {
-		setAddressShuffleMode(AddressShuffleMode.RANDOM);
+		if (shuffleAddresses) {
+			setAddressShuffleMode(AddressShuffleMode.RANDOM);
+		} else {
+			setAddressShuffleMode(AddressShuffleMode.NONE);
+		}
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -524,24 +524,6 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 	}
 
 	/**
-	 * When {@link #setAddresses(String) addresses} are provided and there is more than
-	 * one, set to true (default) to shuffle the list before opening a new connection so
-	 * that the connection to the broker will be attempted in random order.
-	 * @param shuffleAddresses true to shuffle the list.
-	 * @since 2.1.8
-	 * @deprecated since 2.3 in favor of {@link #setAddressShuffleMode(AddressShuffleMode)}.
-	 * @see Collections#shuffle(List)
-	 */
-	@Deprecated
-	public void setShuffleAddresses(boolean shuffleAddresses) {
-		if (shuffleAddresses) {
-			setAddressShuffleMode(AddressShuffleMode.RANDOM);
-		} else {
-			setAddressShuffleMode(AddressShuffleMode.NONE);
-		}
-	}
-
-	/**
 	 * Set the mode for shuffling addresses.
 	 * @param addressShuffleMode the address shuffle mode.
 	 * @since 2.3

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
@@ -65,6 +66,7 @@ import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
 
 import org.springframework.amqp.AmqpConnectException;
@@ -1657,8 +1659,10 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		ccf.createConnection();
 		verify(mock).isAutomaticRecoveryEnabled();
 		verify(mock).setAutomaticRecoveryEnabled(false);
-		verify(mock).newConnection(isNull(),
-				eq(Arrays.asList(new Address("mq1"), new Address("mq2"))), anyString());
+		verify(mock).newConnection(
+				isNull(),
+				argThat((ArgumentMatcher<List<Address>>) a -> a.size() == 2 && a.contains(new Address("mq1")) && a.contains(new Address("mq2"))),
+				anyString());
 		verifyNoMoreInteractions(mock);
 	}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -609,8 +609,8 @@ public CachingConnectionFactory ccf() {
 ----
 ====
 
-The underlying connection factory will attempt to connect to each host, in order, whenever a new connection is established.
-Starting with version 2.1.8, the connection order can be made random by setting the `addressShuffleMode` property to `RANDOM`; the shuffle will be applied before creating any new connection.
+The underlying connection factory will attempt to connect to a host, by choosing a random address, whenever a new connection is established.
+
 Starting with version 2.6, the `INORDER` shuffle mode was added, which means the first address is moved to the end after a connection is created.
 You may wish to use this mode with the https://github.com/rabbitmq/rabbitmq-sharding[RabbitMQ Sharding Plugin] with `CacheMode.CONNECTION` and suitable concurrency if you wish to consume from all shards on all nodes.
 
@@ -621,7 +621,7 @@ You may wish to use this mode with the https://github.com/rabbitmq/rabbitmq-shar
 public CachingConnectionFactory ccf() {
     CachingConnectionFactory ccf = new CachingConnectionFactory();
     ccf.setAddresses("host1:5672,host2:5672,host3:5672");
-    ccf.setAddressShuffleMode(AddressShuffleMode.RANDOM);
+    ccf.setAddressShuffleMode(AddressShuffleMode.INORDER);
     return ccf;
 }
 ----

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -31,3 +31,8 @@ See <<receiving-batch>> for more infoprmation.
 
 `MessageConverter` s can now return `Optional.empty()` for a null value; this is currently implemented by the `Jackson2JsonMessageConverter`.
 See <<Jackson2JsonMessageConverter-from-message>> for more information.
+
+==== Connection Factory Changes
+
+The default `addressShuffleMode` in `AbstractConnectionFactory` is now `RANDOM`. This results in connecting to a random host when multiple addresses are provided.
+See <<cluster>> for more information.


### PR DESCRIPTION
Changed the default behavior of the address which is chosen during creation of a connection in AbstractConnectionFactory. The default addressShuffleMode is now RANDOM. 

See feature request: https://github.com/spring-projects/spring-amqp/issues/1497 
