### PR TITLE
GH-2653: Fix deadlock in the DirectMessageListenerContainer

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.springframework.amqp.AmqpAuthenticationException;
 import org.springframework.amqp.AmqpConnectException;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.AmqpIOException;
+import org.springframework.amqp.AmqpTimeoutException;
 import org.springframework.amqp.ImmediateAcknowledgeAmqpException;
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.Message;
@@ -801,6 +802,9 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 		}
 		catch (AmqpApplicationContextClosedException e) {
 			throw new AmqpConnectException(e);
+		}
+		catch (AmqpTimeoutException timeoutException) {
+			throw timeoutException;
 		}
 		catch (Exception e) {
 			RabbitUtils.closeChannel(channel);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectReplyToMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.amqp.rabbit.listener;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.springframework.amqp.AmqpTimeoutException;
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Address;
 import org.springframework.amqp.core.MessageListener;
@@ -118,22 +119,23 @@ public class DirectReplyToMessageListenerContainer extends DirectMessageListener
 	@Override
 	protected void processMonitorTask() {
 		long now = System.currentTimeMillis();
+		long reduce;
 		this.consumersLock.lock();
 		try {
-			long reduce = this.consumers.stream()
-				.filter(c -> this.whenUsed.containsKey(c) && !this.inUseConsumerChannels.containsValue(c)
-						&& this.whenUsed.get(c) < now - getIdleEventInterval())
-				.count();
-			if (reduce > 0) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("Reducing idle consumes by " + reduce);
-				}
-				this.consumerCount = (int) Math.max(0, this.consumerCount - reduce);
-				super.setConsumersPerQueue(this.consumerCount);
-			}
+			reduce = this.consumers.stream()
+					.filter(c -> this.whenUsed.containsKey(c) && !this.inUseConsumerChannels.containsValue(c)
+							&& this.whenUsed.get(c) < now - getIdleEventInterval())
+					.count();
 		}
 		finally {
 			this.consumersLock.unlock();
+		}
+		if (reduce > 0) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Reducing idle consumes by " + reduce);
+			}
+			this.consumerCount = (int) Math.max(0, this.consumerCount - reduce);
+			super.setConsumersPerQueue(this.consumerCount);
 		}
 	}
 
@@ -159,13 +161,13 @@ public class DirectReplyToMessageListenerContainer extends DirectMessageListener
 	 * @return the channel holder.
 	 */
 	public ChannelHolder getChannelHolder() {
-		this.consumersLock.lock();
-		try {
-			ChannelHolder channelHolder = null;
-			while (channelHolder == null) {
-				if (!isRunning()) {
-					throw new IllegalStateException("Direct reply-to container is not running");
-				}
+		ChannelHolder channelHolder = null;
+		while (channelHolder == null) {
+			if (!isRunning()) {
+				throw new IllegalStateException("Direct reply-to container is not running");
+			}
+			this.consumersLock.lock();
+			try {
 				for (SimpleConsumer consumer : this.consumers) {
 					Channel candidate = consumer.getChannel();
 					if (candidate.isOpen() && this.inUseConsumerChannels.putIfAbsent(candidate, consumer) == null) {
@@ -175,16 +177,23 @@ public class DirectReplyToMessageListenerContainer extends DirectMessageListener
 						break;
 					}
 				}
-				if (channelHolder == null) {
-					this.consumerCount++;
-					super.setConsumersPerQueue(this.consumerCount);
+			}
+			finally {
+				this.consumersLock.unlock();
+			}
+			if (channelHolder == null) {
+				try {
+					super.setConsumersPerQueue(++this.consumerCount);
+				}
+				catch (AmqpTimeoutException timeoutException) {
+					// Possibly No available channels in the cache, so come back to consumers
+					// iteration until existing is available
+					this.consumerCount--;
 				}
 			}
-			return channelHolder;
 		}
-		finally {
-			this.consumersLock.unlock();
-		}
+		return channelHolder;
+
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitBatchIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/EnableRabbitBatchIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.rabbit.batch.SimpleBatchingStrategy;
@@ -61,6 +62,11 @@ public class EnableRabbitBatchIntegrationTests {
 
 	@Autowired
 	private Listener listener;
+
+	@BeforeAll
+	static void setup() {
+		System.setProperty("spring.amqp.deserialization.trust.all", "true");
+	}
 
 	@Test
 	public void simpleList() throws InterruptedException {


### PR DESCRIPTION
Fixes: #2653

When not enough channel in the cache, the `DirectMessageListenerContainer.consume()` returns null and `adjustConsumers()` goes into an infinite loop, since already active consumer does not release its channel.

* Fix `DirectMessageListenerContainer.consume()` to re-throw an `AmqpTimeoutException` which is thrown when no available channels in the cache
* Catch `AmqpTimeoutException` in the `DirectReplyToMessageListenerContainer.getChannelHolder()` and reset `this.consumerCount--` to allow to try existing consumer until it is available, e.g. when this one receives a reply or times out.

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
