### PR TITLE
GH-1210: Add Kotlin suspend functions support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ ext {
 	jaywayJsonPathVersion = '2.7.0'
 	junit4Version = '4.13.2'
 	junitJupiterVersion = '5.9.2'
+	kotlinCoroutinesVersion = '1.6.4'
 	log4jVersion = '2.19.0'
 	logbackVersion = '1.4.4'
 	lz4Version = '1.8.0'
@@ -436,6 +437,7 @@ project('spring-rabbit') {
 		}
 		optionalApi "com.jayway.jsonpath:json-path:$jaywayJsonPathVersion"
 		optionalApi "org.apache.commons:commons-pool2:$commonsPoolVersion"
+		optionalApi "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion"
 
 		testApi project(':spring-rabbit-junit')
 		testImplementation("com.willowtreeapps.assertk:assertk-jvm:$assertkVersion")

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -364,7 +364,7 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 	 * response message back.
 	 * @param resultArg the result object to handle (never <code>null</code>)
 	 * @param request the original request message
-	 * @param channel the Rabbit channel to operate on (may be <code>null</code>)
+	 * @param channel the Rabbit channel to operate on (maybe <code>null</code>)
 	 * @param source the source data for the method invocation - e.g.
 	 * {@code o.s.messaging.Message<?>}; may be null
 	 * @see #buildMessage
@@ -391,8 +391,8 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 			}
 			else if (monoPresent && MonoHandler.isMono(resultArg.getReturnValue())) {
 				if (!this.isManualAck) {
-					this.logger.warn("Container AcknowledgeMode must be MANUAL for a Mono<?> return type; "
-							+ "otherwise the container will ack the message immediately");
+					this.logger.warn("Container AcknowledgeMode must be MANUAL for a Mono<?> return type" +
+							"(or Kotlin suspend function); otherwise the container will ack the message immediately");
 				}
 				MonoHandler.subscribe(resultArg.getReturnValue(),
 						r -> asyncSuccess(resultArg, request, channel, source, r),
@@ -448,7 +448,7 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 	}
 
 	private void asyncFailure(Message request, Channel channel, Throwable t) {
-		this.logger.error("Future or Mono was completed with an exception for " + request, t);
+		this.logger.error("Future, Mono, or suspend function was completed with an exception for " + request, t);
 		try {
 			channel.basicNack(request.getMessageProperties().getDeliveryTag(), false,
 					ContainerUtils.shouldRequeue(this.defaultRequeueRejected, t, this.logger));

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AmqpMessageHandlerMethodFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AmqpMessageHandlerMethodFactory.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.core.KotlinDetector;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
+import org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.validation.Validator;
+
+/**
+ * Extension of the {@link DefaultMessageHandlerMethodFactory} for Spring AMQP requirements.
+ *
+ * @author Artem Bilan
+ *
+ * @since 3.0.5
+ */
+public class AmqpMessageHandlerMethodFactory extends DefaultMessageHandlerMethodFactory {
+
+	private final HandlerMethodArgumentResolverComposite argumentResolvers =
+			new HandlerMethodArgumentResolverComposite();
+
+	private MessageConverter messageConverter;
+
+	private Validator validator;
+
+	@Override
+	public void setMessageConverter(MessageConverter messageConverter) {
+		super.setMessageConverter(messageConverter);
+		this.messageConverter = messageConverter;
+	}
+
+	@Override
+	public void setValidator(Validator validator) {
+		super.setValidator(validator);
+		this.validator = validator;
+	}
+
+	@Override
+	protected List<HandlerMethodArgumentResolver> initArgumentResolvers() {
+		List<HandlerMethodArgumentResolver> resolvers = super.initArgumentResolvers();
+		if (KotlinDetector.isKotlinPresent()) {
+			// Insert before PayloadMethodArgumentResolver
+			resolvers.add(resolvers.size() - 1, new ContinuationHandlerMethodArgumentResolver());
+		}
+		// Has to be at the end, but before PayloadMethodArgumentResolver
+		resolvers.add(resolvers.size() - 1,
+				new OptionalEmptyAwarePayloadArgumentResolver(this.messageConverter, this.validator));
+		this.argumentResolvers.addResolvers(resolvers);
+		return resolvers;
+	}
+
+	@Override
+	public InvocableHandlerMethod createInvocableHandlerMethod(Object bean, Method method) {
+		InvocableHandlerMethod handlerMethod = new KotlinAwareInvocableHandlerMethod(bean, method);
+		handlerMethod.setMessageMethodArgumentResolvers(this.argumentResolvers);
+		return handlerMethod;
+	}
+
+	private static class OptionalEmptyAwarePayloadArgumentResolver extends PayloadMethodArgumentResolver {
+
+		OptionalEmptyAwarePayloadArgumentResolver(MessageConverter messageConverter, @Nullable Validator validator) {
+			super(messageConverter, validator);
+		}
+
+		@Override
+		public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception { // NOSONAR
+			Object resolved;
+			try {
+				resolved = super.resolveArgument(parameter, message);
+			}
+			catch (MethodArgumentNotValidException ex) {
+				Type type = parameter.getGenericParameterType();
+				if (isOptional(message, type)) {
+					BindingResult bindingResult = ex.getBindingResult();
+					if (bindingResult != null) {
+						List<ObjectError> allErrors = bindingResult.getAllErrors();
+						if (allErrors.size() == 1) {
+							String defaultMessage = allErrors.get(0).getDefaultMessage();
+							if ("Payload value must not be empty".equals(defaultMessage)) {
+								return Optional.empty();
+							}
+						}
+					}
+				}
+				throw ex;
+			}
+			/*
+			 * Replace Optional.empty() list elements with null.
+			 */
+			if (resolved instanceof List<?> list) {
+				for (int i = 0; i < list.size(); i++) {
+					if (list.get(i).equals(Optional.empty())) {
+						list.set(i, null);
+					}
+				}
+			}
+			return resolved;
+		}
+
+		private boolean isOptional(Message<?> message, Type type) {
+			return (Optional.class.equals(type) ||
+					(type instanceof ParameterizedType pType && Optional.class.equals(pType.getRawType())))
+					&& message.getPayload().equals(Optional.empty());
+		}
+
+		@Override
+		protected boolean isEmptyPayload(Object payload) {
+			return payload == null || payload.equals(Optional.empty());
+		}
+
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/ContinuationHandlerMethodArgumentResolver.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/ContinuationHandlerMethodArgumentResolver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * No-op resolver for method arguments of type {@link kotlin.coroutines.Continuation}.
+ * <p>
+ * This class is similar to
+ * {@link org.springframework.messaging.handler.annotation.reactive.ContinuationHandlerMethodArgumentResolver}
+ * but for regular {@link HandlerMethodArgumentResolver} contract.
+ *
+ * @author Artem Bilan
+ *
+ * @since 3.0.5
+ *
+ * @see org.springframework.messaging.handler.annotation.reactive.ContinuationHandlerMethodArgumentResolver
+ */
+public class ContinuationHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return "kotlin.coroutines.Continuation".equals(parameter.getParameterType().getName());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+		return Mono.empty();
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/KotlinAwareInvocableHandlerMethod.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/KotlinAwareInvocableHandlerMethod.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener.adapter;
+
+import java.lang.reflect.Method;
+
+import org.springframework.core.CoroutinesUtils;
+import org.springframework.core.KotlinDetector;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+
+/**
+ * An {@link InvocableHandlerMethod} extension for supporting Kotlin {@code suspend} function.
+ *
+ * @author Artem Bilan
+ *
+ * @since 3.0.5
+ */
+public class KotlinAwareInvocableHandlerMethod extends InvocableHandlerMethod {
+
+	public KotlinAwareInvocableHandlerMethod(Object bean, Method method) {
+		super(bean, method);
+	}
+
+	@Override
+	protected Object doInvoke(Object... args) throws Exception {
+		Method method = getBridgedMethod();
+		if (KotlinDetector.isSuspendingFunction(method)) {
+			return CoroutinesUtils.invokeSuspendingFunction(method, getBean(), args);
+		}
+		else {
+			return super.doInvoke(args);
+		}
+	}
+
+}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3085,7 +3085,7 @@ Each queue needed a separate property.
 ====== Reply Management
 
 The existing support in `MessageListenerAdapter` already lets your method have a non-void return type.
-When that is the case, the result of the invocation is encapsulated in a message sent to the the address specified in the `ReplyToAddress` header of the original message, or to the default address configured on the listener.
+When that is the case, the result of the invocation is encapsulated in a message sent to the address specified in the `ReplyToAddress` header of the original message, or to the default address configured on the listener.
 You can set that default address by using the `@SendTo` annotation of the messaging abstraction.
 
 Assuming our `processOrder` method should now return an `OrderStatus`, we can write it as follows to automatically send a reply:
@@ -3659,6 +3659,10 @@ If some exception occurs within the listener method that prevents creation of th
 
 Starting with versions 2.2.21, 2.3.13, 2.4.1, the `AcknowledgeMode` will be automatically set the `MANUAL` when async return types are detected.
 In addition, incoming messages with fatal exceptions will be negatively acknowledged individually, previously any prior unacknowledged message were also negatively acknowledged.
+
+Starting with version 3.0.5, the `@RabbitListener` (and `@RabbitHandler`) methods can be marked with Kotlin `suspend` and the whole handling process and reply producing (optional) happens on respective Kotlin coroutine.
+All the mentioned rules about `AcknowledgeMode.MANUAL` are still apply.
+The `org.jetbrains.kotlinx:kotlinx-coroutines-reactor` dependency must be present in classpath to allow `suspend` function invocations.
 
 [[threading]]
 ===== Threading and Asynchronous Consumers

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -40,7 +40,7 @@ See <<stream-support>> for more information.
 Batch listeners can now consume `Collection<?>` as well as `List<?>`.
 The batch messaging adapter now ensures that the method is suitable for consuming batches.
 When setting the container factory `consumerBatchEnabled` to `true`, the `batchListener` property is also set to `true`.
-See <<receiving-batch>> for more infoprmation.
+See <<receiving-batch>> for more information.
 
 `MessageConverter` s can now return `Optional.empty()` for a null value; this is currently implemented by the `Jackson2JsonMessageConverter`.
 See <<Jackson2JsonMessageConverter-from-message>> for more information
@@ -48,9 +48,13 @@ See <<Jackson2JsonMessageConverter-from-message>> for more information
 You can now configure a `ReplyPostProcessor` via the container factory rather than via a property on `@RabbitListener`.
 See <<async-annotation-driven-reply>> for more information.
 
+The `@RabbitListener` (and `@RabbitHandler`) methods can now be as a Kotlin `suspend` functions.
+See <<async-returns>> for more information.
+
 ==== Connection Factory Changes
 
-The default `addressShuffleMode` in `AbstractConnectionFactory` is now `RANDOM`. This results in connecting to a random host when multiple addresses are provided.
+The default `addressShuffleMode` in `AbstractConnectionFactory` is now `RANDOM`.
+This results in connecting to a random host when multiple addresses are provided.
 See <<cluster>> for more information.
 
 The `LocalizedQueueConnectionFactory` no longer uses the RabbitMQ `http-client` library to determine which node is the leader for a queue.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/1210

Kotlin Coroutines are essentially `Future` wrapping. Therefore, it is natural to have `suspend` support on `@RabbitListener` methods as we do now for `CompletableFuture` and `Mono`

* Introduce some utilities since we cannot reuse existing from Spring Messaging: they are there about Kotlin Coroutines only for reactive handlers
* Some code clean up in the `RabbitListenerAnnotationBeanPostProcessor` for the latest Java
* Add optional dep for `kotlinx-coroutines-reactor` and document the feature

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
