### PR TITLE
RabbitTemplate and RabbitListener add opentelemetry tags

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
@@ -68,7 +68,7 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * The exchange the listener is plugged to (empty if default exchange)
+		 * The exchange the listener is plugged to (empty if default exchange).
 		 * @since 3.2
 		 */
 		EXCHANGE {
@@ -80,7 +80,7 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * The routing key the listener is plugged to
+		 * The routing key the listener is plugged to.
 		 * @since 3.2
 		 */
 		ROUTING_KEY {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
@@ -80,7 +80,7 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * The delivery tags.
+		 * The delivery tag.
 		 * @since 3.2
 		 */
 		DELIVERY_TAG {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
@@ -24,6 +24,7 @@ import io.micrometer.observation.docs.ObservationDocumentation;
 
 /**
  * Spring Rabbit Observation for listeners.
+ *
  * @author Gary Russell
  * @author Vincent Meunier
  * @since 3.0
@@ -34,6 +35,7 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 	 * Observation for Rabbit listeners.
 	 */
 	LISTENER_OBSERVATION {
+
 		@Override
 		public Class<? extends ObservationConvention<? extends Context>> getDefaultConvention() {
 			return DefaultRabbitListenerObservationConvention.class;
@@ -60,6 +62,7 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 		 * Listener id.
 		 */
 		LISTENER_ID {
+
 			@Override
 			public String asString() {
 				return "spring.rabbit.listener.id";
@@ -69,9 +72,11 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 
 		/**
 		 * The queue the listener is plugged to.
+		 *
 		 * @since 3.2
 		 */
 		DESTINATION_NAME {
+
 			@Override
 			public String asString() {
 				return "messaging.destination.name";
@@ -81,9 +86,11 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 
 		/**
 		 * The delivery tag.
+		 *
 		 * @since 3.2
 		 */
 		DELIVERY_TAG {
+
 			@Override
 			public String asString() {
 				return "messaging.rabbitmq.message.delivery_tag";

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
@@ -68,10 +68,10 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * The exchange the listener is plugged to (empty if default exchange).
+		 * The queue the listener is plugged to.
 		 * @since 3.2
 		 */
-		EXCHANGE {
+		DESTINATION_NAME {
 			@Override
 			public String asString() {
 				return "messaging.destination.name";
@@ -80,16 +80,17 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * The routing key the listener is plugged to.
+		 * The delivery tags.
 		 * @since 3.2
 		 */
-		ROUTING_KEY {
+		DELIVERY_TAG {
 			@Override
 			public String asString() {
-				return "messaging.rabbitmq.destination.routing_key";
+				return "messaging.rabbitmq.message.delivery_tag";
 			}
 
 		}
+
 	}
 
 	/**
@@ -105,12 +106,13 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues(RabbitMessageReceiverContext context) {
+			final var messageProperties = context.getCarrier().getMessageProperties();
 			return KeyValues.of(
 					RabbitListenerObservation.ListenerLowCardinalityTags.LISTENER_ID.asString(), context.getListenerId(),
-					RabbitListenerObservation.ListenerLowCardinalityTags.EXCHANGE.asString(),
-					context.getCarrier().getMessageProperties().getReceivedExchange(),
-					RabbitListenerObservation.ListenerLowCardinalityTags.ROUTING_KEY.asString(),
-					context.getCarrier().getMessageProperties().getReceivedRoutingKey()
+					RabbitListenerObservation.ListenerLowCardinalityTags.DESTINATION_NAME.asString(),
+					messageProperties.getConsumerQueue(),
+					RabbitListenerObservation.ListenerLowCardinalityTags.DELIVERY_TAG.asString(),
+					String.valueOf(messageProperties.getDeliveryTag())
 			);
 		}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitListenerObservation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,9 @@ import io.micrometer.observation.docs.ObservationDocumentation;
 
 /**
  * Spring Rabbit Observation for listeners.
- *
  * @author Gary Russell
+ * @author Vincent Meunier
  * @since 3.0
- *
  */
 public enum RabbitListenerObservation implements ObservationDocumentation {
 
@@ -35,8 +34,6 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 	 * Observation for Rabbit listeners.
 	 */
 	LISTENER_OBSERVATION {
-
-
 		@Override
 		public Class<? extends ObservationConvention<? extends Context>> getDefaultConvention() {
 			return DefaultRabbitListenerObservationConvention.class;
@@ -63,14 +60,36 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 		 * Listener id.
 		 */
 		LISTENER_ID {
-
 			@Override
 			public String asString() {
 				return "spring.rabbit.listener.id";
 			}
 
-		}
+		},
 
+		/**
+		 * The exchange the listener is plugged to (empty if default exchange)
+		 * @since 3.2
+		 */
+		EXCHANGE {
+			@Override
+			public String asString() {
+				return "messaging.destination.name";
+			}
+
+		},
+
+		/**
+		 * The routing key the listener is plugged to
+		 * @since 3.2
+		 */
+		ROUTING_KEY {
+			@Override
+			public String asString() {
+				return "messaging.rabbitmq.destination.routing_key";
+			}
+
+		}
 	}
 
 	/**
@@ -86,8 +105,13 @@ public enum RabbitListenerObservation implements ObservationDocumentation {
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues(RabbitMessageReceiverContext context) {
-			return KeyValues.of(RabbitListenerObservation.ListenerLowCardinalityTags.LISTENER_ID.asString(),
-							context.getListenerId());
+			return KeyValues.of(
+					RabbitListenerObservation.ListenerLowCardinalityTags.LISTENER_ID.asString(), context.getListenerId(),
+					RabbitListenerObservation.ListenerLowCardinalityTags.EXCHANGE.asString(),
+					context.getCarrier().getMessageProperties().getReceivedExchange(),
+					RabbitListenerObservation.ListenerLowCardinalityTags.ROUTING_KEY.asString(),
+					context.getCarrier().getMessageProperties().getReceivedRoutingKey()
+			);
 		}
 
 		@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitTemplateObservation.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitTemplateObservation.java
@@ -72,7 +72,7 @@ public enum RabbitTemplateObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * The destination exchange (empty if default exchange)
+		 * The destination exchange (empty if default exchange).
 		 * @since 3.2
 		 */
 		EXCHANGE {
@@ -85,7 +85,7 @@ public enum RabbitTemplateObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * The destination routing key
+		 * The destination routing key.
 		 * @since 3.2
 		 */
 		ROUTING_KEY {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitTemplateObservation.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitTemplateObservation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import io.micrometer.observation.docs.ObservationDocumentation;
  * Spring RabbitMQ Observation for {@link org.springframework.amqp.rabbit.core.RabbitTemplate}.
  *
  * @author Gary Russell
+ * @author Vincent Meunier
  * @since 3.0
  *
  */
@@ -68,7 +69,32 @@ public enum RabbitTemplateObservation implements ObservationDocumentation {
 				return "spring.rabbit.template.name";
 			}
 
+		},
+
+		/**
+		 * The destination exchange (empty if default exchange)
+		 */
+		EXCHANGE {
+
+			@Override
+			public String asString() {
+				return "messaging.destination.name";
+			}
+
+		},
+
+		/**
+		 * The destination routing key
+		 */
+		ROUTING_KEY {
+
+			@Override
+			public String asString() {
+				return "messaging.rabbitmq.destination.routing_key";
+			}
+
 		}
+
 
 	}
 
@@ -85,8 +111,11 @@ public enum RabbitTemplateObservation implements ObservationDocumentation {
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues(RabbitMessageSenderContext context) {
-			return KeyValues.of(RabbitTemplateObservation.TemplateLowCardinalityTags.BEAN_NAME.asString(),
-							context.getBeanName());
+			return KeyValues.of(
+					TemplateLowCardinalityTags.BEAN_NAME.asString(), context.getBeanName(),
+					TemplateLowCardinalityTags.EXCHANGE.asString(), context.getExchange(),
+					TemplateLowCardinalityTags.ROUTING_KEY.asString(), context.getRoutingKey()
+			);
 		}
 
 		@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitTemplateObservation.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/micrometer/RabbitTemplateObservation.java
@@ -73,6 +73,7 @@ public enum RabbitTemplateObservation implements ObservationDocumentation {
 
 		/**
 		 * The destination exchange (empty if default exchange)
+		 * @since 3.2
 		 */
 		EXCHANGE {
 
@@ -85,6 +86,7 @@ public enum RabbitTemplateObservation implements ObservationDocumentation {
 
 		/**
 		 * The destination routing key
+		 * @since 3.2
 		 */
 		ROUTING_KEY {
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/micrometer/ObservationIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/micrometer/ObservationIntegrationTests.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/micrometer/ObservationIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/micrometer/ObservationIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,16 +72,20 @@ public class ObservationIntegrationTests extends SampleTestRunner {
 					.hasSize(4);
 			List<FinishedSpan> producerSpans = finishedSpans.stream()
 					.filter(span -> span.getKind().equals(Kind.PRODUCER))
-					.collect(Collectors.toList());
+					.toList();
 			List<FinishedSpan> consumerSpans = finishedSpans.stream()
 					.filter(span -> span.getKind().equals(Kind.CONSUMER))
-					.collect(Collectors.toList());
+					.toList();
 			SpanAssert.assertThat(producerSpans.get(0))
-					.hasTag("spring.rabbit.template.name", "template");
+					.hasTag("spring.rabbit.template.name", "template")
+					.hasTag("messaging.destination.name", "")
+					.hasTag("messaging.rabbitmq.destination.routing_key", "int.observation.testQ1");
 			SpanAssert.assertThat(producerSpans.get(0))
 					.hasRemoteServiceNameEqualTo("RabbitMQ");
 			SpanAssert.assertThat(producerSpans.get(1))
-					.hasTag("spring.rabbit.template.name", "template");
+					.hasTag("spring.rabbit.template.name", "template")
+					.hasTag("messaging.destination.name", "")
+					.hasTag("messaging.rabbitmq.destination.routing_key", "int.observation.testQ2");
 			SpanAssert.assertThat(consumerSpans.get(0))
 					.hasTagWithKey("spring.rabbit.listener.id");
 			SpanAssert.assertThat(consumerSpans.get(0))

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/micrometer/ObservationIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/micrometer/ObservationIntegrationTests.java
@@ -87,8 +87,8 @@ public class ObservationIntegrationTests extends SampleTestRunner {
 					.hasTag("messaging.rabbitmq.destination.routing_key", "int.observation.testQ2");
 			SpanAssert.assertThat(consumerSpans.get(0))
 					.hasTagWithKey("spring.rabbit.listener.id")
-					.hasTag("messaging.destination.name", "")
-					.hasTag("messaging.rabbitmq.destination.routing_key", "int.observation.testQ1");
+					.hasTag("messaging.destination.name", "int.observation.testQ1")
+					.hasTag("messaging.rabbitmq.message.delivery_tag", "1");
 			SpanAssert.assertThat(consumerSpans.get(0))
 					.hasRemoteServiceNameEqualTo("RabbitMQ");
 			assertThat(consumerSpans.get(0).getTags().get("spring.rabbit.listener.id")).isIn("obs1", "obs2");
@@ -97,8 +97,8 @@ public class ObservationIntegrationTests extends SampleTestRunner {
 			assertThat(consumerSpans.get(1).getTags().get("spring.rabbit.listener.id")).isIn("obs1", "obs2");
 			SpanAssert.assertThat(consumerSpans.get(1))
 					.hasTagWithKey("spring.rabbit.listener.id")
-					.hasTag("messaging.destination.name", "")
-					.hasTag("messaging.rabbitmq.destination.routing_key", "int.observation.testQ2");
+					.hasTag("messaging.destination.name", "int.observation.testQ2")
+					.hasTag("messaging.rabbitmq.message.delivery_tag", "1");
 			assertThat(consumerSpans.get(0).getTags().get("spring.rabbit.listener.id"))
 					.isNotEqualTo(consumerSpans.get(1).getTags().get("spring.rabbit.listener.id"));
 
@@ -120,15 +120,15 @@ public class ObservationIntegrationTests extends SampleTestRunner {
 					.hasTimerWithNameAndTags("spring.rabbit.listener",
 							KeyValues.of(
 									KeyValue.of("spring.rabbit.listener.id", "obs1"),
-									KeyValue.of("messaging.destination.name", ""),
-									KeyValue.of("messaging.rabbitmq.destination.routing_key", "int.observation.testQ1")
+									KeyValue.of("messaging.destination.name", "int.observation.testQ1"),
+									KeyValue.of("messaging.rabbitmq.message.delivery_tag", "1")
 							)
 					)
 					.hasTimerWithNameAndTags("spring.rabbit.listener",
 							KeyValues.of(
 									KeyValue.of("spring.rabbit.listener.id", "obs2"),
-									KeyValue.of("messaging.destination.name", ""),
-									KeyValue.of("messaging.rabbitmq.destination.routing_key", "int.observation.testQ2")
+									KeyValue.of("messaging.destination.name", "int.observation.testQ2"),
+									KeyValue.of("messaging.rabbitmq.message.delivery_tag", "1")
 							)
 					);
 		};


### PR DESCRIPTION
closes #2814

added message.destination.name and message.rabbitmq.destination.routing_key as new tags for RabbitTemplateObservationConvention 
added messaging.rabbitmq.message.delivery_tag and  message.destination.name to RabbitListenerObservationConvention