### PR TITLE
Fixed issue #3122

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1225,7 +1225,8 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 				else {
 					if (e instanceof org.springframework.amqp.rabbit.listener.exception.MessageRejectedWhileStoppingException) {
 						this.logger.info("Listener rejected message while stopping (requeued)", e);
-					} else {
+					}
+					else {
 						this.logger.error("Failed to invoke listener", e);
 					}
 					if (this.transactionManager != null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1223,7 +1223,11 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 					handleAck(deliveryTag, channelLocallyTransacted);
 				}
 				else {
-					this.logger.error("Failed to invoke listener", e);
+					if (e instanceof org.springframework.amqp.rabbit.listener.exception.MessageRejectedWhileStoppingException) {
+						this.logger.info("Listener rejected message while stopping (requeued)", e);
+					} else {
+						this.logger.error("Failed to invoke listener", e);
+					}
 					if (this.transactionManager != null) {
 						if (this.transactionAttribute.rollbackOn(e)) {
 							RabbitResourceHolder resourceHolder =


### PR DESCRIPTION
Description:
This PR addresses issue #3122 by changing the log level for <i><b>MessageRejectedWhileStoppingException</b></i>  in 
<i><b>DirectMessageListenerContainer</b></i>. Previously, this exception was always logged at the error level, even though it is expected during an orderly shutdown and does not indicate a real error. Now, when this exception occurs, it is logged at the info level, reducing unnecessary error noise in logs.

Related Issue:
Fixes #3122

Details:

In <i><b>callExecuteListener</b></i>, exceptions of type <i><b>MessageRejectedWhileStoppingException</b></i> are now logged at info level. All other exceptions continue to be logged as errors.