### PR TITLE
GH-2478 Handle conversion exception in AsyncRabbitTemplate

### DIFF
--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/AsyncRabbitTemplateTests.java
@@ -408,15 +408,9 @@ public class AsyncRabbitTemplateTests {
 
 		RabbitConverterFuture<String> replyFuture = this.asyncTemplate.convertSendAndReceive("conversionException");
 
-		final CountDownLatch cdl = new CountDownLatch(1);
-		final AtomicReference<Object> resultRef = new AtomicReference<>();
-        replyFuture.whenComplete((result, ex) -> {
-			resultRef.set(result);
-			cdl.countDown();
-		});
-        assertThat(cdl.await(10, TimeUnit.SECONDS)).isTrue();
-        assertThat(replyFuture).isCompletedExceptionally();
-        assertThat(resultRef.get()).isNull();
+		assertThat(replyFuture).failsWithin(Duration.ofSeconds(10))
+				.withThrowableThat()
+				.withCauseInstanceOf(MessageConversionException.class);
 	}
 
 	@Test


### PR DESCRIPTION
Previously, conversion errors in AsyncRabbitTemplate lead to AmqpReplyTimeoutException

Fixes https://github.com/spring-projects/spring-amqp/issues/2478

https://github.com/spring-projects/spring-amqp/issues/2478#issuecomment-2543745530