### PR TITLE
GH-3438: Add routing `AmqpConnectionFactory` support

### DIFF
--- a/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/AbstractRoutingAmqpConnectionFactory.java
+++ b/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/AbstractRoutingAmqpConnectionFactory.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbitmq.client;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.rabbitmq.client.amqp.Connection;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * Abstract {@link AmqpConnectionFactory} implementation that routes {@link #getConnection()}
+ * calls to one of various target {@link AmqpConnectionFactory AmqpConnectionFactories} based
+ * on a lookup key. The latter is usually (but not necessarily) determined through some
+ * thread-bound context.
+ *
+ * @author Robin Collard
+ *
+ * @since 4.2
+ */
+public abstract class AbstractRoutingAmqpConnectionFactory
+		implements AmqpConnectionFactory, RoutingAmqpConnectionFactory, InitializingBean {
+
+	private final Map<Object, AmqpConnectionFactory> targetConnectionFactories = new ConcurrentHashMap<>();
+
+	private @Nullable AmqpConnectionFactory defaultTargetConnectionFactory;
+
+	private boolean lenientFallback = true;
+
+	/**
+	 * Specify the map of target {@link AmqpConnectionFactory AmqpConnectionFactories},
+	 * with the lookup key as key.
+	 * <p>The key can be of arbitrary type; this class implements the generic lookup process
+	 * only. The concrete key representation will be handled by {@link #determineCurrentLookupKey()}.
+	 * @param targetConnectionFactories the target connection factories and lookup keys.
+	 */
+	public void setTargetConnectionFactories(Map<Object, AmqpConnectionFactory> targetConnectionFactories) {
+		Assert.notNull(targetConnectionFactories, "'targetConnectionFactories' must not be null.");
+		Assert.noNullElements(targetConnectionFactories.values().toArray(),
+				"'targetConnectionFactories' cannot have null values.");
+		this.targetConnectionFactories.putAll(targetConnectionFactories);
+	}
+
+	/**
+	 * Specify the default target {@link AmqpConnectionFactory}, if any.
+	 * <p>This {@link AmqpConnectionFactory} will be used as target if none of the keyed
+	 * {@link #targetConnectionFactories} match the {@link #determineCurrentLookupKey()}
+	 * current lookup key.
+	 * @param defaultTargetConnectionFactory the default target connection factory.
+	 */
+	public void setDefaultTargetConnectionFactory(AmqpConnectionFactory defaultTargetConnectionFactory) {
+		this.defaultTargetConnectionFactory = defaultTargetConnectionFactory;
+	}
+
+	/**
+	 * Specify whether to apply a lenient fallback to the default {@link AmqpConnectionFactory}
+	 * if no specific {@link AmqpConnectionFactory} could be found for the current lookup key.
+	 * <p>Default is "true", accepting lookup keys without a corresponding entry in the
+	 * {@link #targetConnectionFactories} - simply falling back to the default
+	 * {@link AmqpConnectionFactory} in that case.
+	 * <p>Switch this flag to "false" if you would prefer the fallback to only apply if the
+	 * lookup key was {@code null}. Lookup keys without an {@link AmqpConnectionFactory} entry
+	 * will then lead to an {@link IllegalStateException}.
+	 * @param lenientFallback true to fall back to the default, if specified.
+	 * @see #setTargetConnectionFactories
+	 * @see #setDefaultTargetConnectionFactory
+	 * @see #determineCurrentLookupKey()
+	 */
+	public void setLenientFallback(boolean lenientFallback) {
+		this.lenientFallback = lenientFallback;
+	}
+
+	protected boolean isLenientFallback() {
+		return this.lenientFallback;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		Assert.isTrue(this.defaultTargetConnectionFactory != null || !this.targetConnectionFactories.isEmpty(),
+				"At least one target factory (or default) is required");
+	}
+
+	@Override
+	public Connection getConnection() {
+		return determineTargetConnectionFactory().getConnection();
+	}
+
+	/**
+	 * Retrieve the current target {@link AmqpConnectionFactory}. Determine the
+	 * {@link #determineCurrentLookupKey() current lookup key}, perform a lookup in the
+	 * {@link #targetConnectionFactories} map, fall back to the specified
+	 * {@link #defaultTargetConnectionFactory} if necessary.
+	 * @return the connection factory.
+	 * @see #determineCurrentLookupKey()
+	 */
+	protected AmqpConnectionFactory determineTargetConnectionFactory() {
+		Object lookupKey = determineCurrentLookupKey();
+		AmqpConnectionFactory connectionFactory = null;
+		if (lookupKey != null) {
+			connectionFactory = this.targetConnectionFactories.get(lookupKey);
+		}
+		if (connectionFactory == null && (this.lenientFallback || lookupKey == null)) {
+			connectionFactory = this.defaultTargetConnectionFactory;
+		}
+		if (connectionFactory == null) {
+			throw new IllegalStateException("Cannot determine target AmqpConnectionFactory for lookup key ["
+					+ lookupKey + "]");
+		}
+		return connectionFactory;
+	}
+
+	@Override
+	public @Nullable AmqpConnectionFactory getTargetConnectionFactory(Object key) {
+		return this.targetConnectionFactories.get(key);
+	}
+
+	/**
+	 * Add the given {@link AmqpConnectionFactory} and associate it with the given lookup key.
+	 * @param key the lookup key.
+	 * @param connectionFactory the {@link AmqpConnectionFactory}.
+	 */
+	public void addTargetConnectionFactory(Object key, AmqpConnectionFactory connectionFactory) {
+		this.targetConnectionFactories.put(key, connectionFactory);
+	}
+
+	/**
+	 * Remove the {@link AmqpConnectionFactory} associated with the given lookup key and return it.
+	 * @param key the lookup key.
+	 * @return the {@link AmqpConnectionFactory} that was removed.
+	 */
+	public @Nullable AmqpConnectionFactory removeTargetConnectionFactory(Object key) {
+		return this.targetConnectionFactories.remove(key);
+	}
+
+	/**
+	 * Determine the current lookup key. This will typically be implemented to check a
+	 * thread-bound context.
+	 * @return the lookup key.
+	 */
+	protected abstract @Nullable Object determineCurrentLookupKey();
+
+}

--- a/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/RabbitAmqpTemplate.java
+++ b/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/RabbitAmqpTemplate.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  * A Spring-friendly wrapper around {@link Environment#connectionBuilder()};
  *
  * @author Artem Bilan
+ * @author Robin Collard
  *
  * @since 4.0
  */
@@ -176,6 +177,14 @@ public class RabbitAmqpTemplate implements AsyncAmqpTemplate, DisposableBean {
 	 * @return the {@link Publisher} for low-level AMQP operations.
 	 */
 	public Publisher getPublisher() {
+		if (this.connectionFactory instanceof RoutingAmqpConnectionFactory) {
+			return this.connectionFactory.getConnection()
+					.publisherBuilder()
+					.listeners(this.stateListeners)
+					.publishTimeout(this.publishTimeout)
+					.build();
+		}
+
 		Publisher publisherToReturn = this.publisher;
 		if (publisherToReturn == null) {
 			this.instanceLock.lock();
@@ -238,12 +247,18 @@ public class RabbitAmqpTemplate implements AsyncAmqpTemplate, DisposableBean {
 	private CompletableFuture<Boolean> doSend(@Nullable String exchange, @Nullable String routingKey,
 			@Nullable String queue, Message message) {
 
+		Publisher publisherToUse = getPublisher();
+
 		com.rabbitmq.client.amqp.Message amqpMessage =
-				toAmqpMessage(exchange, routingKey, queue, message, getPublisher()::message);
+				toAmqpMessage(exchange, routingKey, queue, message, publisherToUse::message);
 
 		CompletableFuture<Boolean> publishResult = new CompletableFuture<>();
 
-		getPublisher().publish(amqpMessage,
+		if (publisherToUse != this.publisher) {
+			publishResult.whenComplete((result, ex) -> publisherToUse.close());
+		}
+
+		publisherToUse.publish(amqpMessage,
 				(context) -> {
 					switch (context.status()) {
 						case ACCEPTED -> publishResult.complete(true);
@@ -426,11 +441,15 @@ public class RabbitAmqpTemplate implements AsyncAmqpTemplate, DisposableBean {
 							rpcFuture.complete(false);
 						}
 						else {
-							com.rabbitmq.client.amqp.Message replyMessage = getPublisher().message();
+							Publisher publisherToUse = getPublisher();
+							com.rabbitmq.client.amqp.Message replyMessage = publisherToUse.message();
 							RabbitAmqpUtils.toAmqpMessage(reply, replyMessage);
 							replyMessage.correlationId(messageId);
 							replyMessage.to(replyTo);
-							getPublisher().publish(replyMessage, (ctx) -> {
+							publisherToUse.publish(replyMessage, (ctx) -> {
+								if (publisherToUse != this.publisher) {
+									publisherToUse.close();
+								}
 							});
 							context.accept();
 							rpcFuture.complete(true);

--- a/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/RoutingAmqpConnectionFactory.java
+++ b/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/RoutingAmqpConnectionFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbitmq.client;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Implementations select an {@link AmqpConnectionFactory} based on a supplied key.
+ *
+ * @author Robin Collard
+ *
+ * @since 4.2
+ */
+@FunctionalInterface
+public interface RoutingAmqpConnectionFactory {
+
+	/**
+	 * Return the {@link AmqpConnectionFactory} bound to given lookup key, or {@code null}
+	 * if one does not exist.
+	 * @param key the lookup key to which the {@link AmqpConnectionFactory} is bound.
+	 * @return the {@link AmqpConnectionFactory} bound to the given lookup key,
+	 * or {@code null} if one does not exist.
+	 */
+	@Nullable
+	AmqpConnectionFactory getTargetConnectionFactory(Object key);
+
+}

--- a/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/SimpleRoutingAmqpConnectionFactory.java
+++ b/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/SimpleRoutingAmqpConnectionFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbitmq.client;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.amqp.rabbit.connection.SimpleResourceHolder;
+
+/**
+ * An {@link AbstractRoutingAmqpConnectionFactory} implementation which gets a {@code lookupKey}
+ * for the current {@link AmqpConnectionFactory} from a thread-bound resource by the key of the
+ * instance of this {@link AmqpConnectionFactory}.
+ *
+ * @author Robin Collard
+ *
+ * @since 4.2
+ *
+ * @see SimpleResourceHolder
+ */
+public class SimpleRoutingAmqpConnectionFactory extends AbstractRoutingAmqpConnectionFactory {
+
+	@Override
+	protected @Nullable Object determineCurrentLookupKey() {
+		return SimpleResourceHolder.get(this);
+	}
+
+}

--- a/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/RoutingAmqpConnectionFactoryTests.java
+++ b/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/RoutingAmqpConnectionFactoryTests.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbitmq.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.rabbitmq.client.amqp.Connection;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.rabbit.connection.SimpleResourceHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Robin Collard
+ *
+ * @since 4.2
+ */
+public class RoutingAmqpConnectionFactoryTests {
+
+	@Test
+	void routesToTargetByLookupKey() {
+		AmqpConnectionFactory cf1 = mock();
+		AmqpConnectionFactory cf2 = mock();
+		Connection connection1 = mock();
+		Connection connection2 = mock();
+		given(cf1.getConnection()).willReturn(connection1);
+		given(cf2.getConnection()).willReturn(connection2);
+
+		Map<Object, AmqpConnectionFactory> factories = new HashMap<>();
+		factories.put("one", cf1);
+		factories.put("two", cf2);
+
+		AtomicReference<@Nullable Object> lookupKey = new AtomicReference<>();
+		AbstractRoutingAmqpConnectionFactory routingConnectionFactory =
+				new AbstractRoutingAmqpConnectionFactory() {
+
+					@Override
+					protected @Nullable Object determineCurrentLookupKey() {
+						return lookupKey.get();
+					}
+
+				};
+		routingConnectionFactory.setTargetConnectionFactories(factories);
+
+		lookupKey.set("one");
+		assertThat(routingConnectionFactory.getConnection()).isSameAs(connection1);
+		lookupKey.set("two");
+		assertThat(routingConnectionFactory.getConnection()).isSameAs(connection2);
+
+		assertThat(routingConnectionFactory.getTargetConnectionFactory("one")).isSameAs(cf1);
+		verify(cf1).getConnection();
+		verify(cf2).getConnection();
+	}
+
+	@Test
+	void lenientFallbackToDefault() {
+		AmqpConnectionFactory target = mock();
+		AmqpConnectionFactory defaultCf = mock();
+		Connection defaultConnection = mock();
+		given(defaultCf.getConnection()).willReturn(defaultConnection);
+
+		AbstractRoutingAmqpConnectionFactory routingConnectionFactory =
+				new AbstractRoutingAmqpConnectionFactory() {
+
+					@Override
+					protected @Nullable Object determineCurrentLookupKey() {
+						return "missing";
+					}
+
+				};
+		routingConnectionFactory.setTargetConnectionFactories(Map.of("present", target));
+		routingConnectionFactory.setDefaultTargetConnectionFactory(defaultCf);
+
+		assertThat(routingConnectionFactory.getConnection()).isSameAs(defaultConnection);
+
+		routingConnectionFactory.setLenientFallback(false);
+		assertThatIllegalStateException()
+				.isThrownBy(routingConnectionFactory::getConnection)
+				.withMessageContaining("Cannot determine target AmqpConnectionFactory for lookup key [missing]");
+	}
+
+	@Test
+	void afterPropertiesSetRequiresAtLeastOneFactory() {
+		AbstractRoutingAmqpConnectionFactory routingConnectionFactory =
+				new AbstractRoutingAmqpConnectionFactory() {
+
+					@Override
+					protected @Nullable Object determineCurrentLookupKey() {
+						return null;
+					}
+
+				};
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(routingConnectionFactory::afterPropertiesSet)
+				.withMessageContaining("At least one target factory (or default) is required");
+
+		routingConnectionFactory.setDefaultTargetConnectionFactory(mock());
+		assertThatNoException().isThrownBy(routingConnectionFactory::afterPropertiesSet);
+	}
+
+	@Test
+	void nullTargetValuesAreRejected() {
+		AbstractRoutingAmqpConnectionFactory routingConnectionFactory =
+				new AbstractRoutingAmqpConnectionFactory() {
+
+					@Override
+					protected @Nullable Object determineCurrentLookupKey() {
+						return null;
+					}
+
+				};
+		Map<Object, AmqpConnectionFactory> factories = new HashMap<>();
+		factories.put("key", null);
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> routingConnectionFactory.setTargetConnectionFactories(factories))
+				.withMessageContaining("cannot have null values");
+	}
+
+	@Test
+	void addTargetConnectionFactoryRegistersTargetAtRuntime() {
+		AmqpConnectionFactory cf = mock();
+		AmqpConnectionFactory replacement = mock();
+		Connection connection = mock();
+		Connection replacementConnection = mock();
+		given(cf.getConnection()).willReturn(connection);
+		given(replacement.getConnection()).willReturn(replacementConnection);
+
+		AbstractRoutingAmqpConnectionFactory routingConnectionFactory =
+				new AbstractRoutingAmqpConnectionFactory() {
+
+					@Override
+					protected @Nullable Object determineCurrentLookupKey() {
+						return "added";
+					}
+
+				};
+		routingConnectionFactory.setLenientFallback(false);
+
+		assertThat(routingConnectionFactory.getTargetConnectionFactory("added")).isNull();
+		assertThatIllegalStateException()
+				.isThrownBy(routingConnectionFactory::getConnection)
+				.withMessageContaining("Cannot determine target AmqpConnectionFactory for lookup key [added]");
+
+		routingConnectionFactory.addTargetConnectionFactory("added", cf);
+
+		assertThat(routingConnectionFactory.getTargetConnectionFactory("added")).isSameAs(cf);
+		assertThat(routingConnectionFactory.getConnection()).isSameAs(connection);
+
+		routingConnectionFactory.addTargetConnectionFactory("added", replacement);
+
+		assertThat(routingConnectionFactory.getTargetConnectionFactory("added")).isSameAs(replacement);
+		assertThat(routingConnectionFactory.getConnection()).isSameAs(replacementConnection);
+	}
+
+	@Test
+	void removeTargetConnectionFactoryUnregistersTarget() {
+		AmqpConnectionFactory cf = mock();
+		AmqpConnectionFactory defaultCf = mock();
+		Connection connection = mock();
+		Connection defaultConnection = mock();
+		given(cf.getConnection()).willReturn(connection);
+		given(defaultCf.getConnection()).willReturn(defaultConnection);
+
+		AbstractRoutingAmqpConnectionFactory routingConnectionFactory =
+				new AbstractRoutingAmqpConnectionFactory() {
+
+					@Override
+					protected @Nullable Object determineCurrentLookupKey() {
+						return "removable";
+					}
+
+				};
+		routingConnectionFactory.setTargetConnectionFactories(Map.of("removable", cf));
+		routingConnectionFactory.setDefaultTargetConnectionFactory(defaultCf);
+
+		assertThat(routingConnectionFactory.getConnection()).isSameAs(connection);
+
+		assertThat(routingConnectionFactory.removeTargetConnectionFactory("removable")).isSameAs(cf);
+
+		assertThat(routingConnectionFactory.getTargetConnectionFactory("removable")).isNull();
+		assertThat(routingConnectionFactory.getConnection()).isSameAs(defaultConnection);
+
+		assertThat(routingConnectionFactory.removeTargetConnectionFactory("removable")).isNull();
+	}
+
+	@Test
+	void simpleRoutingResolvesViaResourceHolder() {
+		AmqpConnectionFactory cf = mock();
+		Connection connection = mock();
+		given(cf.getConnection()).willReturn(connection);
+
+		SimpleRoutingAmqpConnectionFactory routingConnectionFactory = new SimpleRoutingAmqpConnectionFactory();
+		routingConnectionFactory.setTargetConnectionFactories(Map.of("lookup", cf));
+
+		SimpleResourceHolder.bind(routingConnectionFactory, "lookup");
+		try {
+			assertThat(routingConnectionFactory.getConnection()).isSameAs(connection);
+		}
+		finally {
+			SimpleResourceHolder.unbind(routingConnectionFactory);
+		}
+	}
+
+}

--- a/src/reference/antora/modules/ROOT/pages/rabbitmq-amqp-client.adoc
+++ b/src/reference/antora/modules/ROOT/pages/rabbitmq-amqp-client.adoc
@@ -80,6 +80,57 @@ AmqpConnectionFactory connectionFactory(Environment environment) {
 
 See `SingleAmqpConnectionFactory` setters for all connection-specific setting.
 
+[[amqp-client-routing-connection-factory]]
+== Routing Connection Factory
+
+Similar to the `AbstractRoutingConnectionFactory` for the AMQP 0.9.1 protocol (see xref:amqp/connections.adoc#routing-connection-factory[Routing Connection Factory]), the `spring-rabbitmq-client` module provides an `AbstractRoutingAmqpConnectionFactory` (since version 4.2) for the AMQP 1.0 protocol.
+This factory provides a mechanism to configure mappings for several `AmqpConnectionFactory` instances and determine a target `AmqpConnectionFactory` by some `lookupKey` at runtime.
+Typically, the implementation checks a thread-bound context.
+For convenience, the `SimpleRoutingAmqpConnectionFactory` is provided, which gets the current thread-bound `lookupKey` from the `SimpleResourceHolder`:
+
+[source,java]
+----
+@Bean
+AmqpConnectionFactory connectionFactory(AmqpConnectionFactory cf1, AmqpConnectionFactory cf2) {
+    SimpleRoutingAmqpConnectionFactory connectionFactory = new SimpleRoutingAmqpConnectionFactory();
+    connectionFactory.setTargetConnectionFactories(Map.of("one", cf1, "two", cf2));
+    return connectionFactory;
+}
+----
+
+The `lookupKey` is bound to (and must be unbound from) the current thread around the target operation:
+
+[source,java]
+----
+public class MyService {
+
+    private final RabbitAmqpTemplate rabbitTemplate;
+
+    private final AmqpConnectionFactory connectionFactory;
+
+    public void service(String key, String payload) {
+        SimpleResourceHolder.bind(this.connectionFactory, key);
+        try {
+            this.rabbitTemplate.convertAndSend("exchange", "routingKey", payload);
+        }
+        finally {
+            SimpleResourceHolder.unbind(this.connectionFactory);
+        }
+    }
+
+}
+----
+
+It is important to unbind the resource after use.
+
+The routing algorithm is as follows: the `determineCurrentLookupKey()` is consulted for a key; if it resolves to a registered target `AmqpConnectionFactory`, that one is used.
+If the key is `null`, the `defaultTargetConnectionFactory` is used, whatever the `lenientFallback` setting.
+If the key is not `null` but has no registered target, the `defaultTargetConnectionFactory` is used only when `lenientFallback = true` (the default); otherwise an `IllegalStateException` is thrown.
+An `IllegalStateException` is also thrown when the fallback applies but no `defaultTargetConnectionFactory` is configured.
+
+To implement a custom routing strategy, extend `AbstractRoutingAmqpConnectionFactory` and provide a `determineCurrentLookupKey()` implementation.
+For more information, see the javadoc:org.springframework.amqp.rabbitmq.client.AbstractRoutingAmqpConnectionFactory[JavaDoc] for `AbstractRoutingAmqpConnectionFactory`.
+
 [[amqp-client-topology]]
 == RabbitMQ Topology Management
 

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -20,3 +20,9 @@ See xref:logging.adoc[] for more information.
 
 The `@RabbitListener` annotation has new `batchSize()` and `batchReceiveTimeout()` attributes to override the respective container factory properties for a single listener.
 See xref:amqp/receiving-messages/batch.adoc[] for more information.
+
+[[x42-routing-amqp-connection-factory]]
+=== Routing AMQP Connection Factory
+
+The `spring-rabbitmq-client` module now provides an `AbstractRoutingAmqpConnectionFactory` (and a `SimpleRoutingAmqpConnectionFactory` implementation) to route to one of several `AmqpConnectionFactory` instances based on a runtime `lookupKey`.
+See xref:rabbitmq-amqp-client.adoc#amqp-client-routing-connection-factory[Routing Connection Factory] for more information.


### PR DESCRIPTION
Introduce a `RoutingAmqpConnectionFactory` strategy interface with an `AbstractRoutingAmqpConnectionFactory` base class that routes `getConnection()` calls to one of several target `AmqpConnectionFactory` instances based on a runtime lookup key, with optional lenient fallback to a default factory.

* Add `SimpleRoutingAmqpConnectionFactory` resolving the lookup key from a thread-bound `SimpleResourceHolder` resource
* Make `RabbitAmqpTemplate.getPublisher()` aware of a `RoutingAmqpConnectionFactory` so the target connection is resolved per call

Closes gh-3438

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.adoc).
-->
