### PR TITLE
Correct typo from 'Connnection' to 'Connection'

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionListenerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ConnectionListenerTests.java
@@ -27,10 +27,11 @@ import org.springframework.amqp.AmqpIOException;
 
 /**
  * @author Gary Russell
+ * @author DongMin Park
  * @since 2.2.17
  *
  */
-public class ConnnectionListenerTests {
+public class ConnectionListenerTests {
 
 	@Test
 	void cantConnectCCF() {


### PR DESCRIPTION
Correct typo from 'Connnection' to 'Connection'. (`ConnnectionListenerTests.java` ->`ConnectionListenerTests.java`)