### PR TITLE
Improve condition for more readability

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractDeclarable.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/AbstractDeclarable.java
@@ -25,9 +25,9 @@ import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Base class for {@link Declarable} classes.
@@ -40,7 +40,7 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractDeclarable implements Declarable {
 
-	 private final Lock lock = new ReentrantLock();
+	private final Lock lock = new ReentrantLock();
 
 	private boolean shouldDeclare = true;
 
@@ -103,16 +103,18 @@ public abstract class AbstractDeclarable implements Declarable {
 
 	@Override
 	public void setAdminsThatShouldDeclare(Object... adminArgs) {
-		Collection<Object> admins = new ArrayList<>();
-		if (adminArgs != null) {
-			if (adminArgs.length > 1) {
-				Assert.noNullElements(adminArgs, "'admins' cannot contain null elements");
-			}
-			if (adminArgs.length > 0 && !(adminArgs.length == 1 && adminArgs[0] == null)) {
-				admins.addAll(Arrays.asList(adminArgs));
-			}
+		this.declaringAdmins = new ArrayList<>();
+		if (ObjectUtils.isEmpty(adminArgs)) {
+			return;
 		}
-		this.declaringAdmins = admins;
+
+		if (adminArgs.length > 1) {
+			Assert.noNullElements(adminArgs, "'admins' cannot contain null elements");
+			this.declaringAdmins.addAll(Arrays.asList(adminArgs));
+		}
+		else if (adminArgs[0] != null) {
+			this.declaringAdmins.add(adminArgs[0]);
+		}
 	}
 
 	@Override

--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.amqp.core;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -39,6 +40,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Ngoc Nhan
  */
 public class Address {
 
@@ -111,21 +113,9 @@ public class Address {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-
-		Address address = (Address) o;
-
-		return !(this.exchangeName != null
-				? !this.exchangeName.equals(address.exchangeName)
-				: address.exchangeName != null)
-				&& !(this.routingKey != null
-				? !this.routingKey.equals(address.routingKey)
-				: address.routingKey != null);
+		return o instanceof Address address
+				&& Objects.equals(this.exchangeName, address.exchangeName)
+				&& Objects.equals(this.routingKey, address.routingKey);
 	}
 
 	@Override

--- a/spring-amqp/src/test/java/org/springframework/amqp/core/AddressTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/core/AddressTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Ngoc Nhan
  */
 public class AddressTests {
 
@@ -100,6 +101,9 @@ public class AddressTests {
 	@Test
 	public void testEquals() {
 		assertThat(new Address("foo/bar")).isEqualTo(new Address("foo/bar"));
+		assertThat(new Address("foo", null)).isEqualTo(new Address("foo", null));
+		assertThat(new Address(null, "bar")).isEqualTo(new Address(null, "bar"));
+		assertThat(new Address(null, null)).isEqualTo(new Address(null, null));
 	}
 
 }


### PR DESCRIPTION
I read code in package `org.springframework.amqp.core` and I think some codebase conditions are too complex. I think we can make it simple for readability purpose.

That's why I create draft PR and I wonder whether I can continue to do this, at least in package `org.springframework.amqp.core`. Please let me know your thoughts