### PR TITLE
Refactor getOrSetCorrelationIdAndSetReplyTo method

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -87,6 +87,7 @@ import com.rabbitmq.client.Channel;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Java4ye
  *
  * @since 1.6
  */
@@ -666,17 +667,13 @@ public class AsyncRabbitTemplate implements AsyncAmqpTemplate, ChannelAwareMessa
 	private String getOrSetCorrelationIdAndSetReplyTo(Message message,
 			@Nullable AsyncCorrelationData<?> correlationData) {
 
-		String correlationId;
 		MessageProperties messageProperties = message.getMessageProperties();
 		Assert.notNull(messageProperties, "the message properties cannot be null");
-		String currentCorrelationId = messageProperties.getCorrelationId();
-		if (!StringUtils.hasText(currentCorrelationId)) {
+		String correlationId = messageProperties.getCorrelationId();
+		if (!StringUtils.hasText(correlationId)) {
 			correlationId = correlationData != null ? correlationData.getId() : UUID.randomUUID().toString();
 			messageProperties.setCorrelationId(correlationId);
 			Assert.isNull(messageProperties.getReplyTo(), "'replyTo' property must be null");
-		}
-		else {
-			correlationId = currentCorrelationId;
 		}
 		messageProperties.setReplyTo(this.replyAddress);
 		return correlationId;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/AsyncRabbitTemplate.java
@@ -87,7 +87,7 @@ import com.rabbitmq.client.Channel;
  *
  * @author Gary Russell
  * @author Artem Bilan
- * @author Java4ye
+ * @author FengYang Su
  *
  * @since 1.6
  */


### PR DESCRIPTION
<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
Refactored the getOrSetCorrelationIdAndSetReplyTo method for improved readability and code organization. Merged the declaration and initialization of 'correlationId' into a single line. Ensured the logic remains unchanged. No functional changes introduced.