### PR TITLE
GH-2482: Option for Containers to Stop Immediately

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -784,11 +784,17 @@ public class BlockingQueueConsumer {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Closing Rabbit Channel: " + this.channel);
 		}
-		RabbitUtils.setPhysicalCloseRequired(this.channel, true);
-		ConnectionFactoryUtils.releaseResources(this.resourceHolder);
-		this.deliveryTags.clear();
-		this.consumers.clear();
-		this.queue.clear(); // in case we still have a client thread blocked
+		forceCloseAndClearQueue();
+	}
+
+	public void forceCloseAndClearQueue() {
+		if (this.channel != null && this.channel.isOpen()) {
+			RabbitUtils.setPhysicalCloseRequired(this.channel, true);
+			ConnectionFactoryUtils.releaseResources(this.resourceHolder);
+			this.deliveryTags.clear();
+			this.consumers.clear();
+			this.queue.clear(); // in case we still have a client thread blocked
+		}
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -813,7 +813,7 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	@Override
-	protected void doShutdown() {
+	protected void shutdownAndWaitOrCallback(@Nullable Runnable callback) {
 		LinkedList<SimpleConsumer> canceledConsumers = null;
 		boolean waitForConsumers = false;
 		synchronized (this.consumersMonitor) {
@@ -826,33 +826,50 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 			}
 		}
 		if (waitForConsumers) {
-			try {
-				if (this.cancellationLock.await(getShutdownTimeout(), TimeUnit.MILLISECONDS)) {
-					this.logger.info("Successfully waited for consumers to finish.");
-				}
-				else {
-					this.logger.info("Consumers not finished.");
-					if (isForceCloseChannel()) {
-						canceledConsumers.forEach(consumer -> {
-							String eventMessage = "Closing channel for unresponsive consumer: " + consumer;
-							if (logger.isWarnEnabled()) {
-								logger.warn(eventMessage);
-							}
-							consumer.cancelConsumer(eventMessage);
-						});
+			LinkedList<SimpleConsumer> consumersToWait = canceledConsumers;
+			Runnable awaitShutdown = () -> {
+				try {
+					if (this.cancellationLock.await(getShutdownTimeout(), TimeUnit.MILLISECONDS)) {
+						this.logger.info("Successfully waited for consumers to finish.");
+					}
+					else {
+						this.logger.info("Consumers not finished.");
+						if (isForceCloseChannel() || this.stopNow.get()) {
+							consumersToWait.forEach(consumer -> {
+								String eventMessage = "Closing channel for unresponsive consumer: " + consumer;
+								if (logger.isWarnEnabled()) {
+									logger.warn(eventMessage);
+								}
+								consumer.cancelConsumer(eventMessage);
+							});
+						}
 					}
 				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					this.logger.warn("Interrupted waiting for consumers. Continuing with shutdown.");
+				}
+				finally {
+					this.startedLatch = new CountDownLatch(1);
+					this.started = false;
+					this.aborted = false;
+					this.hasStopped = true;
+				}
+				this.stopNow.set(false);
+				runCallbackIfNotNull(callback);
+			};
+			if (callback == null) {
+				awaitShutdown.run();
 			}
-			catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				this.logger.warn("Interrupted waiting for consumers. Continuing with shutdown.");
+			else {
+				getTaskExecutor().execute(awaitShutdown);
 			}
-			finally {
-				this.startedLatch = new CountDownLatch(1);
-				this.started = false;
-				this.aborted = false;
-				this.hasStopped = true;
-			}
+		}
+	}
+
+	private void runCallbackIfNotNull(@Nullable Runnable callback) {
+		if (callback != null) {
+			callback.run();
 		}
 	}
 
@@ -863,7 +880,12 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 	private void actualShutDown(List<SimpleConsumer> consumers) {
 		Assert.state(getTaskExecutor() != null, "Cannot shut down if not initialized");
 		this.logger.debug("Shutting down");
-		consumers.forEach(this::cancelConsumer);
+		if (isForceStop()) {
+			this.stopNow.set(true);
+		}
+		else {
+			consumers.forEach(this::cancelConsumer);
+		}
 		this.consumers.clear();
 		this.consumersByQueue.clear();
 		this.logger.debug("All consumers canceled");
@@ -1031,6 +1053,10 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		public void handleDelivery(String consumerTag, Envelope envelope,
 				BasicProperties properties, byte[] body) {
 
+			if (!getChannel().isOpen()) {
+				this.logger.debug("Discarding prefetch, channel closed");
+				return;
+			}
 			MessageProperties messageProperties =
 					getMessagePropertiesConverter().toMessageProperties(properties, envelope, "UTF-8");
 			messageProperties.setConsumerTag(consumerTag);
@@ -1071,6 +1097,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 				catch (Exception e) {
 					// NOSONAR
 				}
+			}
+			if (DirectMessageListenerContainer.this.stopNow.get()) {
+				closeChannel();
 			}
 		}
 
@@ -1308,11 +1337,15 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		}
 
 		private void finalizeConsumer() {
+			closeChannel();
+			DirectMessageListenerContainer.this.cancellationLock.release(this);
+			consumerRemoved(this);
+		}
+
+		private void closeChannel() {
 			RabbitUtils.setPhysicalCloseRequired(getChannel(), true);
 			RabbitUtils.closeChannel(getChannel());
 			RabbitUtils.closeConnection(this.connection);
-			DirectMessageListenerContainer.this.cancellationLock.release(this);
-			consumerRemoved(this);
 		}
 
 		@Override

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -3527,6 +3527,10 @@ Starting with version 1.5, you can now assign a `group` to the container on the 
 This provides a mechanism to get a reference to a subset of containers.
 Adding a `group` attribute causes a bean of type `Collection<MessageListenerContainer>` to be registered with the context with the group name.
 
+By default, stopping a container will cancel the consumer and process all prefetched messages before stopping.
+Starting with versions 2.4.14, 3.0.6, you can set the <<forceStop>> container property to true to stop immediately after the current message is processed, causing any prefetched messages to be requeued.
+This is useful, for example, if exclusive or single-active consumers are being used.
+
 [[receiving-batch]]
 ===== @RabbitListener with Batching
 
@@ -6204,6 +6208,18 @@ a|
 |If the consumers do not respond to a shutdown within `shutdownTimeout`, if this is `true`, the channel will be closed, causing any unacked messages to be requeued.
 Defaults to `true` since 2.0.
 You can set it to `false` to revert to the previous behavior.
+
+a|image::images/tickmark.png[]
+a|image::images/tickmark.png[]
+a|
+
+|[[forceStop]]<<forceStop,`forceStop`>> +
+(N/A)
+
+|Set to true to stop (when the container is stopped) after the current record is processed; causing all prefetched messages to be requeued.
+By default, the container will cancel the consumer and process all prefetched messages before stopping.
+Since versions 2.4.14, 3.0.6
+Defaults to `false`.
 
 a|image::images/tickmark.png[]
 a|image::images/tickmark.png[]


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/2482

`forceStop` means stop after the current record and requeue all prefetched.

Just close the channel - canceling the consumer first causes a race condition which could allow another exclusive or single-active consumer to start processing while this container is still running.

Also support async stop on DMLC (previously only available on the SMLC).

**cherry-pick to 2.4.x**
