### PR TITLE
GH-2601: Add a batchReceiveTimeout

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
@@ -392,6 +392,14 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 		this.receiveTimeout = receiveTimeout;
 	}
 
+	/**
+	 * The number of milliseconds of timeout for gathering batch messages.
+	 * It limits the time to wait to fill batchSize.
+	 * Default is 0 (no timeout).
+	 * @param batchReceiveTimeout the timeout for gathering batch messages.
+	 * @since 3.1.2
+	 * @see #setBatchSize(int)
+	 */
 	public void setBatchReceiveTimeout(long batchReceiveTimeout) {
 		this.batchReceiveTimeout = batchReceiveTimeout;
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/ListenerContainerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ import org.springframework.util.backoff.BackOff;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Johno Crawford
+ * @author Jeonggi Kim
  *
  * @since 2.0
  *
@@ -165,6 +166,8 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 	private Integer consecutiveIdleTrigger;
 
 	private Long receiveTimeout;
+
+	private Long batchReceiveTimeout;
 
 	private Integer batchSize;
 
@@ -389,6 +392,10 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 		this.receiveTimeout = receiveTimeout;
 	}
 
+	public void setBatchReceiveTimeout(long batchReceiveTimeout) {
+		this.batchReceiveTimeout = batchReceiveTimeout;
+	}
+
 	/**
 	 * This property has several functions.
 	 * <p>
@@ -552,6 +559,7 @@ public class ListenerContainerFactoryBean extends AbstractFactoryBean<AbstractMe
 					.acceptIfNotNull(this.consecutiveActiveTrigger, container::setConsecutiveActiveTrigger)
 					.acceptIfNotNull(this.consecutiveIdleTrigger, container::setConsecutiveIdleTrigger)
 					.acceptIfNotNull(this.receiveTimeout, container::setReceiveTimeout)
+					.acceptIfNotNull(this.batchReceiveTimeout, container::setBatchReceiveTimeout)
 					.acceptIfNotNull(this.batchSize, container::setBatchSize)
 					.acceptIfNotNull(this.consumerBatchEnabled, container::setConsumerBatchEnabled)
 					.acceptIfNotNull(this.declarationRetries, container::setDeclarationRetries)

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -125,8 +125,13 @@ public class SimpleRabbitListenerContainerFactory
 	}
 
 	/**
-	 * @param batchReceiveTimeout the timeout for gather batch messages.
+	 * The number of milliseconds of timeout for gathering batch messages.
+	 * It limits the time to wait to fill batchSize.
+	 * Default is 0 (no timeout).
+	 * @param batchReceiveTimeout the timeout for gathering batch messages.
+	 * @since 3.1.2
 	 * @see SimpleMessageListenerContainer#setBatchReceiveTimeout
+	 * @see #setBatchSize(Integer)
 	 */
 	public void setBatchReceiveTimeout(Long batchReceiveTimeout) {
 		this.batchReceiveTimeout = batchReceiveTimeout;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.amqp.utils.JavaUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Dustin Schultz
+ * @author Jeonggi Kim
  *
  * @since 1.4
  */
@@ -53,6 +54,8 @@ public class SimpleRabbitListenerContainerFactory
 	private Integer consecutiveIdleTrigger;
 
 	private Long receiveTimeout;
+
+	private Long batchReceiveTimeout;
 
 	private Boolean consumerBatchEnabled;
 
@@ -122,6 +125,14 @@ public class SimpleRabbitListenerContainerFactory
 	}
 
 	/**
+	 * @param batchReceiveTimeout the timeout for gather batch messages.
+	 * @see SimpleMessageListenerContainer#setBatchReceiveTimeout
+	 */
+	public void setBatchReceiveTimeout(Long batchReceiveTimeout) {
+		this.batchReceiveTimeout = batchReceiveTimeout;
+	}
+
+	/**
 	 * Set to true to present a list of messages based on the {@link #setBatchSize(Integer)},
 	 * if the listener supports it. Starting with version 3.0, setting this to true will
 	 * also {@link #setBatchListener(boolean)} to true.
@@ -163,7 +174,8 @@ public class SimpleRabbitListenerContainerFactory
 			.acceptIfNotNull(this.stopConsumerMinInterval, instance::setStopConsumerMinInterval)
 			.acceptIfNotNull(this.consecutiveActiveTrigger, instance::setConsecutiveActiveTrigger)
 			.acceptIfNotNull(this.consecutiveIdleTrigger, instance::setConsecutiveIdleTrigger)
-			.acceptIfNotNull(this.receiveTimeout, instance::setReceiveTimeout);
+			.acceptIfNotNull(this.receiveTimeout, instance::setReceiveTimeout)
+			.acceptIfNotNull(this.batchReceiveTimeout, instance::setBatchReceiveTimeout);
 		if (Boolean.TRUE.equals(this.consumerBatchEnabled)) {
 			instance.setConsumerBatchEnabled(true);
 			/*

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1012,17 +1012,14 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 		List<Message> messages = null;
 		long deliveryTag = 0;
-		long startTime = System.currentTimeMillis();
-
+		boolean isBatchReceiveTimeoutEnabled = this.batchReceiveTimeout > 0;
+		long startTime = isBatchReceiveTimeoutEnabled ? System.currentTimeMillis() : 0;
 		for (int i = 0; i < this.batchSize; i++) {
-			boolean batchTimedOut = this.batchReceiveTimeout > 0 &&
+			boolean batchTimedOut = isBatchReceiveTimeoutEnabled &&
 					(System.currentTimeMillis() - startTime) > this.batchReceiveTimeout;
 			if (batchTimedOut) {
 				if (logger.isTraceEnabled()) {
-					long gathered = 0;
-					if (messages != null) {
-						gathered = messages.size();
-					}
+					long gathered = messages != null ? messages.size() : 0;
 					logger.trace("Timed out for gathering batch messages. gathered size is " + gathered);
 				}
 				break;

--- a/src/reference/antora/modules/ROOT/pages/amqp/containerAttributes.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/containerAttributes.adoc
@@ -198,7 +198,7 @@ a|
 |[[consumerBatchEnabled]]<<consumerBatchEnabled,`consumerBatchEnabled`>> +
 (batch-enabled)
 
-|If the `MessageListener` supports it, setting this to true enables batching of discrete messages, up to `batchSize`; a partial batch will be delivered if no new messages arrive in `receiveTimeout`.
+|If the `MessageListener` supports it, setting this to true enables batching of discrete messages, up to `batchSize`; a partial batch will be delivered if no new messages arrive in `receiveTimeout` or gathering batch messages time exceeded `batchReceiveTimeout`.
 When this is false, batching is only supported for batches created by a producer; see xref:amqp/sending-messages.adoc#template-batching[Batching].
 
 a|image::tickmark.png[]
@@ -606,6 +606,18 @@ a|
 If `acknowledgeMode=NONE`, this has very little effect -- the container spins round and asks for another message.
 It has the biggest effect for a transactional `Channel` with `batchSize > 1`, since it can cause messages already consumed not to be acknowledged until the timeout expires.
 When `consumerBatchEnabled` is true, a partial batch will be delivered if this timeout occurs before a batch is complete.
+
+a|image::tickmark.png[]
+a|
+a|
+
+|[[batchReceiveTimeout]]<<batchReceiveTimeout,`batchReceiveTimeout`>> +
+(batch-receive-timeout)
+
+|The number of milliseconds of timeout for gathering batch messages.
+It limits the time to wait to fill batchSize.
+When `batchSize > 1` and the time to gathering batch messages is greater than `batchReceiveTime`, batch will be delivered.
+Default is 0 (no timeout).
 
 a|image::tickmark.png[]
 a|


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/2601

stop to waiting next message and execute listener when batchReceiveTimeout is timed out.