### PR TITLE
GH-3418: Option to disable acknowledgements on error

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/BaseRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/BaseRabbitListenerContainerFactory.java
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Ngoc Nhan
  * @author Artem Bilan
  * @author Stephane Nicoll
+ * @author Aram Peres
  *
  * @since 2.4
  *
@@ -232,6 +233,7 @@ public abstract class BaseRabbitListenerContainerFactory<C extends MessageListen
 	 * acknowledgment itself (e.g. via {@code channel.basicReject()}) without causing
 	 * a duplicate-ack error. Default is {@code true}.
 	 * @param acknowledgeOnError false to skip auto-ack on null return from error handler.
+	 * @since 3.2.11
 	 * @see MessagingMessageListenerAdapter#setAcknowledgeOnError(boolean)
 	 */
 	public void setAcknowledgeOnError(boolean acknowledgeOnError) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/BaseRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/BaseRabbitListenerContainerFactory.java
@@ -29,6 +29,7 @@ import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.listener.adapter.AbstractAdaptableMessageListener;
+import org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.utils.JavaUtils;
 import org.springframework.beans.BeansException;
@@ -68,6 +69,8 @@ public abstract class BaseRabbitListenerContainerFactory<C extends MessageListen
 	private @Nullable Boolean micrometerEnabled;
 
 	private @Nullable Boolean observationEnabled;
+
+	private @Nullable Boolean acknowledgeOnError;
 
 	@SuppressWarnings("NullAway.Init")
 	private ApplicationContext applicationContext;
@@ -158,6 +161,10 @@ public abstract class BaseRabbitListenerContainerFactory<C extends MessageListen
 					.acceptIfCondition(this.retryTemplate != null && this.recoveryCallback != null,
 							this.recoveryCallback, messageListener::setRecoveryCallback)
 					.acceptIfNotNull(this.defaultRequeueRejected, messageListener::setDefaultRequeueRejected);
+			if (iml instanceof MessagingMessageListenerAdapter adapter) {
+				JavaUtils.INSTANCE
+						.acceptIfNotNull(this.acknowledgeOnError, adapter::setAcknowledgeOnError);
+			}
 			if (endpoint != null) {
 				JavaUtils.INSTANCE
 						.acceptIfNotNull(endpoint.getReplyPostProcessor(), messageListener::setReplyPostProcessor)
@@ -216,6 +223,19 @@ public abstract class BaseRabbitListenerContainerFactory<C extends MessageListen
 
 	protected @Nullable Boolean getObservationEnabled() {
 		return this.observationEnabled;
+	}
+
+	/**
+	 * Set to {@code false} to prevent auto-acknowledgment of messages when a
+	 * {@link org.springframework.amqp.rabbit.listener.api.RabbitListenerErrorHandler}
+	 * returns {@code null} in MANUAL ack mode. This lets the error handler manage
+	 * acknowledgment itself (e.g. via {@code channel.basicReject()}) without causing
+	 * a duplicate-ack error. Default is {@code true}.
+	 * @param acknowledgeOnError false to skip auto-ack on null return from error handler.
+	 * @see MessagingMessageListenerAdapter#setAcknowledgeOnError(boolean)
+	 */
+	public void setAcknowledgeOnError(boolean acknowledgeOnError) {
+		this.acknowledgeOnError = acknowledgeOnError;
 	}
 
 	@Override

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -454,7 +454,7 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 				channel.basicAck(request.getMessageProperties().getDeliveryTag(), false);
 			}
 			catch (IOException e) {
-				this.logger.warn("Failed to ack message", e);
+				this.logger.error("Failed to ack message", e);
 			}
 		}
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -118,7 +118,6 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	 * allows the error handler to manage acknowledgment itself (e.g. by calling
 	 * {@code channel.basicReject()}) without causing a duplicate ack error.
 	 * Default is {@code true} (auto-acknowledge on null return from error handler).
-	 * @since 3.2.11
 	 * @param acknowledgeOnError false to skip the auto-ack on null return from error handler.
 	 */
 	public void setAcknowledgeOnError(boolean acknowledgeOnError) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -68,6 +68,8 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 
 	protected final @Nullable RabbitListenerErrorHandler errorHandler;
 
+	private boolean acknowledgeOnError = true;
+
 	private @Nullable HandlerAdapter handlerAdapter;
 
 	public MessagingMessageListenerAdapter() {
@@ -108,6 +110,19 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 
 		return new MessagingMessageConverterAdapter(bean, method, batch, Channel.class);
 	}
