### PR TITLE
Output of `asciidoctorPdf` can be pulled from cache when run on machines with different checkout directories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -587,7 +587,7 @@ asciidoctorPdf {
 
 	asciidoctorj {
 		sourceDir "$buildDir/asciidoc"
-		inputs.dir(sourceDir)
+		inputs.dir(sourceDir).withPathSensitivity(PathSensitivity.RELATIVE)
 		sources {
 			include 'index.adoc'
 		}


### PR DESCRIPTION
This sets the path sensitivity to relative for the `sourceDir` property of the `asciidoctorPdf` task. Previously, the full absolute path to the source directory would be considered as an input to the task. This would cause a local build cache miss when executing the task from two different directories or a remote build cache hit given that the paths to the sources directory on CI and for local developers will undoubtedly be different.

You can recreate this with the [Gradle Enterprise Build Validation Scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts) using the following command:

```shell
./03-validate-local-build-caching-different-locations.sh \
  -r https://github.com/spring-projects/spring-amqp \
  -t asciidoctorPdf \
  -c 31834589d727b697833ad5ef38117555dc9a848b
```

Looking at the task inputs comparison we can see the difference: https://ge.solutions-team.gradle.com/c/5nevshchvo24s/m75khvofipjne/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure

Using the [diffoscope](https://diffoscope.org/) tool we can see the only difference for the generated `index.pdf` is in the creation and modification dates:

![image](https://github.com/spring-projects/spring-amqp/assets/5797900/1befb7f6-bce5-43a1-b936-a91bd52b32c5)

See also: spring-projects/spring-kafka#2794