### PR TITLE
Add convenient getter for stream name

### DIFF
--- a/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/listener/StreamListenerContainer.java
+++ b/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/listener/StreamListenerContainer.java
@@ -119,7 +119,9 @@ public class StreamListenerContainer extends ObservableListenerContainer {
 	}
 
 	/**
-	 * Get a name of stream this listener listens to.
+	 * Get a stream name this listener is subscribed to.
+	 * @return the stream name this listener is subscribed to.
+	 * @since 3.2.3
 	 */
 	public String getStreamName() {
 		return this.streamName;

--- a/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/listener/StreamListenerContainer.java
+++ b/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/listener/StreamListenerContainer.java
@@ -118,6 +118,13 @@ public class StreamListenerContainer extends ObservableListenerContainer {
 	}
 
 	/**
+	 * Get a name of stream this listener listens to.
+	 */
+	public String getStreamName() {
+		return streamName;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 * Mutually exclusive with {@link #superStream(String, String)}.
 	 */

--- a/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/listener/StreamListenerContainer.java
+++ b/spring-rabbit-stream/src/main/java/org/springframework/rabbit/stream/listener/StreamListenerContainer.java
@@ -57,6 +57,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Ngoc Nhan
  * @author Artem Bilan
+ * @author David Horak
  *
  * @since 2.4
  *
@@ -121,7 +122,7 @@ public class StreamListenerContainer extends ObservableListenerContainer {
 	 * Get a name of stream this listener listens to.
 	 */
 	public String getStreamName() {
-		return streamName;
+		return this.streamName;
 	}
 
 	/**


### PR DESCRIPTION
It would be nice to have `StreamListenerContainer.getStreamName()` method to fulfill need to dynamically stop/start listeners in reaction of broker events.

Let's say I need to react to RabbitMQ broker events of `queue.created` / `queue.deleted` ([see](https://www.rabbitmq.com/docs/event-exchange#rabbitmq-broker) ~ name of queue is sent in event) and I need to start and stop listeners, which are assigned to these streams. Currently I need to create an extra map of `listenerId` to `streamName` OR include streamName  in `listenerId` (e.g. `listener:{streamName}`) to be able to carry our operations on listener.

A simple getter for `streamName` on `StreamListenerContainer` would allow me to react to these changes dynamically without extra code effort.

An concise example with `BrokerEventListener`:
```java
private final RabbitListenerEndpointRegistry listenerRegistry;

@Bean
public BrokerEventListener eventListener(ConnectionFactory connectionFactory) {
    return new BrokerEventListener(connectionFactory, "queue.created", "queue.deleted");
}

@EventListener(condition = "event.eventType == 'queue.created'")
public void onQueueCreation(BrokerEvent event) {
    if (!event.getEventProperties().get("type").equals("rabbit_stream_queue")) {
        return; // handle only streams
    }
    final String createdStream = (String) event.getEventProperties().get("name");
    listenerRegistry.getListenerContainers()
        .stream()
        .filter(StreamListenerContainer.class::isInstance)
        .map(StreamListenerContainer.class::cast)
        .filter(listener -> listener.getStreamName().equals(createdStream))
        // .filter(listener -> listener.getListenerId().equals("listener:" + streamName)) // depends on listenerId without 'getStreamName'
        .forEach(listener -> listener.start());
}
```