### PR TITLE
Ability to provide an implementation of ConnectionFactory

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitConnectionFactoryBean.java
@@ -121,7 +121,7 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 
 	private static final String TRUST_STORE_DEFAULT_TYPE = "JKS";
 
-	protected final ConnectionFactory connectionFactory = new ConnectionFactory(); // NOSONAR
+	protected final ConnectionFactory connectionFactory;
 
 	private final Properties sslProperties = new Properties();
 
@@ -162,6 +162,11 @@ public class RabbitConnectionFactoryBean extends AbstractFactoryBean<ConnectionF
 	private String trustStoreAlgorithm = SUN_X509;
 
 	public RabbitConnectionFactoryBean() {
+		this(new ConnectionFactory());
+	}
+
+	public RabbitConnectionFactoryBean(ConnectionFactory connectionFactory) {
+		this.connectionFactory = connectionFactory;
 		this.connectionFactory.setAutomaticRecoveryEnabled(false);
 	}
 


### PR DESCRIPTION
Currently it's not possible to provide a custom implementation of a ConnectionFactory to this class. 

I need to be able to override some methods in the factory and being able to simply pass the implementation will prevent me from having to use hacky workarounds.

This is required in order to make modifications to allow use of an explicit proxy.
