### PR TITLE
GH-3365: Fix AmqpListenerAnnBPP for lazy init

### DIFF
--- a/spring-amqp-client/src/main/java/org/springframework/amqp/client/annotation/AmqpListenerAnnotationBeanPostProcessor.java
+++ b/spring-amqp-client/src/main/java/org/springframework/amqp/client/annotation/AmqpListenerAnnotationBeanPostProcessor.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.aopalliance.aop.Advice;
 import org.jspecify.annotations.Nullable;
@@ -59,7 +59,7 @@ import org.springframework.util.ObjectUtils;
  */
 public class AmqpListenerAnnotationBeanPostProcessor extends AbstractListenerAnnotationBeanPostProcessor<AmqpListener> {
 
-	private final Map<MethodAmqpListenerEndpoint, @Nullable AmqpMessageListenerContainerFactory> endpoints =
+	private final Map<MethodAmqpListenerEndpoint, Supplier<@Nullable AmqpMessageListenerContainerFactory>> endpoints =
 			new HashMap<>();
 
 	private @Nullable AmqpListenerEndpointRegistry amqpListenerEndpointRegistry;
@@ -127,63 +127,78 @@ public class AmqpListenerAnnotationBeanPostProcessor extends AbstractListenerAnn
 	private void processListener(MethodAmqpListenerEndpoint endpoint, AmqpListener listener,
 			Method method, String beanName) {
 
-		JavaUtils.INSTANCE
-				.acceptIfHasText(resolveExpressionAsString(listener.id(), "id"), endpoint::setId)
-				.acceptIfHasText(listener.returnExceptions(),
-						(value) -> endpoint.setReturnExceptions(resolveExpressionAsBoolean(value)))
-				.acceptIfHasText(listener.defaultRequeueRejected(),
-						(value) -> endpoint.setDefaultRequeueRejected(resolveExpressionAsBoolean(value)))
-				.acceptIfHasText(listener.autoStartup(),
-						(value) -> endpoint.setAutoStartup(resolveExpressionAsBoolean(value)))
-				.acceptIfHasText(listener.autoAccept(),
-						(value) -> endpoint.setAutoAccept(resolveExpressionAsBoolean(value)))
-				.acceptIfNotNull(resolveExpressionToInteger(listener.concurrency(), "concurrency"),
-						endpoint::setConcurrency)
-				.acceptIfNotNull(resolveExpressionToInteger(listener.initialCredits(), "initialCredits"),
-						endpoint::setInitialCredits)
-				.acceptIfHasText(resolveExpressionAsString(listener.receiveTimeout(), "receiveTimeout"),
-						(value) -> endpoint.setReceiveTimeout(toDuration(value, TimeUnit.MILLISECONDS)))
-				.acceptIfHasText(resolveExpressionAsString(listener.gracefulShutdownPeriod(), "gracefulShutdownPeriod"),
-						(value) -> endpoint.setGracefulShutdownPeriod(toDuration(value, TimeUnit.MILLISECONDS)))
-				.acceptIfHasText(resolveExpressionAsString(listener.replyContentType(), "replyContentType"),
-						endpoint::setReplyContentType)
-				.acceptIfNotNull(resolveExpressionToBean(listener.errorHandler(), "errorHandler", method, beanName,
-						AmqpListenerErrorHandler.class), endpoint::setErrorHandler)
-				.acceptIfNotNull(resolveExpressionToBean(listener.executor(), "executor", method, beanName,
-						Executor.class), endpoint::setTaskExecutor)
-				.acceptIfNotNull(resolveExpressionToBean(listener.headerMapper(), "headerMapper", method, beanName,
-						AmqpHeaderMapper.class), endpoint::setHeaderMapper)
-				.acceptIfNotNull(resolveExpressionToBean(listener.replyPostProcessor(), "replyPostProcessor", method,
-						beanName, ReplyPostProcessor.class), endpoint::setReplyPostProcessor)
-				.acceptIfNotNull(resolveExpressionToBean(listener.messageConverter(), "messageConverter", method,
-						beanName, MessageConverter.class), endpoint::setMessageConverter);
+		Supplier<@Nullable AmqpMessageListenerContainerFactory> containerFactorySupplier =
+				() -> {
+					JavaUtils.INSTANCE
+							.acceptIfHasText(resolveExpressionAsString(listener.id(), "id"), endpoint::setId)
+							.acceptIfHasText(listener.returnExceptions(),
+									(value) -> endpoint.setReturnExceptions(resolveExpressionAsBoolean(value)))
+							.acceptIfHasText(listener.defaultRequeueRejected(),
+									(value) ->
+											endpoint.setDefaultRequeueRejected(resolveExpressionAsBoolean(value)))
+							.acceptIfHasText(listener.autoStartup(),
+									(value) -> endpoint.setAutoStartup(resolveExpressionAsBoolean(value)))
+							.acceptIfHasText(listener.autoAccept(),
+									(value) -> endpoint.setAutoAccept(resolveExpressionAsBoolean(value)))
+							.acceptIfNotNull(resolveExpressionToInteger(listener.concurrency(), "concurrency"),
+									endpoint::setConcurrency)
+							.acceptIfNotNull(resolveExpressionToInteger(listener.initialCredits(), "initialCredits"),
+									endpoint::setInitialCredits)
+							.acceptIfHasText(resolveExpressionAsString(listener.receiveTimeout(), "receiveTimeout"),
+									(value) -> endpoint.setReceiveTimeout(toDuration(value)))
+							.acceptIfHasText(
+									resolveExpressionAsString(listener.gracefulShutdownPeriod(),
+											"gracefulShutdownPeriod"),
+									(value) -> endpoint.setGracefulShutdownPeriod(toDuration(value)))
+							.acceptIfHasText(resolveExpressionAsString(listener.replyContentType(), "replyContentType"),
+									endpoint::setReplyContentType)
+							.acceptIfNotNull(
+									resolveExpressionToBean(listener.errorHandler(), "errorHandler", method, beanName,
+											AmqpListenerErrorHandler.class), endpoint::setErrorHandler)
+							.acceptIfNotNull(
+									resolveExpressionToBean(listener.executor(), "executor", method, beanName,
+											Executor.class),
+									endpoint::setTaskExecutor)
+							.acceptIfNotNull(
+									resolveExpressionToBean(listener.headerMapper(), "headerMapper", method, beanName,
+											AmqpHeaderMapper.class),
+									endpoint::setHeaderMapper)
+							.acceptIfNotNull(
+									resolveExpressionToBean(listener.replyPostProcessor(), "replyPostProcessor", method,
+											beanName, ReplyPostProcessor.class),
+									endpoint::setReplyPostProcessor)
+							.acceptIfNotNull(
+									resolveExpressionToBean(listener.messageConverter(), "messageConverter", method,
+											beanName, MessageConverter.class),
+									endpoint::setMessageConverter);
 
-		BeanFactory beanFactory = getBeanFactory();
-		String[] adviceNamesChain = listener.adviceChain();
-		if (!ObjectUtils.isEmpty(adviceNamesChain)) {
-			Advice[] adviceChain =
-					Arrays.stream(adviceNamesChain)
-							.map((name) -> beanFactory.getBean(name, Advice.class))
-							.toArray(Advice[]::new);
-			endpoint.setAdviceChain(adviceChain);
-		}
+					BeanFactory beanFactory = getBeanFactory();
+					String[] adviceNamesChain = listener.adviceChain();
+					if (!ObjectUtils.isEmpty(adviceNamesChain)) {
+						Advice[] adviceChain =
+								Arrays.stream(adviceNamesChain)
+										.map((name) -> beanFactory.getBean(name, Advice.class))
+										.toArray(Advice[]::new);
+						endpoint.setAdviceChain(adviceChain);
+					}
 
-		AmqpMessageListenerContainerFactory containerFactory =
-				resolveExpressionToBean(listener.containerFactory(), "containerFactory", method, beanName,
-						AmqpMessageListenerContainerFactory.class);
+					return resolveExpressionToBean(listener.containerFactory(), "containerFactory", method, beanName,
+							AmqpMessageListenerContainerFactory.class);
+				};
 
 		if (this.amqpListenerEndpointRegistry == null) {
-			this.endpoints.put(endpoint, containerFactory);
+			this.endpoints.put(endpoint, containerFactorySupplier);
 		}
 		else {
-			registerListenerEndpoint(endpoint, containerFactory);
+			registerListenerEndpoint(endpoint, containerFactorySupplier);
 		}
 	}
 
 	@SuppressWarnings("NullAway")
 	private void registerListenerEndpoint(MethodAmqpListenerEndpoint endpoint,
-			@Nullable AmqpMessageListenerContainerFactory containerFactory) {
+			Supplier<@Nullable AmqpMessageListenerContainerFactory> containerFactorySupplier) {
 
+		AmqpMessageListenerContainerFactory containerFactory = containerFactorySupplier.get();
 		if (containerFactory != null) {
 			this.amqpListenerEndpointRegistry.registerListenerEndpoint(containerFactory, endpoint);
 		}

--- a/spring-amqp/src/main/java/org/springframework/amqp/listener/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/listener/AbstractListenerAnnotationBeanPostProcessor.java
@@ -298,6 +298,10 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 		return value;
 	}
 
+	protected static Duration toDuration(String value) {
+		return toDuration(value, TimeUnit.MILLISECONDS);
+	}
+
 	protected static Duration toDuration(String value, TimeUnit timeUnit) {
 		DurationFormat.Unit unit = DurationFormat.Unit.fromChronoUnit(timeUnit.toChronoUnit());
 		return DurationFormatterUtils.detectAndParse(value, unit);


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-amqp/issues/3365

When the `@AmqpListener` is declared in the same `@Configuration` with any beans referenced from the annotation, it may lead to the `BeanCurrentlyInCreationException`

* Fix `AmqpListenerAnnotationBeanPostProcessor` to defer annotation attributes resolution until after the whole application context is ready unsing `Supplier` callback as endpoints map value
* Add convenient `AbstractListenerAnnotationBeanPostProcessor.toDuration()` based on the `TimeUnit.MILLISECONDS`

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
