### PR TITLE
Make sure ReceivedDelay is non-negative

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
@@ -95,7 +95,7 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
 				if (MessageProperties.X_DELAY.equals(key)) {
 					Object value = entry.getValue();
 					if (value instanceof Number numberValue) {
-						long receivedDelayLongValue = numberValue.longValue();
+						long receivedDelayLongValue = Math.abs(numberValue.longValue());
 						target.setReceivedDelayLong(receivedDelayLongValue);
 						target.setHeader(key, receivedDelayLongValue);
 					}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

It was observed that x-delay values sent from broker can be inconsistently positive or negative, which burdens business logic to check signs and can cause bugs.
This PR to make sure it has a non-negative sign.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
