### PR TITLE
GH-2572 Treat ConfirmType.SIMPLE same as ConfirmType.CORRELATED

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -393,7 +393,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 
 	@Override
 	public boolean isPublisherConfirms() {
-		return ConfirmType.CORRELATED.equals(this.confirmType);
+		return !ConfirmType.NONE.equals(this.confirmType);
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -2344,6 +2344,9 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 				if (channel == null) {
 					throw new IllegalStateException("Connection returned a null channel");
 				}
+				if (!connectionFactory.isPublisherConfirms() && !connectionFactory.isSimplePublisherConfirms()) {
+					RabbitUtils.setPhysicalCloseRequired(channel, true);
+				}
 				this.dedicatedChannels.set(channel);
 			}
 			catch (RuntimeException e) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2343,9 +2343,6 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 				channel = connection.createChannel(false);
 				if (channel == null) {
 					throw new IllegalStateException("Connection returned a null channel");
-				}
-				if (!connectionFactory.isPublisherConfirms()) {
-					RabbitUtils.setPhysicalCloseRequired(channel, true);
 				}
 				this.dedicatedChannels.set(channel);
 			}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -2344,7 +2344,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 				if (channel == null) {
 					throw new IllegalStateException("Connection returned a null channel");
 				}
-				if (!connectionFactory.isPublisherConfirms() && !connectionFactory.isSimplePublisherConfirms()) {
+				if (!connectionFactory.isPublisherConfirms()) {
 					RabbitUtils.setPhysicalCloseRequired(channel, true);
 				}
 				this.dedicatedChannels.set(channel);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1965,6 +1965,30 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		cf.shutdownCompleted(new ShutdownSignalException(false, false, null, chanShutDown));
 		assertThat(connShutDown.get()).isTrue();
 		assertThat(chanShutDown.get()).isFalse();
+	}
+
+	@Test
+	void isPublisherConfirmsHandlesSimple() {
+		CachingConnectionFactory ccf = new CachingConnectionFactory("someHost", 1234);
+		ccf.setPublisherConfirmType(ConfirmType.SIMPLE);
+
+		assertThat(ccf.isPublisherConfirms()).isTrue();
+	}
+
+	@Test
+	void isPublisherConfirmsHandlesCorrelated() {
+		CachingConnectionFactory ccf = new CachingConnectionFactory("someHost", 1234);
+		ccf.setPublisherConfirmType(ConfirmType.CORRELATED);
+
+		assertThat(ccf.isPublisherConfirms()).isTrue();
+	}
+
+	@Test
+	void isPublisherConfirmsHandlesNone() {
+		CachingConnectionFactory ccf = new CachingConnectionFactory("someHost", 1234);
+		ccf.setPublisherConfirmType(ConfirmType.NONE);
+
+		assertThat(ccf.isPublisherConfirms()).isFalse();
 	}
 
 }

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -557,6 +557,78 @@ public class RabbitTemplateTests {
 		template.invoke(t -> null);
 		verify(pcf).createConnection();
 		verify(conn).createChannel(false);
+	}
+
+	@Test
+	public void testPublisherConnWithInvokePhysicallyCloses() {
+		RabbitUtils.clearPhysicalCloseRequired();
+
+		org.springframework.amqp.rabbit.connection.ConnectionFactory cf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		org.springframework.amqp.rabbit.connection.ConnectionFactory pcf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		given(cf.getPublisherConnectionFactory()).willReturn(pcf);
+		given(pcf.isPublisherConfirms()).willReturn(false);
+
+		RabbitTemplate template = new RabbitTemplate(cf);
+		template.setUsePublisherConnection(true);
+		org.springframework.amqp.rabbit.connection.Connection conn = mock(
+				org.springframework.amqp.rabbit.connection.Connection.class);
+		ChannelProxy channel = mock(ChannelProxy.class);
+		given(pcf.createConnection()).willReturn(conn);
+		given(conn.isOpen()).willReturn(true);
+		given(conn.createChannel(false)).willReturn(channel);
+		template.invoke(t -> null);
+
+		assertThat(RabbitUtils.isPhysicalCloseRequired()).isTrue();
+	}
+
+	@Test
+	public void testPublisherConnWithInvokeAndPublisherConfirmations() {
+		RabbitUtils.clearPhysicalCloseRequired();
+
+		org.springframework.amqp.rabbit.connection.ConnectionFactory cf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		org.springframework.amqp.rabbit.connection.ConnectionFactory pcf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		given(cf.getPublisherConnectionFactory()).willReturn(pcf);
+		given(pcf.isPublisherConfirms()).willReturn(true);
+
+		RabbitTemplate template = new RabbitTemplate(cf);
+		template.setUsePublisherConnection(true);
+		org.springframework.amqp.rabbit.connection.Connection conn = mock(
+				org.springframework.amqp.rabbit.connection.Connection.class);
+		ChannelProxy channel = mock(ChannelProxy.class);
+		given(pcf.createConnection()).willReturn(conn);
+		given(conn.isOpen()).willReturn(true);
+		given(conn.createChannel(false)).willReturn(channel);
+		template.invoke(t -> null);
+
+		assertThat(RabbitUtils.isPhysicalCloseRequired()).isFalse();
+	}
+
+	@Test
+	public void testPublisherConnWithInvokeAndSimpleConfirmations() {
+		RabbitUtils.clearPhysicalCloseRequired();
+
+		org.springframework.amqp.rabbit.connection.ConnectionFactory cf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		org.springframework.amqp.rabbit.connection.ConnectionFactory pcf = mock(
+				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+		given(cf.getPublisherConnectionFactory()).willReturn(pcf);
+		given(pcf.isSimplePublisherConfirms()).willReturn(true);
+
+		RabbitTemplate template = new RabbitTemplate(cf);
+		template.setUsePublisherConnection(true);
+		org.springframework.amqp.rabbit.connection.Connection conn = mock(
+				org.springframework.amqp.rabbit.connection.Connection.class);
+		ChannelProxy channel = mock(ChannelProxy.class);
+		given(pcf.createConnection()).willReturn(conn);
+		given(conn.isOpen()).willReturn(true);
+		given(conn.createChannel(false)).willReturn(channel);
+		template.invoke(t -> null);
+
+		assertThat(RabbitUtils.isPhysicalCloseRequired()).isFalse();
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateTests.java
@@ -608,30 +608,6 @@ public class RabbitTemplateTests {
 	}
 
 	@Test
-	public void testPublisherConnWithInvokeAndSimpleConfirmations() {
-		RabbitUtils.clearPhysicalCloseRequired();
-
-		org.springframework.amqp.rabbit.connection.ConnectionFactory cf = mock(
-				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
-		org.springframework.amqp.rabbit.connection.ConnectionFactory pcf = mock(
-				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
-		given(cf.getPublisherConnectionFactory()).willReturn(pcf);
-		given(pcf.isSimplePublisherConfirms()).willReturn(true);
-
-		RabbitTemplate template = new RabbitTemplate(cf);
-		template.setUsePublisherConnection(true);
-		org.springframework.amqp.rabbit.connection.Connection conn = mock(
-				org.springframework.amqp.rabbit.connection.Connection.class);
-		ChannelProxy channel = mock(ChannelProxy.class);
-		given(pcf.createConnection()).willReturn(conn);
-		given(conn.isOpen()).willReturn(true);
-		given(conn.createChannel(false)).willReturn(channel);
-		template.invoke(t -> null);
-
-		assertThat(RabbitUtils.isPhysicalCloseRequired()).isFalse();
-	}
-
-	@Test
 	public void testPublisherConnWithInvokeInTx() {
 		org.springframework.amqp.rabbit.connection.ConnectionFactory cf = mock(
 				org.springframework.amqp.rabbit.connection.ConnectionFactory.class);


### PR DESCRIPTION
GH-2572 Do not close channel when `ConfirmType.SIMPLE` is used for publisher confirmations.

See #2571 (discussion) and #2572 (issue) for reference.
 

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
