### PR TITLE
GH-2511: Fix Container Stop Regression

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -1293,6 +1293,9 @@ public abstract class AbstractMessageListenerContainer extends ObservableListene
 			if (!isActive()) {
 				logger.debug("Shutdown ignored - container is not active already");
 				this.lifecycleMonitor.notifyAll();
+				if (callback != null) {
+					callback.run();
+				}
 				return;
 			}
 			this.active = false;


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/2511

When inactive containers are present, the `DefaultLifecycleProcessor` hangs for (default) 30 seconds waiting for containers to stop.

When `stop(Runnable)` is called, the callback was not run if the container was not running; this was a regression caused by 1fdfe650ac1b6b28f11543af026c94b5128f1ba5.

**cherry-pick to 2.4.x**
