### PR TITLE
GH-1524: Fix ThreadChannelCF with Transactional

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactory.java
@@ -307,8 +307,7 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory im
 		}
 
 		private void handleClose(Channel channel, boolean transactional) {
-
-			if (transactional && this.txChannels.get() == null ? true : this.channels.get() == null) {
+			if ((transactional && this.txChannels.get() == null) || (!transactional && this.channels.get() == null)) {
 				physicalClose(channel);
 			}
 			else {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,36 @@ public class ThreadChannelConnectionFactoryTests {
 				.isFalse();
 		assertThat(((Channel) TestUtils.getPropertyValue(conn, "txChannels", ThreadLocal.class).get()).isOpen())
 				.isFalse();
+	}
+
+	@Test
+	void testClose() throws Exception {
+		ConnectionFactory rabbitConnectionFactory = new ConnectionFactory();
+		rabbitConnectionFactory.setHost("localhost");
+		ThreadChannelConnectionFactory tccf = new ThreadChannelConnectionFactory(rabbitConnectionFactory);
+		Connection conn = tccf.createConnection();
+		Channel chann1 = conn.createChannel(false);
+		Channel targetChannel1 = ((ChannelProxy) chann1).getTargetChannel();
+		chann1.close();
+		Channel chann2 = conn.createChannel(false);
+		Channel targetChannel2 = ((ChannelProxy) chann2).getTargetChannel();
+		assertThat(chann2).isSameAs(chann1);
+		assertThat(targetChannel2).isSameAs(targetChannel1);
+	}
+
+	@Test
+	void testTxClose() throws Exception {
+		ConnectionFactory rabbitConnectionFactory = new ConnectionFactory();
+		rabbitConnectionFactory.setHost("localhost");
+		ThreadChannelConnectionFactory tccf = new ThreadChannelConnectionFactory(rabbitConnectionFactory);
+		Connection conn = tccf.createConnection();
+		Channel chann1 = conn.createChannel(true);
+		Channel targetChannel1 = ((ChannelProxy) chann1).getTargetChannel();
+		chann1.close();
+		Channel chann2 = conn.createChannel(true);
+		Channel targetChannel2 = ((ChannelProxy) chann2).getTargetChannel();
+		assertThat(chann2).isSameAs(chann1);
+		assertThat(targetChannel2).isSameAs(targetChannel1);
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/1524

Channel was always physically closed.

**cherry-pick to 2.4.x**

