### PR TITLE
Update anchor id and add JUnit section

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-1-7-since-1-6.adoc
+++ b/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-1-7-since-1-6.adoc
@@ -51,7 +51,7 @@ The framework is no longer compatible with previous versions.
 == JUnit `@Rules`
 
 Rules that have previously been used internally by the framework have now been made available in a separate jar called `spring-rabbit-junit`.
-See xref:testing.adoc#junit-rules[JUnit4 `@Rules`] for more information.
+See <<junit4-rules>> for more information.
 
 [[container-conditional-rollback]]
 == Container Conditional Rollback
@@ -74,3 +74,32 @@ See xref:amqp/connections.adoc[Connection and Resource Management] for more info
 You can now configure message re-queue on transaction rollback to be consistent, regardless of whether or not a transaction manager is configured.
 See xref:amqp/transactions.adoc#transaction-rollback[A note on Rollback of Received Messages] for more information.
 
+[[junit4-rules]]
+== JUnit4 `@Rules`
+
+Spring AMQP version 1.7 and later provide an additional jar called `spring-rabbit-junit`.
+This jar contains a couple of utility `@Rule` instances for use when running JUnit4 tests.
+See xref:testing.adoc#junit5-conditions[JUnit5 Conditions] for JUnit5 testing.
+
+[[using-brokerrunning]]
+=== Using `BrokerRunning`
+
+`BrokerRunning` provides a mechanism to let tests succeed when a broker is not running (on `localhost`, by default).
+
+It also has utility methods to initialize and empty queues and delete queues and exchanges.
+
+The following example shows its usage:
+
+[source, java]
+----
+
+@ClassRule
+public static BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues("foo", "bar");
+
+@AfterClass
+public static void tearDown() {
+    brokerRunning.removeTestQueues("some.other.queue.too"); // removes foo, bar as well
+}
+----
+
+There are several `isRunning...` static methods, such as `isBrokerAndManagementRunning()`, which verifies the broker has the management plugin enabled.

--- a/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-2-2-since-2-1.adoc
+++ b/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-2-2-since-2-1.adoc
@@ -21,7 +21,7 @@ JUnit (4) is now an optional dependency and will no longer appear as a transitiv
 
 The `spring-rabbit-junit` module is now a *compile* dependency in the `spring-rabbit-test` module for a better target application development experience when with only a single `spring-rabbit-test` we get the full stack of testing utilities for AMQP components.
 
-[[-breaking-api-changes]]
+[[breaking-api-changes]]
 == "Breaking" API Changes
 
 the JUnit (5) `RabbitAvailableCondition.getBrokerRunning()` now returns a `BrokerRunningSupport` instance instead of a `BrokerRunning`, which depends on JUnit 4.
@@ -87,7 +87,7 @@ See xref:logging.adoc[Logging Subsystem AMQP Appenders] for more information.
 The `MessageListenerAdapter` provides now a new `buildListenerArguments(Object, Channel, Message)` method  to build an array of arguments to be passed into target listener and an old one is deprecated.
 See xref:amqp/receiving-messages/async-consumer.adoc#message-listener-adapter[`MessageListenerAdapter`] for more information.
 
-[[exchange/queue-declaration-changes]]
+[[exchange-queue-declaration-changes]]
 == Exchange/Queue Declaration Changes
 
 The `ExchangeBuilder` and `QueueBuilder` fluent APIs used to create `Exchange` and `Queue` objects for declaration by `RabbitAdmin` now support "well known" arguments.


### PR DESCRIPTION
Since gh-3055 deprecates the JUnit 4 section but the `changes-in-1-7-since-1-6.adoc` still references JUnit4 section, I think we should add it to `changes-in-1-7-since-1-6.adoc`.