### PR TITLE
Fix typo in stream.adoc

### DIFF
--- a/src/reference/asciidoc/stream.adoc
+++ b/src/reference/asciidoc/stream.adoc
@@ -71,13 +71,13 @@ The `RabbitStreamTemplate` provides a subset of the `RabbitTemplate` (AMQP) func
 ----
 public interface RabbitStreamOperations extends AutoCloseable {
 
-	ConvertableFuture<Boolean> send(Message message);
+	CompletableFuture<Boolean> send(Message message);
 
-	ConvertableFuture<Boolean> convertAndSend(Object message);
+	CompletableFuture<Boolean> convertAndSend(Object message);
 
-	ConvertableFuture<Boolean> convertAndSend(Object message, @Nullable MessagePostProcessor mpp);
+	CompletableFuture<Boolean> convertAndSend(Object message, @Nullable MessagePostProcessor mpp);
 
-	ConvertableFuture<Boolean> send(com.rabbitmq.stream.Message message);
+	CompletableFuture<Boolean> send(com.rabbitmq.stream.Message message);
 
 	MessageBuilder messageBuilder();
 


### PR DESCRIPTION
ConvertableFuture -> CompletableFuture

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
