### PR TITLE
GH-2498: Fix Manual Redeclaration With Dup. Names

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpAdmin.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AmqpAdmin.java
@@ -19,6 +19,7 @@ package org.springframework.amqp.core;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.springframework.lang.Nullable;
 
@@ -133,9 +134,20 @@ public interface AmqpAdmin {
 	 * Return the manually declared AMQP objects.
 	 * @return the manually declared AMQP objects.
 	 * @since 2.4.13
+	 * @deprecated in favor of {@link #getManualDeclarableSet()}.
 	 */
+	@Deprecated
 	default Map<String, Declarable> getManualDeclarables() {
 		return Collections.emptyMap();
+	}
+
+	/**
+	 * Return the manually declared AMQP objects.
+	 * @return the manually declared AMQP objects.
+	 * @since 2.4.15
+	 */
+	default Set<Declarable> getManualDeclarableSet() {
+		return Collections.emptySet();
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1924,8 +1924,7 @@ public abstract class AbstractMessageListenerContainer extends ObservableListene
 					context.getBeansOfType(Queue.class, false, false).values());
 			Map<String, Declarables> declarables = context.getBeansOfType(Declarables.class, false, false);
 			declarables.values().forEach(dec -> queues.addAll(dec.getDeclarablesByType(Queue.class)));
-			admin.getManualDeclarables()
-					.values()
+			admin.getManualDeclarableSet()
 					.stream()
 					.filter(Queue.class::isInstance)
 					.map(Queue.class::cast)


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/2498

Manual redeclaration logic did not account for an exchange having the same name as a queue.

**back port to 2.4.x will have conflicts and requires instanceof polishing** (I will do it after merge).
