### PR TITLE
Change the method return condition. connectionFactory.isPublisherConfirms()

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -386,7 +386,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	@Override
 	public boolean isPublisherConfirms() {
-		return ConfirmType.CORRELATED.equals(this.confirmType);
+		return !ConfirmType.NONE.equals(this.confirmType);
 	}
 
 	@Override


### PR DESCRIPTION
<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->

I fix this issue https://github.com/spring-projects/spring-amqp/issues/2572

`connectionFactory.isPublisherConfirms()` return condition.
I believe this condition is appropriate, **but some people may not think so, as mentioned in the issue above.** 
Please confirm.

