### PR TITLE
Migrate to Gradle version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 	id 'base'
 	id 'idea'
 	alias(libs.plugins.antora)
-	alias(libs.plugins.io.spring.antora.generate.yml)
+	alias(libs.plugins.spring.antora.generateYml)
 	alias(libs.plugins.aggregate.javadoc)
 	alias(libs.plugins.nullability) apply false
 }
@@ -89,15 +89,16 @@ allprojects {
 	}
 
 	dependencies {
-		dependencyManagement(platform(libs.com.fasterxml.jackson.bom))
+		dependencyManagement(platform(libs.fasterxml.jackson.bom))
 		dependencyManagement(platform(libs.tools.jackson.bom))
-		dependencyManagement(platform(libs.org.junit.bom))
+		dependencyManagement(platform(libs.junit.bom))
+		dependencyManagement(platform(libs.mockito.bom))
 		dependencyManagement(platform(libs.spring.framework.bom))
-		dependencyManagement(platform(libs.io.projectreactor.bom))
-		dependencyManagement(platform(libs.apache.logging.log4j.bom))
+		dependencyManagement(platform(libs.reactor.bom))
+		dependencyManagement(platform(libs.log4j.bom))
 		dependencyManagement(platform(libs.spring.data.bom))
-		dependencyManagement(platform(libs.io.micrometer.bom))
-		dependencyManagement(platform(libs.io.micrometer.tracing.bom))
+		dependencyManagement(platform(libs.micrometer.bom))
+		dependencyManagement(platform(libs.micrometer.tracing.bom))
 		dependencyManagement(platform(libs.testcontainers.bom))
 	}
 }
@@ -156,18 +157,18 @@ configure(javaProjects) { subproject ->
 		testImplementation spotBugs
 
 		testImplementation 'org.apache.logging.log4j:log4j-core'
-		testImplementation libs.org.hamcrest
-		testImplementation libs.org.mockito.core
-		testImplementation libs.org.mockito.junit.jupiter
+		testImplementation libs.hamcrest
+		testImplementation 'org.mockito:mockito-core'
+		testImplementation 'org.mockito:mockito-junit-jupiter'
 		testImplementation 'org.springframework:spring-test'
 		testImplementation 'org.junit.jupiter:junit-jupiter-api'
 		testImplementation 'org.junit.jupiter:junit-jupiter-params'
 		testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 		testImplementation 'org.junit.platform:junit-platform-launcher'
-		testImplementation libs.org.awaitility
+		testImplementation libs.awaitility
 		testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
 		testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-		testImplementation libs.com.willowtreeapps.assertk
+		testImplementation libs.assertk
 
 		testRuntimeOnly 'org.apache.logging.log4j:log4j-jcl'
 		testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
@@ -281,9 +282,9 @@ project('spring-amqp') {
 		optionalApi 'tools.jackson.module:jackson-module-kotlin'
 		// Spring Data projection message binding support
 		optionalApi 'org.springframework.data:spring-data-commons'
-		optionalApi libs.com.jayway.jsonpath
+		optionalApi libs.jsonpath
 
-		testImplementation libs.org.assertj.core
+		testImplementation libs.assertj
 	}
 
 }
