### PR TITLE
Update Reference  Links

### DIFF
--- a/src/reference/antora/modules/ROOT/nav.adoc
+++ b/src/reference/antora/modules/ROOT/nav.adoc
@@ -72,7 +72,6 @@
 *** xref:appendix/previous-whats-new/changes-in-3-0-since-2-4.adoc[]
 *** xref:appendix/previous-whats-new/changes-in-2-4-since-2-3.adoc[]
 *** xref:appendix/previous-whats-new/message-converter-changes.adoc[]
-*** xref:appendix/previous-whats-new/message-converter-changes-1.adoc[]
 *** xref:appendix/previous-whats-new/stream-support-changes.adoc[]
 *** xref:appendix/previous-whats-new/changes-in-2-3-since-2-2.adoc[]
 *** xref:appendix/previous-whats-new/changes-in-2-2-since-2-1.adoc[]

--- a/src/reference/antora/modules/ROOT/pages/amqp/broker-configuration.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/broker-configuration.adoc
@@ -359,7 +359,7 @@ public Exchange exchange() {
 }
 ----
 
-See the Javadoc for https://docs.spring.io/spring-amqp/docs/current/api/org/springframework/amqp/core/QueueBuilder.html[`org.springframework.amqp.core.QueueBuilder`] and https://docs.spring.io/spring-amqp/docs/latest-ga/api/org/springframework/amqp/core/ExchangeBuilder.html[`org.springframework.amqp.core.ExchangeBuilder`] for more information.
+See the Javadoc for https://docs.spring.io/spring-amqp/docs/current/api/org/springframework/amqp/core/QueueBuilder.html[`org.springframework.amqp.core.QueueBuilder`] and https://docs.spring.io/spring-amqp/docs/current/api/org/springframework/amqp/core/ExchangeBuilder.html[`org.springframework.amqp.core.ExchangeBuilder`] for more information.
 
 Starting with version 2.0, the `ExchangeBuilder` now creates durable exchanges by default, to be consistent with the simple constructors on the individual `AbstractExchange` classes.
 To make a non-durable exchange with the builder, use `.durable(false)` before invoking `.build()`.

--- a/src/reference/antora/modules/ROOT/pages/amqp/receiving-messages/micrometer-observation.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/receiving-messages/micrometer-observation.adoc
@@ -7,7 +7,7 @@ Using Micrometer for observation is now supported, since version 3.0, for the `R
 Set `observationEnabled` on each component to enable observation; this will disable xref:amqp/receiving-messages/micrometer.adoc[Micrometer Timers] because the timers will now be managed with each observation.
 When using annotated listeners, set `observationEnabled` on the container factory.
 
-Refer to https://micrometer.io/docs/tracing[Micrometer Tracing] for more information.
+Refer to https://docs.micrometer.io/tracing/reference/[Micrometer Tracing] for more information.
 
 To add tags to timers/traces, configure a custom `RabbitTemplateObservationConvention` or `RabbitListenerObservationConvention` to the template or listener container, respectively.
 

--- a/src/reference/antora/modules/ROOT/pages/amqp/transactions.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/transactions.adoc
@@ -116,7 +116,7 @@ See xref:amqp/containerAttributes.adoc[Message Listener Container Configuration]
 [[using-rabbittransactionmanager]]
 == Using `RabbitTransactionManager`
 
-The https://docs.spring.io/spring-amqp/docs/latest_ga/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html[RabbitTransactionManager] is an alternative to executing Rabbit operations within, and synchronized with, external transactions.
+The https://docs.spring.io/spring-amqp/docs/current/api/org/springframework/amqp/rabbit/transaction/RabbitTransactionManager.html[RabbitTransactionManager] is an alternative to executing Rabbit operations within, and synchronized with, external transactions.
 This transaction manager is an implementation of the https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/transaction/PlatformTransactionManager.html[`PlatformTransactionManager`] interface and should be used with a single Rabbit `ConnectionFactory`.
 
 IMPORTANT: This strategy is not able to provide XA transactions -- for example, in order to share transactions between messaging and database access.

--- a/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-1-6-since-1-5.adoc
+++ b/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-1-6-since-1-5.adoc
@@ -242,7 +242,7 @@ See <<java-deserialization>> for more information.
 
 Improvements to the JSON message converter now allow the consumption of messages that do not have type information
 in message headers.
-See xref:amqp/receiving-messages/async-annotation-driven/conversion.adoc[Message Conversion for Annotated Methods] and <<json-message-converter>> for more information.
+See xref:amqp/receiving-messages/async-annotation-driven/conversion.adoc[Message Conversion for Annotated Methods] and xref:amqp/message-converters.adoc#json-message-converter[`Jackson2JsonMessageConverter`] for more information.
 
 [[logging-appenders]]
 == Logging Appenders

--- a/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/message-converter-changes-1.adoc
+++ b/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/message-converter-changes-1.adoc
@@ -1,7 +1,0 @@
-[[message-converter-changes]]
-= Message Converter Changes
-:page-section-summary-toc: 1
-
-The `Jackson2JsonMessageConverter` can now determine the charset from the `contentEncoding` header.
-See <<json-message-converter>> for more information.
-

--- a/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/message-converter-changes.adoc
+++ b/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/message-converter-changes.adoc
@@ -3,5 +3,5 @@
 :page-section-summary-toc: 1
 
 The `Jackson2JsonMessageConverter` can now determine the charset from the `contentEncoding` header.
-See <<json-message-converter>> for more information.
+See xref:amqp/message-converters.adoc#json-message-converter[`Jackson2JsonMessageConverter`] for more information.
 

--- a/src/reference/antora/modules/ROOT/pages/sample-apps.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sample-apps.adoc
@@ -351,4 +351,4 @@ Spring applications, when sending JSON, set the `__TypeId__` header to the fully
 
 The `spring-rabbit-json` sample explores several techniques to convert the JSON from a non-Spring application.
 
-See also <<json-message-converter>> as well as the https://docs.spring.io/spring-amqp/docs/current/api/index.html?org/springframework/amqp/support/converter/DefaultClassMapper.html[Javadoc for the `DefaultClassMapper`].
+See also xref:amqp/message-converters.adoc#json-message-converter[`Jackson2JsonMessageConverter`] as well as the https://docs.spring.io/spring-amqp/docs/current/api/index.html?org/springframework/amqp/support/converter/DefaultClassMapper.html[Javadoc for the `DefaultClassMapper`].

--- a/src/reference/antora/modules/ROOT/pages/stream.adoc
+++ b/src/reference/antora/modules/ROOT/pages/stream.adoc
@@ -298,7 +298,7 @@ The container now also supports Micrometer timers (when observation is not enabl
 Set `observationEnabled` on each component to enable observation; this will disable xref:amqp/receiving-messages/micrometer.adoc[Micrometer Timers] because the timers will now be managed with each observation.
 When using annotated listeners, set `observationEnabled` on the container factory.
 
-Refer to https://micrometer.io/docs/tracing[Micrometer Tracing] for more information.
+Refer to https://docs.micrometer.io/tracing/reference/[Micrometer Tracing] for more information.
 
 To add tags to timers/traces, configure a custom `RabbitStreamTemplateObservationConvention` or `RabbitStreamListenerObservationConvention` to the template or listener container, respectively.
 


### PR DESCRIPTION
I update some reference links.

I also delete `message-converter-changes-1.adoc` because I think `message-converter-changes-1.adoc` and `message-converter-changes.adoc` are the same.

Please check again and tell me if I miss something.