### PR TITLE
GH-2495: Add maxInboundMessageBodySize to RCFB

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ import com.rabbitmq.client.impl.nio.NioParams;
  * using the supplied properties and intializes key and trust manager factories, using
  * algorithm {@code SunX509} by default. These are then used to initialize an
  * {@link SSLContext} using the {@link #setSslAlgorithm(String) sslAlgorithm} (default
- * TLSv1.1).
+ * TLSv1.2, falling back to TLSv1.1, if 1.2 is not available).
  * <p>
  * Override {@link #createSSLContext()} to create and/or perform further modification of
  * the context.
@@ -670,6 +670,16 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	 */
 	public void setEnableHostnameVerification(boolean enable) {
 		this.enableHostnameVerification = enable;
+	}
+
+	/**
+	 * Set the maximum body size of inbound (received) messages in bytes.
+	 * @param maxInboundMessageBodySize the maximum size.
+	 * @since 2.4.15
+	 * @see com.rabbitmq.client.ConnectionFactory#setMaxInboundMessageBodySize(int)
+	 */
+	public void setMaxInboundMessageBodySize(int maxInboundMessageBodySize) {
+		this.connectionFactory.setMaxInboundMessageBodySize(maxInboundMessageBodySize);
 	}
 
 	protected String getKeyStoreAlgorithm() {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/SSLConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ public class SSLConnectionTests {
 	@Test
 	public void testAlgNoProps() throws Exception {
 		RabbitConnectionFactoryBean fb = new RabbitConnectionFactoryBean();
+		fb.setMaxInboundMessageBodySize(1000);
 		ConnectionFactory rabbitCf = spy(TestUtils.getPropertyValue(fb, "connectionFactory", ConnectionFactory.class));
 		new DirectFieldAccessor(fb).setPropertyValue("connectionFactory", rabbitCf);
 		fb.setUseSSL(true);
@@ -83,6 +84,7 @@ public class SSLConnectionTests {
 		fb.afterPropertiesSet();
 		fb.getObject();
 		verify(rabbitCf).useSslProtocol(Mockito.any(SSLContext.class));
+		assertThat(rabbitCf).hasFieldOrPropertyWithValue("maxInboundMessageBodySize", 1000);
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/2495

Although the factory bean has...

```java
	/**
	 * Access the connection factory to set any other properties not supported by
	 * this factory bean.
	 * @return the connection factory.
	 * @since 1.7.14
	 */
	public ConnectionFactory getRabbitConnectionFactory() {
```

...this new CF property could be a breaking change for users that configure the factory bean using XML.

**cherry-pick to 2.4.x**

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