@@ -316,13 +317,13 @@ project('spring-amqp-client') {
 
 	dependencies {
 		api project(':spring-amqp')
-		api libs.org.apache.qpid.protonj2.client
+		api libs.qpid.protonj2.client
 		api 'org.springframework:spring-context'
 		api 'org.springframework:spring-messaging'
 
 		testImplementation project(':spring-rabbit-junit')
 		testImplementation 'io.projectreactor:reactor-core'
-		testImplementation libs.org.jetbrains.kotlinx.coroutines.reactor
+		testImplementation libs.kotlinx.coroutines.reactor
 		testImplementation 'org.testcontainers:testcontainers-rabbitmq'
 		testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
 
@@ -336,7 +337,7 @@ project('spring-rabbit') {
 
 	dependencies {
 		api project(':spring-amqp')
-		api libs.com.rabbitmq.amqp.client
+		api libs.rabbitmq.amqp.client
 		api 'org.springframework:spring-context'
 		api 'org.springframework:spring-messaging'
 		api 'org.springframework:spring-tx'
@@ -344,27 +345,27 @@ project('spring-rabbit') {
 
 		optionalApi 'org.springframework:spring-aop'
 		optionalApi 'org.springframework:spring-webflux'
-		optionalApi libs.apache.httpcomponents.httpclient5
+		optionalApi libs.httpclient5
 		optionalApi 'io.projectreactor:reactor-core'
 		optionalApi 'io.projectreactor.netty:reactor-netty-http'
-		optionalApi libs.ch.qos.logback
+		optionalApi libs.logback
 		optionalApi 'org.apache.logging.log4j:log4j-core'
 		optionalApi 'io.micrometer:micrometer-core'
 		optionalApi 'io.micrometer:micrometer-tracing'
-		optionalApi libs.apache.commons.pool2
-		optionalApi libs.org.jetbrains.kotlinx.coroutines.reactor
+		optionalApi libs.commons.pool2
+		optionalApi libs.kotlinx.coroutines.reactor
 
 		testImplementation project(':spring-rabbit-junit')
 		testImplementation 'org.springframework.data:spring-data-commons'
-		testImplementation libs.com.jayway.jsonpath
-		testImplementation libs.org.hibernate.validator
+		testImplementation libs.jsonpath
+		testImplementation libs.hibernate.validator
 		testImplementation 'io.micrometer:micrometer-observation-test'
 		testImplementation 'io.micrometer:micrometer-tracing-bridge-brave'
 		testImplementation 'io.micrometer:micrometer-tracing-test'
 		testImplementation 'io.micrometer:micrometer-tracing-integration-test'
 		testImplementation 'org.testcontainers:testcontainers-rabbitmq'
 		testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
-		testImplementation libs.apache.httpcomponents.httpclient5
+		testImplementation libs.httpclient5
 
 		testRuntimeOnly 'tools.jackson.core:jackson-databind'
 		testRuntimeOnly 'tools.jackson.dataformat:jackson-dataformat-xml'
@@ -376,7 +377,7 @@ project('spring-rabbit-stream') {
 
 	dependencies {
 		api project(':spring-rabbit')
-		api libs.com.rabbitmq.stream.client
+		api libs.rabbitmq.stream.client
 
 		optionalApi 'io.micrometer:micrometer-core'
 
@@ -399,7 +400,7 @@ project('spring-rabbitmq-client') {
 
 	dependencies {
 		api project(':spring-rabbit')
-		api libs.com.rabbitmq.client.amqp
+		api libs.rabbitmq.client.amqp
 
 		testImplementation project(':spring-rabbit-junit')
 		testImplementation 'io.projectreactor:reactor-core'
@@ -416,14 +417,14 @@ project('spring-rabbit-junit') {
 	dependencies { // no spring-amqp dependencies allowed
 		api 'org.springframework:spring-core'
 		api 'org.springframework:spring-test'
-		api libs.com.rabbitmq.amqp.client
+		api libs.rabbitmq.amqp.client
 		api 'org.springframework:spring-web'
 		api 'org.junit.jupiter:junit-jupiter-api'
-		api libs.org.assertj.core
+		api libs.assertj
 
 		optionalApi 'org.testcontainers:testcontainers-rabbitmq'
 		optionalApi 'org.testcontainers:testcontainers-junit-jupiter'
-		optionalApi libs.ch.qos.logback
+		optionalApi libs.logback
 		optionalApi 'org.apache.logging.log4j:log4j-core'
 	}
 }
@@ -434,8 +435,8 @@ project('spring-rabbit-test') {
 	dependencies {
 		api project(':spring-rabbit')
 		api project(':spring-rabbit-junit')
-		api libs.org.hamcrest
-		api libs.org.mockito.core
+		api libs.hamcrest
+		api 'org.mockito:mockito-core'
 
 		testImplementation project(':spring-rabbit').sourceSets.test.output
 	}
@@ -446,7 +447,7 @@ configurations {
 }
 
 dependencies {
-	micrometerDocs libs.io.micrometer.docs.generator
+	micrometerDocs libs.micrometer.docs.generator
 }
 
 def observationInputDir = file('build/docs/microsources').absolutePath

--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,10 @@ buildscript {
 plugins {
 	id 'base'
 	id 'idea'
-	id 'org.antora' version '1.0.0'
-	id 'io.spring.antora.generate-antora-yml' version '0.0.1'
-	id 'io.freefair.aggregate-javadoc' version '9.2.0'
-	id 'io.spring.nullability' version '0.0.12' apply false
+	alias(libs.plugins.antora)
+	alias(libs.plugins.io.spring.antora.generate.yml)
+	alias(libs.plugins.aggregate.javadoc)
+	alias(libs.plugins.nullability) apply false
 }
 
 description = 'Spring AMQP'
@@ -28,34 +28,6 @@ ext {
 	linkScmUrl = 'https://github.com/spring-projects/spring-amqp'
 	linkScmConnection = 'git://github.com/spring-projects/spring-amqp.git'
 	linkScmDevConnection = 'git@github.com:spring-projects/spring-amqp.git'
-
-	assertjVersion = '3.27.7'
-	assertkVersion = '0.28.1'
-	awaitilityVersion = '4.3.0'
-	commonsHttpClientVersion = '5.6'
-	commonsPoolVersion = '2.13.0'
-	hamcrestVersion = '3.0'
-	hibernateValidationVersion = '9.1.0.Final'
-	jacksonBomVersion = '2.21.2'
-	jackson3Version = '3.1.1'
-	jaywayJsonPathVersion = '3.0.0'
-	junitJupiterVersion = '6.0.3'
-	kotlinCoroutinesVersion = '1.10.2'
-	log4jVersion = '2.25.4'
-	logbackVersion = '1.5.32'
-	micrometerDocsVersion = '1.0.4'
-	micrometerVersion = '1.17.0-SNAPSHOT'
-	micrometerTracingVersion = '1.7.0-SNAPSHOT'
-	mockitoVersion = '5.23.0'
-	protonjVersion = '1.1.0'
-	rabbitmqAmqpClientVersion = '0.9.0'
-	rabbitmqStreamVersion = '1.5.0'
-	rabbitmqVersion = '5.29.0'
-	reactorVersion = '2025.0.4'
-	springDataVersion = '2026.0.0-SNAPSHOT'
-	springVersion = '7.0.6'
-	testcontainersVersion = '2.0.4'
-
 	javaProjects = subprojects - project(':spring-amqp-bom')
 }
 
@@ -117,16 +89,16 @@ allprojects {
 	}
 
 	dependencies {
-		dependencyManagement(platform("com.fasterxml.jackson:jackson-bom:$jacksonBomVersion"))
-		dependencyManagement(platform("tools.jackson:jackson-bom:$jackson3Version"))
-		dependencyManagement(platform("org.junit:junit-bom:$junitJupiterVersion"))
-		dependencyManagement(platform("org.springframework:spring-framework-bom:$springVersion"))
-		dependencyManagement(platform("io.projectreactor:reactor-bom:$reactorVersion"))
-		dependencyManagement(platform("org.apache.logging.log4j:log4j-bom:$log4jVersion"))
-		dependencyManagement(platform("org.springframework.data:spring-data-bom:$springDataVersion"))
-		dependencyManagement(platform("io.micrometer:micrometer-bom:$micrometerVersion"))
-		dependencyManagement(platform("io.micrometer:micrometer-tracing-bom:$micrometerTracingVersion"))
-		dependencyManagement(platform("org.testcontainers:testcontainers-bom:$testcontainersVersion"))
+		dependencyManagement(platform(libs.com.fasterxml.jackson.bom))
+		dependencyManagement(platform(libs.tools.jackson.bom))
+		dependencyManagement(platform(libs.org.junit.bom))
+		dependencyManagement(platform(libs.spring.framework.bom))
+		dependencyManagement(platform(libs.io.projectreactor.bom))
+		dependencyManagement(platform(libs.apache.logging.log4j.bom))
+		dependencyManagement(platform(libs.spring.data.bom))
+		dependencyManagement(platform(libs.io.micrometer.bom))
+		dependencyManagement(platform(libs.io.micrometer.tracing.bom))
+		dependencyManagement(platform(libs.testcontainers.bom))
 	}
 }
 
@@ -184,18 +156,18 @@ configure(javaProjects) { subproject ->
 		testImplementation spotBugs
 
 		testImplementation 'org.apache.logging.log4j:log4j-core'
-		testImplementation "org.hamcrest:hamcrest-core:$hamcrestVersion"
-		testImplementation "org.mockito:mockito-core:$mockitoVersion"
-		testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
+		testImplementation libs.org.hamcrest
+		testImplementation libs.org.mockito.core
+		testImplementation libs.org.mockito.junit.jupiter
 		testImplementation 'org.springframework:spring-test'
 		testImplementation 'org.junit.jupiter:junit-jupiter-api'
 		testImplementation 'org.junit.jupiter:junit-jupiter-params'
 		testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 		testImplementation 'org.junit.platform:junit-platform-launcher'
-		testImplementation "org.awaitility:awaitility:$awaitilityVersion"
+		testImplementation libs.org.awaitility
 		testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
 		testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-		testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertkVersion"
+		testImplementation libs.com.willowtreeapps.assertk
 
 		testRuntimeOnly 'org.apache.logging.log4j:log4j-jcl'
 		testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
@@ -309,9 +281,9 @@ project('spring-amqp') {
 		optionalApi 'tools.jackson.module:jackson-module-kotlin'
 		// Spring Data projection message binding support
 		optionalApi 'org.springframework.data:spring-data-commons'
-		optionalApi "com.jayway.jsonpath:json-path:$jaywayJsonPathVersion"
+		optionalApi libs.com.jayway.jsonpath
 
-		testImplementation "org.assertj:assertj-core:$assertjVersion"
+		testImplementation libs.org.assertj.core
 	}
 
 }
@@ -344,13 +316,13 @@ project('spring-amqp-client') {
 
 	dependencies {
 		api project(':spring-amqp')
-		api "org.apache.qpid:protonj2-client:$protonjVersion"
+		api libs.org.apache.qpid.protonj2.client
 		api 'org.springframework:spring-context'
 		api 'org.springframework:spring-messaging'
 
 		testImplementation project(':spring-rabbit-junit')
 		testImplementation 'io.projectreactor:reactor-core'
-		testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion"
+		testImplementation libs.org.jetbrains.kotlinx.coroutines.reactor
 		testImplementation 'org.testcontainers:testcontainers-rabbitmq'
 		testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
 
@@ -364,7 +336,7 @@ project('spring-rabbit') {
 
 	dependencies {
 		api project(':spring-amqp')
-		api "com.rabbitmq:amqp-client:$rabbitmqVersion"
+		api libs.com.rabbitmq.amqp.client
 		api 'org.springframework:spring-context'
 		api 'org.springframework:spring-messaging'
 		api 'org.springframework:spring-tx'
@@ -372,27 +344,27 @@ project('spring-rabbit') {
 
 		optionalApi 'org.springframework:spring-aop'
 		optionalApi 'org.springframework:spring-webflux'
-		optionalApi "org.apache.httpcomponents.client5:httpclient5:$commonsHttpClientVersion"
+		optionalApi libs.apache.httpcomponents.httpclient5
 		optionalApi 'io.projectreactor:reactor-core'
 		optionalApi 'io.projectreactor.netty:reactor-netty-http'
-		optionalApi "ch.qos.logback:logback-classic:$logbackVersion"
+		optionalApi libs.ch.qos.logback
 		optionalApi 'org.apache.logging.log4j:log4j-core'
 		optionalApi 'io.micrometer:micrometer-core'
 		optionalApi 'io.micrometer:micrometer-tracing'
-		optionalApi "org.apache.commons:commons-pool2:$commonsPoolVersion"
-		optionalApi "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion"
+		optionalApi libs.apache.commons.pool2
+		optionalApi libs.org.jetbrains.kotlinx.coroutines.reactor
 
 		testImplementation project(':spring-rabbit-junit')
 		testImplementation 'org.springframework.data:spring-data-commons'
-		testImplementation "com.jayway.jsonpath:json-path:$jaywayJsonPathVersion"
-		testImplementation "org.hibernate.validator:hibernate-validator:$hibernateValidationVersion"
+		testImplementation libs.com.jayway.jsonpath
+		testImplementation libs.org.hibernate.validator
 		testImplementation 'io.micrometer:micrometer-observation-test'
 		testImplementation 'io.micrometer:micrometer-tracing-bridge-brave'
 		testImplementation 'io.micrometer:micrometer-tracing-test'
 		testImplementation 'io.micrometer:micrometer-tracing-integration-test'
 		testImplementation 'org.testcontainers:testcontainers-rabbitmq'
 		testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
-		testImplementation "org.apache.httpcomponents.client5:httpclient5:$commonsHttpClientVersion"
+		testImplementation libs.apache.httpcomponents.httpclient5
 
 		testRuntimeOnly 'tools.jackson.core:jackson-databind'
 		testRuntimeOnly 'tools.jackson.dataformat:jackson-dataformat-xml'
@@ -404,7 +376,7 @@ project('spring-rabbit-stream') {
 
 	dependencies {
 		api project(':spring-rabbit')
-		api "com.rabbitmq:stream-client:$rabbitmqStreamVersion"
+		api libs.com.rabbitmq.stream.client
 
 		optionalApi 'io.micrometer:micrometer-core'
 
@@ -427,7 +399,7 @@ project('spring-rabbitmq-client') {
 
 	dependencies {
 		api project(':spring-rabbit')
-		api "com.rabbitmq.client:amqp-client:$rabbitmqAmqpClientVersion"
+		api libs.com.rabbitmq.client.amqp
 
 		testImplementation project(':spring-rabbit-junit')
 		testImplementation 'io.projectreactor:reactor-core'
@@ -444,14 +416,14 @@ project('spring-rabbit-junit') {
 	dependencies { // no spring-amqp dependencies allowed
 		api 'org.springframework:spring-core'
 		api 'org.springframework:spring-test'
-		api "com.rabbitmq:amqp-client:$rabbitmqVersion"
+		api libs.com.rabbitmq.amqp.client
 		api 'org.springframework:spring-web'
 		api 'org.junit.jupiter:junit-jupiter-api'
-		api "org.assertj:assertj-core:$assertjVersion"
+		api libs.org.assertj.core
 
 		optionalApi 'org.testcontainers:testcontainers-rabbitmq'
 		optionalApi 'org.testcontainers:testcontainers-junit-jupiter'
-		optionalApi "ch.qos.logback:logback-classic:$logbackVersion"
+		optionalApi libs.ch.qos.logback
 		optionalApi 'org.apache.logging.log4j:log4j-core'
 	}
 }
@@ -462,9 +434,8 @@ project('spring-rabbit-test') {
 	dependencies {
 		api project(':spring-rabbit')
 		api project(':spring-rabbit-junit')
-		api "org.hamcrest:hamcrest-library:$hamcrestVersion"
-		api "org.hamcrest:hamcrest-core:$hamcrestVersion"
-		api "org.mockito:mockito-core:$mockitoVersion"
+		api libs.org.hamcrest
+		api libs.org.mockito.core
 
 		testImplementation project(':spring-rabbit').sourceSets.test.output
 	}
@@ -475,7 +446,7 @@ configurations {
 }
 
 dependencies {
-	micrometerDocs "io.micrometer:micrometer-docs-generator:$micrometerDocsVersion"
+	micrometerDocs libs.io.micrometer.docs.generator
 }
 
 def observationInputDir = file('build/docs/microsources').absolutePath
@@ -700,12 +671,12 @@ def generateAttributes() {
 	return [
 			'project-version'                                 : project.version,
 			'spring-integration-docs'                         : "$springDocs/spring-integration/reference".toString(),
-			'spring-framework-docs'                           : "$springDocs/spring-framework/reference/${generateVersionWithoutPatch(springVersion)}".toString(),
-			'spring-framework-javadoc'                        : "$springDocs/spring-framework/docs/$springVersion/javadoc-api".toString(),
-			'javadoc-location-org-springframework-transaction': "$springDocs/spring-framework/docs/$springVersion/javadoc-api".toString(),
+			'spring-framework-docs'                           : "$springDocs/spring-framework/reference/${generateVersionWithoutPatch(libs.versions.springVersion.get())}".toString(),
+			'spring-framework-javadoc'                        : "$springDocs/spring-framework/docs/${libs.versions.springVersion.get()}/javadoc-api".toString(),
+			'javadoc-location-org-springframework-transaction': "$springDocs/spring-framework/docs/${libs.versions.springVersion.get()}/javadoc-api".toString(),
 			'javadoc-location-org-springframework-amqp'       : "$springDocs/spring-amqp/docs/$project.version/api".toString(),
-			'micrometer-docs'                                 : "$micrometerDocsPrefix/micrometer/reference/${generateVersionWithoutPatch(micrometerVersion)}".toString(),
-			'micrometer-tracing-docs'                         : "$micrometerDocsPrefix/tracing/reference/${generateVersionWithoutPatch(micrometerTracingVersion)}".toString()
+			'micrometer-docs'                                 : "$micrometerDocsPrefix/micrometer/reference/${generateVersionWithoutPatch(libs.versions.micrometerVersion.get())}".toString(),
+			'micrometer-tracing-docs'                         : "$micrometerDocsPrefix/tracing/reference/${generateVersionWithoutPatch(libs.versions.micrometerTracingVersion.get())}".toString()
 	]
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,36 +27,35 @@ springVersion = "7.0.6"
 testcontainersVersion = "2.0.4"
 
 [libraries]
-apache-commons-pool2 = { module = "org.apache.commons:commons-pool2", version.ref = "commonsPoolVersion" }
-apache-httpcomponents-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "commonsHttpClientVersion" }
-apache-logging-log4j-bom = { module = "org.apache.logging.log4j:log4j-bom", version.ref = "log4jVersion" }
-ch-qos-logback = { module = "ch.qos.logback:logback-classic", version.ref = "logbackVersion" }
-com-fasterxml-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jacksonBomVersion" }
-com-jayway-jsonpath = { module = "com.jayway.jsonpath:json-path", version.ref = "jaywayJsonPathVersion" }
-com-rabbitmq-amqp-client = { module = "com.rabbitmq:amqp-client", version.ref = "rabbitmqVersion" }
-com-rabbitmq-client-amqp = { module = "com.rabbitmq.client:amqp-client", version.ref = "rabbitmqAmqpClientVersion" }
-com-rabbitmq-stream-client = { module = "com.rabbitmq:stream-client", version.ref = "rabbitmqStreamVersion" }
-com-willowtreeapps-assertk = { module = "com.willowtreeapps.assertk:assertk-jvm", version.ref = "assertkVersion" }
-io-micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometerVersion" }
-io-micrometer-docs-generator = { module = "io.micrometer:micrometer-docs-generator", version.ref = "micrometerDocsVersion" }
-io-micrometer-tracing-bom = { module = "io.micrometer:micrometer-tracing-bom", version.ref = "micrometerTracingVersion" }
-io-projectreactor-bom = { module = "io.projectreactor:reactor-bom", version.ref = "reactorVersion" }
-org-apache-qpid-protonj2-client = { module = "org.apache.qpid:protonj2-client", version.ref = "protonjVersion" }
-org-assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertjVersion" }
-org-awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitilityVersion" }
-org-hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrestVersion" }
-org-hibernate-validator = { module = "org.hibernate.validator:hibernate-validator", version.ref = "hibernateValidationVersion" }
-org-jetbrains-kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinCoroutinesVersion" }
-org-junit-bom = { module = "org.junit:junit-bom", version.ref = "junitJupiterVersion" }
-org-mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoVersion" }
-org-mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockitoVersion" }
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertjVersion" }
+assertk = { module = "com.willowtreeapps.assertk:assertk-jvm", version.ref = "assertkVersion" }
+awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitilityVersion" }
+commons-pool2 = { module = "org.apache.commons:commons-pool2", version.ref = "commonsPoolVersion" }
+fasterxml-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jacksonBomVersion" }
+hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrestVersion" }
+hibernate-validator = { module = "org.hibernate.validator:hibernate-validator", version.ref = "hibernateValidationVersion" }
+httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "commonsHttpClientVersion" }
+jsonpath = { module = "com.jayway.jsonpath:json-path", version.ref = "jaywayJsonPathVersion" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junitJupiterVersion" }
+kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinCoroutinesVersion" }
+log4j-bom = { module = "org.apache.logging.log4j:log4j-bom", version.ref = "log4jVersion" }
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logbackVersion" }
+micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometerVersion" }
+micrometer-docs-generator = { module = "io.micrometer:micrometer-docs-generator", version.ref = "micrometerDocsVersion" }
+micrometer-tracing-bom = { module = "io.micrometer:micrometer-tracing-bom", version.ref = "micrometerTracingVersion" }
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockitoVersion" }
+qpid-protonj2-client = { module = "org.apache.qpid:protonj2-client", version.ref = "protonjVersion" }
+rabbitmq-amqp-client = { module = "com.rabbitmq:amqp-client", version.ref = "rabbitmqVersion" }
+rabbitmq-client-amqp = { module = "com.rabbitmq.client:amqp-client", version.ref = "rabbitmqAmqpClientVersion" }
+rabbitmq-stream-client = { module = "com.rabbitmq:stream-client", version.ref = "rabbitmqStreamVersion" }
+reactor-bom = { module = "io.projectreactor:reactor-bom", version.ref = "reactorVersion" }
 spring-data-bom = { module = "org.springframework.data:spring-data-bom", version.ref = "springDataVersion" }
 spring-framework-bom = { module = "org.springframework:spring-framework-bom", version.ref = "springVersion" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainersVersion" }
 tools-jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson3Version" }
 
 [plugins]
-antora = { id = "org.antora", version = "1.0.0" }
-io-spring-antora-generate-yml = { id = "io.spring.antora.generate-antora-yml", version = "0.0.1" }
 aggregate-javadoc = { id = "io.freefair.aggregate-javadoc", version = "9.2.0" }
+antora = { id = "org.antora", version = "1.0.0" }
 nullability = { id = "io.spring.nullability", version = "0.0.12" }
+spring-antora-generateYml = { id = "io.spring.antora.generate-antora-yml", version = "0.0.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,62 @@
+[versions]
+assertjVersion = "3.27.7"
+assertkVersion = "0.28.1"
+awaitilityVersion = "4.3.0"
+commonsHttpClientVersion = "5.6"
+commonsPoolVersion = "2.13.0"
+hamcrestVersion = "3.0"
+hibernateValidationVersion = "9.1.0.Final"
+jacksonBomVersion = "2.21.2"
+jackson3Version = "3.1.1"
+jaywayJsonPathVersion = "3.0.0"
+junitJupiterVersion = "6.0.3"
+kotlinCoroutinesVersion = "1.10.2"
+log4jVersion = "2.25.4"
+logbackVersion = "1.5.32"
+micrometerDocsVersion = "1.0.4"
+micrometerVersion = "1.17.0-SNAPSHOT"
+micrometerTracingVersion = "1.7.0-SNAPSHOT"
+mockitoVersion = "5.23.0"
+protonjVersion = "1.1.0"
+rabbitmqAmqpClientVersion = "0.10.0"
+rabbitmqStreamVersion = "1.5.0"
+rabbitmqVersion = "5.29.0"
+reactorVersion = "2025.0.4"
+springDataVersion = "2026.0.0-SNAPSHOT"
+springVersion = "7.0.6"
+testcontainersVersion = "2.0.4"
+
+[libraries]
+apache-commons-pool2 = { module = "org.apache.commons:commons-pool2", version.ref = "commonsPoolVersion" }
+apache-httpcomponents-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "commonsHttpClientVersion" }
+apache-logging-log4j-bom = { module = "org.apache.logging.log4j:log4j-bom", version.ref = "log4jVersion" }
+ch-qos-logback = { module = "ch.qos.logback:logback-classic", version.ref = "logbackVersion" }
+com-fasterxml-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jacksonBomVersion" }
+com-jayway-jsonpath = { module = "com.jayway.jsonpath:json-path", version.ref = "jaywayJsonPathVersion" }
+com-rabbitmq-amqp-client = { module = "com.rabbitmq:amqp-client", version.ref = "rabbitmqVersion" }
+com-rabbitmq-client-amqp = { module = "com.rabbitmq.client:amqp-client", version.ref = "rabbitmqAmqpClientVersion" }
+com-rabbitmq-stream-client = { module = "com.rabbitmq:stream-client", version.ref = "rabbitmqStreamVersion" }
+com-willowtreeapps-assertk = { module = "com.willowtreeapps.assertk:assertk-jvm", version.ref = "assertkVersion" }
+io-micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometerVersion" }
+io-micrometer-docs-generator = { module = "io.micrometer:micrometer-docs-generator", version.ref = "micrometerDocsVersion" }
+io-micrometer-tracing-bom = { module = "io.micrometer:micrometer-tracing-bom", version.ref = "micrometerTracingVersion" }
+io-projectreactor-bom = { module = "io.projectreactor:reactor-bom", version.ref = "reactorVersion" }
+org-apache-qpid-protonj2-client = { module = "org.apache.qpid:protonj2-client", version.ref = "protonjVersion" }
+org-assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertjVersion" }
+org-awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitilityVersion" }
+org-hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrestVersion" }
+org-hibernate-validator = { module = "org.hibernate.validator:hibernate-validator", version.ref = "hibernateValidationVersion" }
+org-jetbrains-kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinCoroutinesVersion" }
+org-junit-bom = { module = "org.junit:junit-bom", version.ref = "junitJupiterVersion" }
+org-mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoVersion" }
+org-mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockitoVersion" }
+spring-data-bom = { module = "org.springframework.data:spring-data-bom", version.ref = "springDataVersion" }
+spring-framework-bom = { module = "org.springframework:spring-framework-bom", version.ref = "springVersion" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainersVersion" }
+tools-jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson3Version" }
+
+[plugins]
+antora = { id = "org.antora", version = "1.0.0" }
+io-spring-antora-generate-yml = { id = "io.spring.antora.generate-antora-yml", version = "0.0.1" }
+aggregate-javadoc = { id = "io.freefair.aggregate-javadoc", version = "9.2.0" }
+nullability = { id = "io.spring.nullability", version = "0.0.12" }


### PR DESCRIPTION
- Add gradle/libs.versions.toml to manage project dependencies.
- Update build.gradle to reference the version catalog.
- Centralize dependency versions to improve build maintainability.
- Update hamcrest to remove redirect
- Update com.rabbitmq.client:amqp-client to next major version

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
