### PR TITLE
feat: add classic queue type option to QueueBuilder

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/QueueBuilder.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/QueueBuilder.java
@@ -246,7 +246,7 @@ public final class QueueBuilder extends AbstractBuilder {
 	/**
 	 * Set the queue argument to declare a queue of type 'classic' instead of default type.
 	 * @return the builder.
-	 * @since 2.2.2
+	 * @since 3.2.10
 	 */
 	public QueueBuilder classic() {
 		return withArgument("x-queue-type", "classic");


### PR DESCRIPTION
"QueueBuilder" sets the default queue type if no argument is provided. Judging by the fact that "classic()" option doesn't exist, it is believed that the default type is always "classic". But it could be any.

In my project, SRE set the default type to "quorum". And I had to override with "withArguments" method. I think that we also need more convenient "classic" method.

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
