### PR TITLE
GH-3079: allow sending ACKs within the ShutdownTimeout period

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -888,7 +888,7 @@ public class BlockingQueueConsumer {
 
 	/**
 	 * Perform a commit or message acknowledgement, as appropriate.
-	 * NOTE: This method was never been intended tobe public.
+	 * NOTE: This method was never intended to be public.
 	 * @param localTx Whether the channel is locally transacted.
 	 * @param forceAck perform {@link Channel#basicAck(long, boolean)} independently of {@link #acknowledgeMode}.
 	 * @return true if at least one delivery tag exists.
@@ -909,7 +909,7 @@ public class BlockingQueueConsumer {
 		try {
 			boolean ackRequired = forceAck || (!this.acknowledgeMode.isAutoAck() && !this.acknowledgeMode.isManual());
 
-			if (ackRequired && (!this.transactional || (isLocallyTransacted && !cancelled()))) {
+			if (ackRequired && (!this.transactional || isLocallyTransacted)) {
 				OptionalLong deliveryTag = this.deliveryTags.stream().mapToLong(l -> l).max();
 				deliveryTag.ifPresent((tag) -> {
 					try {


### PR DESCRIPTION
Refer to https://github.com/spring-projects/spring-amqp/issues/3079

When the process shutdown, within the `shutdownTimeout` period, we want to allow sending `Basic.Ack` replies to processed in-flight message.