### PR TITLE
GH-2305: Add immediate scale-down to SimpleMessageListenerContainer

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -63,6 +63,8 @@ public class SimpleRabbitListenerContainerFactory
 
 	private @Nullable Boolean enforceImmediateAckForManual;
 
+	private @Nullable Boolean immediateScaleDown;
+
 	/**
 	 * @param batchSize the batch size.
 	 * @since 2.2
@@ -169,6 +171,16 @@ public class SimpleRabbitListenerContainerFactory
 		this.enforceImmediateAckForManual = enforceImmediateAckForManual;
 	}
 
+	/**
+	 * Set to {@code true} to enable immediate scale-down behavior.
+	 * @param immediateScaleDown true to enable immediate scale-down.
+	 * @since 4.1
+	 * @see SimpleMessageListenerContainer#setImmediateScaleDown(boolean)
+	 */
+	public void setImmediateScaleDown(Boolean immediateScaleDown) {
+		this.immediateScaleDown = immediateScaleDown;
+	}
+
 	@Override
 	protected SimpleMessageListenerContainer createContainerInstance() {
 		return new SimpleMessageListenerContainer();
@@ -199,7 +211,8 @@ public class SimpleRabbitListenerContainerFactory
 				.acceptIfNotNull(this.consecutiveIdleTrigger, instance::setConsecutiveIdleTrigger)
 				.acceptIfNotNull(this.receiveTimeout, instance::setReceiveTimeout)
 				.acceptIfNotNull(this.batchReceiveTimeout, instance::setBatchReceiveTimeout)
-				.acceptIfNotNull(this.enforceImmediateAckForManual, instance::setEnforceImmediateAckForManual);
+				.acceptIfNotNull(this.enforceImmediateAckForManual, instance::setEnforceImmediateAckForManual)
+				.acceptIfNotNull(this.immediateScaleDown, instance::setImmediateScaleDown);
 		if (Boolean.TRUE.equals(this.consumerBatchEnabled)) {
 			instance.setConsumerBatchEnabled(true);
 			/*

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -89,6 +89,7 @@ import org.springframework.util.backoff.BackOffExecution;
  * @author Java4ye
  * @author Thomas Badie
  * @author Jeongjun Min
+ * @author DoYeon Kim
  *
  * @since 1.0
  */
@@ -146,6 +147,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 	private boolean enforceImmediateAckForManual;
 
+	private boolean immediateScaleDown;
+
 	private volatile int concurrentConsumers = 1;
 
 	private volatile @Nullable Integer maxConcurrentConsumers;
@@ -196,7 +199,16 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			int delta = this.concurrentConsumers - concurrentConsumers;
 			this.concurrentConsumers = concurrentConsumers;
 			if (isActive()) {
-				adjustConsumers(delta);
+				if (this.immediateScaleDown && delta > 0) {
+					// Defer scale-down to checkAdjust() so that a consumer stops itself
+					// after it finishes processing the current message, instead of
+					// adjustConsumers() arbitrarily cancelling a consumer that may still
+					// be processing.
+					logger.debug("Immediate scale-down: deferring consumer removal to checkAdjust");
+				}
+				else {
+					adjustConsumers(delta);
+				}
 			}
 		}
 		finally {
@@ -529,6 +541,36 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	 */
 	public void setEnforceImmediateAckForManual(boolean enforceImmediateAckForManual) {
 		this.enforceImmediateAckForManual = enforceImmediateAckForManual;
+	}
+
+	/**
+	 * Set to {@code true} to enable immediate scale-down behavior when the number of
+	 * concurrent consumers is reduced dynamically (for example, by invoking
+	 * {@link #setConcurrentConsumers(int)} or {@link #setConcurrency(String)}
+	 * from within a listener).
+	 * <p>
+	 * When enabled, a scale-down request does not arbitrarily cancel one of the existing
+	 * consumers. Instead, each consumer checks after every message whether it is in
+	 * excess and, if so, stops itself once the current message has been processed. This
+	 * avoids cancelling a consumer that is still actively processing a message while a
+	 * consumer that just finished keeps running.
+	 * <p>
+	 * When enabled, the following properties are bypassed for scale-down decisions
+	 * because the intent is immediate reaction:
+	 * {@link #setConsecutiveIdleTrigger(int) consecutiveIdleTrigger} and
+	 * {@link #setStopConsumerMinInterval(long) stopConsumerMinInterval}.
+	 * Scale-up related properties are not affected.
+	 * <p>
+	 * Has no effect unless {@link #setMaxConcurrentConsumers(int) maxConcurrentConsumers}
+	 * is also configured, because {@code checkAdjust()} is only invoked in that case.
+	 * Default is {@code false}.
+	 * @param immediateScaleDown true to enable immediate scale-down.
+	 * @since 4.1
+	 * @see #setConcurrentConsumers(int)
+	 * @see #setMaxConcurrentConsumers(int)
+	 */
+	public void setImmediateScaleDown(boolean immediateScaleDown) {
+		this.immediateScaleDown = immediateScaleDown;
 	}
 
 	/**
@@ -1297,6 +1339,8 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 
 		private boolean failedExclusive;
 
+		private volatile boolean markedForStop;
+
 		AsyncMessageProcessingConsumer(BlockingQueueConsumer consumer) {
 			this.consumer = consumer;
 			this.start = new CountDownLatch(1);
@@ -1355,7 +1399,9 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			try {
 				initialize();
 				SimpleMessageListenerContainer.this.processorThreadsToInterrupt.add(Thread.currentThread());
-				while (isActive(this.consumer) || this.consumer.hasDelivery() || !this.consumer.cancelled()) {
+				while (!this.markedForStop
+						&& (isActive(this.consumer) || this.consumer.hasDelivery() || !this.consumer.cancelled())) {
+
 					mainLoop();
 				}
 			}
@@ -1507,14 +1553,47 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 						considerAddingAConsumer();
 						this.consecutiveMessages = 0;
 					}
+					if (SimpleMessageListenerContainer.this.immediateScaleDown) {
+						markForStopIfExcess();
+					}
 				}
 			}
 			else {
 				this.consecutiveMessages = 0;
-				if (this.consecutiveIdles++ > SimpleMessageListenerContainer.this.consecutiveIdleTrigger) {
+				if (SimpleMessageListenerContainer.this.immediateScaleDown) {
+					markForStopIfExcess();
+					this.consecutiveIdles = 0;
+				}
+				else if (this.consecutiveIdles++ > SimpleMessageListenerContainer.this.consecutiveIdleTrigger) {
 					considerStoppingAConsumer(this.consumer);
 					this.consecutiveIdles = 0;
 				}
+			}
+		}
+
+		/**
+		 * When immediate scale-down is enabled, stop this consumer itself if the
+		 * number of active consumers exceeds the configured concurrency. This runs
+		 * after a message has been processed (acked), so the consumer terminates
+		 * cleanly rather than being cancelled mid-processing by another thread.
+		 */
+		private void markForStopIfExcess() {
+			SimpleMessageListenerContainer.this.consumersLock.lock();
+			try {
+				SimpleMessageListenerContainer container = SimpleMessageListenerContainer.this;
+				if (container.consumers != null
+						&& container.consumers.size() > container.concurrentConsumers) {
+
+					this.consumer.basicCancel(true);
+					container.consumers.remove(this.consumer);
+					this.markedForStop = true;
+					if (logger.isDebugEnabled()) {
+						logger.debug("Immediate scale-down: consumer marked for stop: " + this.consumer);
+					}
+				}
+			}
+			finally {
+				SimpleMessageListenerContainer.this.consumersLock.unlock();
 			}
 		}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -194,9 +194,9 @@ public class SimpleMessageListenerContainerTests {
 	 */
 	@Test
 	public void testTxSizeAcks() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
-		Channel channel = mock(Channel.class);
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel = mock();
 		given(connectionFactory.createConnection()).willReturn(connection);
 		given(connection.createChannel(false)).willReturn(channel);
 		final AtomicReference<Consumer> consumer = new AtomicReference<>();
@@ -246,9 +246,9 @@ public class SimpleMessageListenerContainerTests {
 	 */
 	@Test
 	public void testTxSizeAcksWIthShortSet() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
-		Channel channel = mock(Channel.class);
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel = mock();
 		given(connectionFactory.createConnection()).willReturn(connection);
 		given(connection.createChannel(false)).willReturn(channel);
 		final AtomicReference<Consumer> consumer = new AtomicReference<>();
@@ -299,9 +299,9 @@ public class SimpleMessageListenerContainerTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testConsumerArgs() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
-		Channel channel = mock(Channel.class);
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel = mock();
 		given(connectionFactory.createConnection()).willReturn(connection);
 		given(connection.createChannel(false)).willReturn(channel);
 		final AtomicReference<Consumer> consumer = new AtomicReference<>();
@@ -335,10 +335,10 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testChangeQueues() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
-		Channel channel1 = mock(Channel.class);
-		Channel channel2 = mock(Channel.class);
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel1 = mock();
+		Channel channel2 = mock();
 		given(channel1.isOpen()).willReturn(true);
 		given(channel2.isOpen()).willReturn(true);
 		given(connectionFactory.createConnection()).willReturn(connection);
@@ -371,7 +371,7 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testChangeQueuesSimple() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		ConnectionFactory connectionFactory = mock();
 		final SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		container.setQueueNames("foo");
 		container.setReceiveTimeout(10);
@@ -386,9 +386,9 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testAddQueuesAndStartInCycle() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
-		Channel channel1 = mock(Channel.class);
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel1 = mock();
 		given(channel1.isOpen()).willReturn(true);
 		given(connectionFactory.createConnection()).willReturn(connection);
 		given(connection.createChannel(false)).willReturn(channel1);
@@ -443,7 +443,7 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testCallbackIsRunOnStopAlsoWhenNoConsumerIsActive() throws InterruptedException {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		ConnectionFactory connectionFactory = mock();
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		ReflectionTestUtils.setField(container, "active", Boolean.TRUE);
@@ -455,7 +455,7 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testCallbackIsRunOnStopAlsoWhenContainerIsStoppingForAbort() throws InterruptedException {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		ConnectionFactory connectionFactory = mock();
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		ReflectionTestUtils.setField(container, "containerStoppingForAbort", new AtomicReference<>(new Thread()));
@@ -472,8 +472,8 @@ public class SimpleMessageListenerContainerTests {
 				mock(com.rabbitmq.client.ConnectionFactory.class);
 		com.rabbitmq.client.Connection mockConnection1 = mock(com.rabbitmq.client.Connection.class);
 		com.rabbitmq.client.Connection mockConnection2 = mock(com.rabbitmq.client.Connection.class);
-		Channel mockChannel1 = mock(Channel.class);
-		Channel mockChannel2 = mock(Channel.class);
+		Channel mockChannel1 = mock();
+		Channel mockChannel2 = mock();
 
 		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString()))
 				.willReturn(mockConnection1)
@@ -532,9 +532,9 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testConsumerCancel() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
-		Channel channel = mock(Channel.class);
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel = mock();
 		given(connectionFactory.createConnection()).willReturn(connection);
 		given(connection.createChannel(false)).willReturn(channel);
 		final AtomicReference<Consumer> consumer = new AtomicReference<>();
@@ -597,7 +597,7 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	public void testPossibleAuthenticationFailureNotFatal() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		ConnectionFactory connectionFactory = mock();
 
 		given(connectionFactory.createConnection())
 				.willThrow(new AmqpAuthenticationException(new PossibleAuthenticationFailureException("intentional")));
@@ -623,7 +623,7 @@ public class SimpleMessageListenerContainerTests {
 		try {
 			Thread.currentThread().setContextClassLoader(child);
 
-			ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+			ConnectionFactory connectionFactory = mock();
 
 			SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 			container.setConnectionFactory(connectionFactory);
@@ -676,9 +676,9 @@ public class SimpleMessageListenerContainerTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	void setConcurrency() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
-		Channel channel = mock(Channel.class);
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel = mock();
 		given(connectionFactory.createConnection()).willReturn(connection);
 		given(connection.createChannel(false)).willReturn(channel);
 		final AtomicReference<Consumer> consumer = new AtomicReference<>();
@@ -701,9 +701,9 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	void testWithConsumerStartWhenNotActive() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
-		Channel channel = mock(Channel.class);
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel = mock();
 		given(connectionFactory.createConnection()).willReturn(connection);
 		given(connection.createChannel(false)).willReturn(channel);
 
@@ -725,9 +725,9 @@ public class SimpleMessageListenerContainerTests {
 
 	@Test
 	void testShutdownWithPendingReplies() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
-		Channel channel = mock(Channel.class);
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel = mock();
 		given(connectionFactory.createConnection()).willReturn(connection);
 		given(connection.createChannel(false)).willReturn(channel);
 		given(channel.isOpen()).willReturn(true);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainerTests.java
@@ -86,12 +86,14 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -106,6 +108,7 @@ import static org.mockito.Mockito.verify;
  * @author Tim Bourquin
  * @author Jeonggi Kim
  * @author Jeongjun Min
+ * @author DoYeon Kim
  */
 public class SimpleMessageListenerContainerTests {
 
@@ -797,6 +800,57 @@ public class SimpleMessageListenerContainerTests {
 		container.stop();
 
 		assertThat(interruptedLatch.await(10, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	public void testImmediateScaleDownDefersConsumerRemoval() throws Exception {
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		Channel channel = mock();
+		given(connectionFactory.createConnection()).willReturn(connection);
+		given(connection.createChannel(false)).willReturn(channel);
+		given(channel.isOpen()).willReturn(true);
+		given(connection.isOpen()).willReturn(true);
+		willAnswer(invocation -> {
+			Consumer callback = invocation.getArgument(6);
+			callback.handleConsumeOk("consumerTag");
+			return "consumerTag";
+		}).given(channel)
+				.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
+						anyMap(), any(Consumer.class));
+
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setQueueNames("testQueue");
+		container.setConcurrentConsumers(2);
+		container.setMaxConcurrentConsumers(4);
+		container.setImmediateScaleDown(true);
+		container.setReceiveTimeout(10);
+		container.setMessageListener(message -> {
+		});
+		container.afterPropertiesSet();
+		container.start();
+
+		Set<?> consumers = TestUtils.getPropertyValue(container, "consumers");
+		await().until(() -> consumers.size() == 2);
+
+		// Inject a Log spy to verify which scale-down path is taken
+		Log logger = spy(TestUtils.<Log>getPropertyValue(container, "logger"));
+		given(logger.isDebugEnabled()).willReturn(true);
+		new DirectFieldAccessor(container).setPropertyValue("logger", logger);
+
+		// Reduce concurrency — with immediateScaleDown, removal is deferred to checkAdjust()
+		container.setConcurrentConsumers(1);
+
+		// Wait for the excess consumer to self-remove via markForStopIfExcess()
+		await().until(() -> consumers.size() == 1);
+
+		container.stop();
+
+		// Verify markForStopIfExcess() path was used, not considerStoppingAConsumer()
+		verify(logger, atLeastOnce()).debug(argThat(msg ->
+				msg.toString().contains("Immediate scale-down: consumer marked for stop")));
+		verify(logger, never()).debug(argThat(msg ->
+				msg.toString().contains("Idle consumer terminating")));
 	}
 
 	private Answer<Object> messageToConsumer(final Channel mockChannel, final SimpleMessageListenerContainer container,


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-amqp/issues/2305

When `setConcurrentConsumers()` is invoked dynamically (for example, from within a listener) to scale down, the current implementation arbitrarily cancels a consumer via `adjustConsumers()`, which may kill a consumer that is still actively processing a message while another consumer that just finished keeps running.

This change introduces an `immediateScaleDown` flag. When enabled:

* Scale-down requests are deferred to `checkAdjust()` so that a consumer
  stops itself only after it has finished processing the current message.
* `consecutiveIdleTrigger` and `stopConsumerMinInterval` are bypassed for
  scale-down decisions — the intent is immediate reaction.
* A `markedForStop` flag lets the consumer exit its main loop cleanly,
  preventing it from processing an additional prefetched message between
  the ack and the basicCancel.

Scale-up behavior is unchanged.