### PR TITLE
Fix README on publishing to local Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ If you encounter out of memory errors during the build, increase available heap 
 
 	GRADLE_OPTS='-XX:MaxPermSize=1024m -Xmx1024m'
 
-To build and install jars into your local Maven cache:
+To build and publish jars to your local Maven repository:
 
-	./gradlew install
+	./gradlew publishToMavenLocal
 
 To build api Javadoc (results will be in `build/api`):
 


### PR DESCRIPTION
Since the switch to the `maven-publish` plugin (instead of the deprecated `maven` plugin)
in 48e816d0a901893ed50a1fcd0c74009d3d0bee8c, the correct way to publish to a local Maven repository is to use the `publishToMavenLocal` task.

This updates this in the README, and also changes to wording from "Maven cache" to "Maven repository" (which is more in line with Maven terminology).

See the documentation for [the Maven Publish plugin here](https://docs.gradle.org/current/userguide/publishing_maven.html).

