### PR TITLE
GH-2532: Ignore Kotlin Continuation Parameter

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -447,7 +447,8 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 			Type parameterType = methodParameter.getGenericParameterType();
 			if (parameterType.equals(Channel.class)
 					|| parameterType.equals(MessageProperties.class)
-					|| parameterType.equals(org.springframework.amqp.core.Message.class)) {
+					|| parameterType.equals(org.springframework.amqp.core.Message.class)
+					|| parameterType.getTypeName().startsWith("kotlin.coroutines.Continuation")) {
 				return false;
 			}
 			if (parameterType instanceof ParameterizedType parameterizedType &&


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/2532

The presence of the parameter caused the inferred type to be set to `null` due to ambiguous parameters present.

It must be considered an ineligible type when inferring conversion types.

**cherry-pick to 3.0.x (#2533), 2.4.x (#2534)**
