### PR TITLE
Make use compareAndSet instead lock

### DIFF
--- a/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/producer/RabbitStreamTemplate.java
+++ b/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/producer/RabbitStreamTemplate.java
@@ -177,7 +177,7 @@ public class RabbitStreamTemplate implements RabbitStreamOperations, Application
 	}
 
 	private void throwIfProducerAlreadyInitialized() {
-		if (producerInitialized.get()) {
+		if (this.producerInitialized.get()) {
 			throw new IllegalStateException("producer is already initialized");
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->

### Changes
1. Use compareAndSwap operation: CAS operation is more efficient than lock + unlock operation.
2. Set the parameters((superStreamRouting, producerCustomizer, ...) required to create a producer in advance : The parameters used to create a producer have no effect after the producer has been created, so i changed them to only have an effect when the producer is not initialized.
3. Rename streamConverter to streamMessageConverter.

### New found
- If send() and close() are executed at the same time, there is a race condition where producer becomes null but trying to call a method on producer