### PR TITLE
Improve connections document

### DIFF
--- a/src/reference/antora/antora-playbook.yml
+++ b/src/reference/antora/antora-playbook.yml
@@ -24,6 +24,7 @@ asciidoc:
     - '@asciidoctor/tabs'
     - '@springio/asciidoctor-extensions'
     - '@springio/asciidoctor-extensions/javadoc-extension'
+    - '@springio/asciidoctor-extensions/configuration-properties-extension'
   sourcemap: true
 urls:
   latest_version_segment: ''

--- a/src/reference/antora/modules/ROOT/pages/amqp/connections.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/connections.adoc
@@ -278,7 +278,7 @@ public ConnectionFactory rabbitConnectionFactory(ConnectionNameStrategy cns) {
 The property must exist in the application context's `Environment`.
 
 NOTE: When using Spring Boot and its autoconfigured connection factory, you need only declare the `ConnectionNameStrategy` `@Bean`.
-Boot auto-detects the bean and wires it into the factory.
+Spring Boot auto-detects the bean and wires it into the factory.
 
 [[blocked-connections-and-resource-constraints]]
 == Blocked Connections and Resource Constraints
@@ -332,8 +332,11 @@ Other setters delegate to the underlying factory.
 Previously, you had to configure the SSL options programmatically.
 The following example shows how to configure a `RabbitConnectionFactoryBean`:
 
+[tabs]
+======
+Java::
++
 [source,java,role=primary]
-.Java
 ----
 @Bean
 RabbitConnectionFactoryBean rabbitConnectionFactory() {
@@ -351,34 +354,40 @@ CachingConnectionFactory connectionFactory(ConnectionFactory rabbitConnectionFac
     return ccf;
 }
 ----
-[source,properties,role=secondary]
-.Boot application.properties
-----
-spring.rabbitmq.ssl.enabled:true
-spring.rabbitmq.ssl.keyStore=...
-spring.rabbitmq.ssl.keyStoreType=jks
-spring.rabbitmq.ssl.keyStorePassword=...
-spring.rabbitmq.ssl.trustStore=...
-spring.rabbitmq.ssl.trustStoreType=jks
-spring.rabbitmq.ssl.trustStorePassword=...
-spring.rabbitmq.host=...
-...
-----
+XML::
++
 [source,xml,role=secondary]
-.XML
 ----
-<rabbit:connection-factory id="rabbitConnectionFactory"
-    connection-factory="clientConnectionFactory"
-    host="${host}"
-    port="${port}"
-    virtual-host="${vhost}"
-    username="${username}" password="${password}" />
-
-<bean id="clientConnectionFactory"
+<bean id="rabbitConnectionFactory"
         class="org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean">
     <property name="useSSL" value="true" />
     <property name="sslPropertiesLocation" value="classpath:secrets/rabbitSSL.properties"/>
 </bean>
+
+<rabbit:connection-factory id="connectionFactory"
+    connection-factory="rabbitConnectionFactory"
+    host="${host}"
+    port="${port}"
+    virtual-host="${vhost}"
+    username="${username}" password="${password}" />
+----
+======
+
+Spring Boot application file (`.yaml` or `.properties`)
+
+[configprops%novalidate,yaml]
+----
+spring:
+  rabbitmq:
+    host: ...
+    ssl:
+      keyStoreType: jks
+      trustStoreType: jks
+      keyStore: ...
+      trustStore: ...
+      trustStorePassword: ...
+      keyStorePassword: ...
+      enabled: true
 ----
 
 See the https://www.rabbitmq.com/ssl.html[RabbitMQ Documentation] for information about configuring SSL.
@@ -622,7 +631,7 @@ To add `WebFlux` to the class path:
 compile 'org.springframework.amqp:spring-rabbit'
 ----
 
-You can also use other REST technology by implementing `LocalizedQueueConnectionFactory.NodeLocator` and overriding its `createClient, ``restCall`, and optionally, `close` methods.
+You can also use other REST technology by implementing javadoc:org.springframework.amqp.rabbit.connection.LocalizedQueueConnectionFactory#setNodeLocator(org.springframework.amqp.rabbit.connection.NodeLocator)[LocalizedQueueConnectionFactory#setNodeLocator] and overriding its `createClient`, `restCall`, and optionally, `close` methods.
 
 [source, java]
 ----
@@ -634,9 +643,9 @@ lqcf.setNodeLocator(new NodeLocator<MyClient>() {
     }
 
     @Override
-    public HashMap<String, Object> restCall(MyClient client, URI uri) {
+    public Map<String, Object> restCall(MyClient client, String baseUri, String vhost, String queue) throws URISyntaxException {
         ...
-    });
+    }
 
 });
 ----


### PR DESCRIPTION
Current Reference
https://docs.spring.io/spring-amqp/reference/4.0-SNAPSHOT/amqp/connections.html

I've updated the code example and also replaced the outdated`NodeLocator` example.

I think we can apply the `configprops` tag to display the properties or yaml file, in the code block below the 'Spring Boot application file (`.yaml` or `.properties`)' section shown in the image.

The result 
![image](https://github.com/user-attachments/assets/7b2d30b2-3b28-4a98-9048-fdec0d97205d)

