### PR TITLE
GH-2552: Fix Builder Argument Types maxLength etc

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/QueueBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/QueueBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,9 +150,23 @@ public final class QueueBuilder extends AbstractBuilder {
 	 * @param count the number of (ready) messages allowed.
 	 * @return the builder.
 	 * @since 2.2
+	 * @deprecated in favor of {@link #maxLength(long)}.
 	 * @see #overflow(Overflow)
 	 */
+	@Deprecated
 	public QueueBuilder maxLength(int count) {
+		return withArgument("x-max-length", count);
+	}
+
+	/**
+	 * Set the number of (ready) messages allowed in the queue before it starts to drop
+	 * them.
+	 * @param count the number of (ready) messages allowed.
+	 * @return the builder.
+	 * @since 3.1
+	 * @see #overflow(Overflow)
+	 */
+	public QueueBuilder maxLength(long count) {
 		return withArgument("x-max-length", count);
 	}
 

--- a/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/config/SuperStreamBuilder.java
+++ b/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/config/SuperStreamBuilder.java
@@ -28,6 +28,7 @@ import org.springframework.util.StringUtils;
  * Based on <a href="https://www.rabbitmq.com/streams.html">Streams documentation</a>
  *
  * @author Sergei Kurenchuk
+ * @author Gary Russell
  * @since 3.1
  */
 public class SuperStreamBuilder {
@@ -73,7 +74,7 @@ public class SuperStreamBuilder {
 	 * @param bytes the max total size in bytes
 	 * @return the builder
 	 */
-	public SuperStreamBuilder maxLength(int bytes) {
+	public SuperStreamBuilder maxLength(long bytes) {
 		return withArgument("max-length-bytes", bytes);
 	}
 
@@ -82,7 +83,7 @@ public class SuperStreamBuilder {
 	 * @param bytes the max segments size in bytes
 	 * @return the builder
 	 */
-	public SuperStreamBuilder maxSegmentSize(int bytes) {
+	public SuperStreamBuilder maxSegmentSize(long bytes) {
 		return withArgument("x-stream-max-segment-size-bytes", bytes);
 	}
 

--- a/spring-rabbit-stream/src/test/java/org/springframework/rabbit/stream/config/SuperStreamConfigurationTests.java
+++ b/spring-rabbit-stream/src/test/java/org/springframework/rabbit/stream/config/SuperStreamConfigurationTests.java
@@ -85,8 +85,8 @@ public class SuperStreamConfigurationTests {
 		var finalPartitionsNumber = 4;
 		var finalName = "test-name";
 		var maxAge = "1D";
-		var maxLength = 10_000_000;
-		var maxSegmentsSize = 100_000;
+		var maxLength = 10_000_000L;
+		var maxSegmentsSize = 100_000L;
 		var initialClusterSize = 5;
 
 		var testArgName = "test-key";

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/FixedReplyQueueDeadLetterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/FixedReplyQueueDeadLetterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -265,7 +265,7 @@ public class FixedReplyQueueDeadLetterTests extends NeedsManagementTests {
 			return QueueBuilder.nonDurable("all.args.1")
 					.ttl(1000)
 					.expires(200_000)
-					.maxLength(42)
+					.maxLength(42L)
 					.maxLengthBytes(10_000)
 					.overflow(Overflow.rejectPublish)
 					.deadLetterExchange("reply.dlx")
@@ -282,7 +282,7 @@ public class FixedReplyQueueDeadLetterTests extends NeedsManagementTests {
 			return QueueBuilder.nonDurable("all.args.2")
 					.ttl(1000)
 					.expires(200_000)
-					.maxLength(42)
+					.maxLength(42L)
 					.maxLengthBytes(10_000)
 					.overflow(Overflow.dropHead)
 					.deadLetterExchange("reply.dlx")
@@ -298,7 +298,7 @@ public class FixedReplyQueueDeadLetterTests extends NeedsManagementTests {
 			return QueueBuilder.nonDurable("all.args.3")
 					.ttl(1000)
 					.expires(200_000)
-					.maxLength(42)
+					.maxLength(42L)
 					.maxLengthBytes(10_000)
 					.overflow(Overflow.rejectPublish)
 					.deadLetterExchange("reply.dlx")

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplatePublisherCallbacksIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -833,7 +833,7 @@ public class RabbitTemplatePublisherCallbacksIntegrationTests {
 		RabbitAdmin admin = new RabbitAdmin(this.connectionFactory);
 		Queue queue = QueueBuilder.nonDurable()
 				.autoDelete()
-				.maxLength(1)
+				.maxLength(1L)
 				.overflow(Overflow.rejectPublish)
 				.build();
 		admin.declareQueue(queue);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererWithConfirmsIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererWithConfirmsIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ class RepublishMessageRecovererWithConfirmsIntegrationTests {
 		RabbitTemplate template = new RabbitTemplate(ccf);
 		RabbitAdmin admin = new RabbitAdmin(ccf);
 		Queue queue = QueueBuilder.durable(QUEUE + ".nack")
-				.maxLength(1)
+				.maxLength(1L)
 				.overflow(Overflow.rejectPublish)
 				.build();
 		admin.declareQueue(queue);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-amqp/issues/2552

Variables map to Erlang ints which are 8 bytes, so need to be long in Java.
