### PR TITLE
Read x-death count in a safer way

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Ngoc Nhan
  * @author Johan Kaving
+ * @author Raul Avila
  *
  * @since 1.0
  */
@@ -147,7 +148,11 @@ public class DefaultMessagePropertiesConverter implements MessagePropertiesConve
 		if (target.getRetryCount() == 0) {
 			List<Map<String, ?>> xDeathHeader = target.getXDeathHeader();
 			if (!CollectionUtils.isEmpty(xDeathHeader)) {
-				target.setRetryCount((long) xDeathHeader.get(0).get("count"));
+				Object value = xDeathHeader.get(0).get("count");
+
+				if (value instanceof Number numberValue) {
+					target.setRetryCount(numberValue.longValue());
+				}
 			}
 		}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverterTests.java
@@ -105,6 +105,21 @@ public class DefaultMessagePropertiesConverterTests {
 	}
 
 	@Test
+	public void testToMessagePropertiesXDeathCount() {
+		Map<String, Object> headers = new HashMap<String, Object>();
+
+		headers.put("x-death", List.of(Map.of("count", Integer.valueOf(2))));
+
+		BasicProperties source = new BasicProperties.Builder()
+				.headers(headers)
+				.build();
+
+		MessageProperties messageProperties = messagePropertiesConverter.toMessageProperties(source, envelope, "UTF-8");
+
+		assertThat(messageProperties.getRetryCount()).isEqualTo(2);
+	}
+
+	@Test
 	public void testLongLongString() {
 		Map<String, Object> headers = new HashMap<String, Object>();
 		headers.put("longString", longString);


### PR DESCRIPTION
We had an issue in our system trying to consume a message from RabbitMQ that contained an `x-death` header, with `count` value typed as Integer. This caused a ClassCastException in https://github.com/spring-projects/spring-amqp/blob/355be1ee4c20dd1179c6eed59bb43fac5d18db6b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/support/DefaultMessagePropertiesConverter.java#L150

The reason the `count` value was an int and not a long is that we were storing headers in an internal database as part of a recovery process, and the typing was slightly changed during serialisation / deserialisation.

We propose this pull request to make the reading process of the `count` field in `x-death` header safer.