### PR TITLE
GH-1528: Fix possible type pollution in RabbitListenerAnnotationBeanPostProcessor

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -323,12 +323,12 @@ public class RabbitListenerAnnotationBeanPostProcessor
 	}
 
 	private TypeMetadata buildMetadata(Class<?> targetClass) {
-		Collection<RabbitListener> classLevelListeners = findListenerAnnotations(targetClass);
+		List<RabbitListener> classLevelListeners = findListenerAnnotations(targetClass);
 		final boolean hasClassLevelListeners = classLevelListeners.size() > 0;
 		final List<ListenerMethod> methods = new ArrayList<>();
 		final List<Method> multiMethods = new ArrayList<>();
 		ReflectionUtils.doWithMethods(targetClass, method -> {
-			Collection<RabbitListener> listenerAnnotations = findListenerAnnotations(method);
+			List<RabbitListener> listenerAnnotations = findListenerAnnotations(method);
 			if (listenerAnnotations.size() > 0) {
 				methods.add(new ListenerMethod(method,
 						listenerAnnotations.toArray(new RabbitListener[listenerAnnotations.size()])));
@@ -349,7 +349,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 				classLevelListeners.toArray(new RabbitListener[classLevelListeners.size()]));
 	}
 
-	private Collection<RabbitListener> findListenerAnnotations(AnnotatedElement element) {
+	private List<RabbitListener> findListenerAnnotations(AnnotatedElement element) {
 		return MergedAnnotations.from(element, SearchStrategy.TYPE_HIERARCHY)
 				.stream(RabbitListener.class)
 				.map(ann -> ann.synthesize())


### PR DESCRIPTION
Hi,

this PR fixes #1528 by returning `List` rather than `Collection` from `findListenerAnnotations`.
Regardless of the mentioned issue imho that's the better return type in any case for this method.

If possible, a backport to 2.x would be highly appreciated

Cheers,
Christoph