+
+	/**
+	 * Set to {@code false} to prevent the framework from automatically acknowledging
+	 * messages when the error handler returns {@code null} in MANUAL ack mode. This
+	 * allows the error handler to manage acknowledgment itself (e.g. by calling
+	 * {@code channel.basicReject()}) without causing a duplicate ack error.
+	 * Default is {@code true} (auto-acknowledge on null return from error handler).
+	 * @param acknowledgeOnError false to skip the auto-ack on null return from error handler.
+	 */
+	public void setAcknowledgeOnError(boolean acknowledgeOnError) {
+		this.acknowledgeOnError = acknowledgeOnError;
+	}
+
 	/**
 	 * Set the {@link HandlerAdapter} to use to invoke the method
 	 * processing an incoming {@link org.springframework.amqp.core.Message}.
@@ -212,10 +227,13 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 							: getHandlerAdapter().getInvocationResultFor(errorResult, payload);
 					handleResult(invResult, amqpMessage, channel, message);
 				}
-				else {
-					logger.trace("Error handler returned no result; acknowledging the message.");
-					if (isManualAck()) {
+				else if (isManualAck()) {
+					if (this.acknowledgeOnError) {
+						logger.trace("Error handler returned no result; acknowledging the message.");
 						basicAck(amqpMessage, channel);
+					}
+					else {
+						logger.trace("Error handler returned no result; skipping auto-acknowledgment.");
 					}
 				}
 			}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -119,6 +119,7 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	 * {@code channel.basicReject()}) without causing a duplicate ack error.
 	 * Default is {@code true} (auto-acknowledge on null return from error handler).
 	 * @param acknowledgeOnError false to skip the auto-ack on null return from error handler.
+	 * @since 3.2.11
 	 */
 	public void setAcknowledgeOnError(boolean acknowledgeOnError) {
 		this.acknowledgeOnError = acknowledgeOnError;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -57,6 +57,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Kai Stapel
+ * @author Aram Peres
  *
  * @since 1.4
  */
@@ -117,6 +118,7 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	 * allows the error handler to manage acknowledgment itself (e.g. by calling
 	 * {@code channel.basicReject()}) without causing a duplicate ack error.
 	 * Default is {@code true} (auto-acknowledge on null return from error handler).
+	 * @since 3.2.11
 	 * @param acknowledgeOnError false to skip the auto-ack on null return from error handler.
 	 */
 	public void setAcknowledgeOnError(boolean acknowledgeOnError) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -341,7 +341,7 @@ public class MessagingMessageListenerAdapterTests {
 
 	@Test
 	void acknowledgeOnErrorDefaultAutoAcksInManualMode() throws Exception {
-		org.springframework.amqp.core.Message message = MessageTestUtils.createTextMessage("foo");
+		org.springframework.amqp.core.Message message = MessageTestUtils.createTextMessage("manualAcknowledgeOnErrorDefault");
 		Channel channel = mock(Channel.class);
 		MessagingMessageListenerAdapter listener = getSimpleInstance("fail",
 				(amqpMessage, ch, msg, ex) -> null, false, String.class);
@@ -352,7 +352,7 @@ public class MessagingMessageListenerAdapterTests {
 
 	@Test
 	void acknowledgeOnErrorFalseSkipsAutoAckInManualMode() throws Exception {
-		org.springframework.amqp.core.Message message = MessageTestUtils.createTextMessage("foo");
+		org.springframework.amqp.core.Message message = MessageTestUtils.createTextMessage("manualAcknowledgeOnErrorFalse");
 		Channel channel = mock(Channel.class);
 		MessagingMessageListenerAdapter listener = getSimpleInstance("fail",
 				(amqpMessage, ch, msg, ex) -> null, false, String.class);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -66,6 +66,7 @@ import static org.mockito.Mockito.verify;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Kai Stapel
+ * @author Aram Peres
  */
 public class MessagingMessageListenerAdapterTests {
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -30,6 +30,7 @@ import com.rabbitmq.client.Channel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.listener.ListenerExecutionFailedException;
 import org.springframework.amqp.listener.adapter.DelegatingInvocableHandler;
@@ -57,6 +58,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -334,6 +336,29 @@ public class MessagingMessageListenerAdapterTests {
 		listener.onMessage(message, channel);
 		verify(channel).basicPublish(any(), any(), anyBoolean(), any(), any());
 		assertThat(ehCalled.get()).isTrue();
+	}
+
+	@Test
+	void acknowledgeOnErrorDefaultAutoAcksInManualMode() throws Exception {
+		org.springframework.amqp.core.Message message = MessageTestUtils.createTextMessage("foo");
+		Channel channel = mock(Channel.class);
+		MessagingMessageListenerAdapter listener = getSimpleInstance("fail",
+				(amqpMessage, ch, msg, ex) -> null, false, String.class);
+		listener.containerAckMode(AcknowledgeMode.MANUAL);
+		listener.onMessage(message, channel);
+		verify(channel).basicAck(message.getMessageProperties().getDeliveryTag(), false);
+	}
+
+	@Test
+	void acknowledgeOnErrorFalseSkipsAutoAckInManualMode() throws Exception {
+		org.springframework.amqp.core.Message message = MessageTestUtils.createTextMessage("foo");
+		Channel channel = mock(Channel.class);
+		MessagingMessageListenerAdapter listener = getSimpleInstance("fail",
+				(amqpMessage, ch, msg, ex) -> null, false, String.class);
+		listener.containerAckMode(AcknowledgeMode.MANUAL);
+		listener.setAcknowledgeOnError(false);
+		listener.onMessage(message, channel);
+		verify(channel, never()).basicAck(message.getMessageProperties().getDeliveryTag(), false);
 	}
 
 	@Test


### PR DESCRIPTION
This is another approach to fixing GH-3418.

In my opinion the `MANUAL` acknowledge mode should not be _automatically_ acknowledging messages. It should be up to the developer to acknowledge messages whether they are successfully handled or not.

Evidently since this change was intentional for GH-3247 I propose adding an option on the Container Factory to disable the new behavior, returning control to the library user to acknowledge (or reject) messages in error handlers, without causing unintended effects.