### PR TITLE
GH-3487: Apply Nullability to MessageProperties

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/MessageProperties.java
@@ -188,7 +188,7 @@ public class MessageProperties implements Serializable {
 		return this.headers;
 	}
 
-	public void setTimestamp(Date timestamp) {
+	public void setTimestamp(@Nullable Date timestamp) {
 		this.timestamp = timestamp; //NOSONAR
 	}
 
@@ -196,7 +196,7 @@ public class MessageProperties implements Serializable {
 		return this.timestamp; //NOSONAR
 	}
 
-	public void setMessageId(String messageId) {
+	public void setMessageId(@Nullable String messageId) {
 		this.messageId = messageId;
 	}
 
@@ -204,7 +204,7 @@ public class MessageProperties implements Serializable {
 		return this.messageId;
 	}
 
-	public void setUserId(String userId) {
+	public void setUserId(@Nullable String userId) {
 		this.userId = userId;
 	}
 
@@ -221,11 +221,11 @@ public class MessageProperties implements Serializable {
 		return this.receivedUserId;
 	}
 
-	public void setReceivedUserId(String receivedUserId) {
+	public void setReceivedUserId(@Nullable String receivedUserId) {
 		this.receivedUserId = receivedUserId;
 	}
 
-	public void setAppId(String appId) {
+	public void setAppId(@Nullable String appId) {
 		this.appId = appId;
 	}
 
@@ -233,7 +233,7 @@ public class MessageProperties implements Serializable {
 		return this.appId;
 	}
 
-	public void setClusterId(String clusterId) {
+	public void setClusterId(@Nullable String clusterId) {
 		this.clusterId = clusterId;
 	}
 
@@ -241,7 +241,7 @@ public class MessageProperties implements Serializable {
 		return this.clusterId;
 	}
 
-	public void setType(String type) {
+	public void setType(@Nullable String type) {
 		this.type = type;
 	}
 
@@ -322,7 +322,7 @@ public class MessageProperties implements Serializable {
 		return this.receivedDeliveryMode;
 	}
 
-	public void setReceivedDeliveryMode(MessageDeliveryMode receivedDeliveryMode) {
+	public void setReceivedDeliveryMode(@Nullable MessageDeliveryMode receivedDeliveryMode) {
 		this.receivedDeliveryMode = receivedDeliveryMode;
 	}
 
@@ -332,7 +332,7 @@ public class MessageProperties implements Serializable {
 	 * milliseconds.
 	 * @param expiration the expiration.
 	 */
-	public void setExpiration(String expiration) {
+	public void setExpiration(@Nullable String expiration) {
 		this.expiration = expiration;
 	}
 
@@ -354,7 +354,7 @@ public class MessageProperties implements Serializable {
 		return this.priority;
 	}
 
-	public void setReceivedExchange(String receivedExchange) {
+	public void setReceivedExchange(@Nullable String receivedExchange) {
 		this.receivedExchange = receivedExchange;
 	}
 
@@ -362,7 +362,7 @@ public class MessageProperties implements Serializable {
 		return this.receivedExchange;
 	}
 
-	public void setReceivedRoutingKey(String receivedRoutingKey) {
+	public void setReceivedRoutingKey(@Nullable String receivedRoutingKey) {
 		this.receivedRoutingKey = receivedRoutingKey;
 	}
 
@@ -388,11 +388,11 @@ public class MessageProperties implements Serializable {
 	 * @since 3.1.2
 	 * @see #setDelayLong(Long)
 	 */
-	public void setReceivedDelayLong(Long receivedDelay) {
+	public void setReceivedDelayLong(@Nullable Long receivedDelay) {
 		this.receivedDelay = receivedDelay;
 	}
 
-	public void setRedelivered(Boolean redelivered) {
+	public void setRedelivered(@Nullable Boolean redelivered) {
 		this.redelivered = redelivered;
 	}
 
@@ -425,7 +425,7 @@ public class MessageProperties implements Serializable {
 	 * @param messageCount the count
 	 * @see #getMessageCount()
 	 */
-	public void setMessageCount(Integer messageCount) {
+	public void setMessageCount(@Nullable Integer messageCount) {
 		this.messageCount = messageCount;
 	}
 
@@ -442,7 +442,7 @@ public class MessageProperties implements Serializable {
 		return this.consumerTag;
 	}
 
-	public void setConsumerTag(String consumerTag) {
+	public void setConsumerTag(@Nullable String consumerTag) {
 		this.consumerTag = consumerTag;
 	}
 
@@ -450,7 +450,7 @@ public class MessageProperties implements Serializable {
 		return this.consumerQueue;
 	}
 
-	public void setConsumerQueue(String consumerQueue) {
+	public void setConsumerQueue(@Nullable String consumerQueue) {
 		this.consumerQueue = consumerQueue;
 	}
 
@@ -551,7 +551,7 @@ public class MessageProperties implements Serializable {
 	 * @param inferredArgumentType the type.
 	 * @since 1.6
 	 */
-	public void setInferredArgumentType(Type inferredArgumentType) {
+	public void setInferredArgumentType(@Nullable Type inferredArgumentType) {
 		this.inferredArgumentType = inferredArgumentType;
 	}
 
@@ -658,7 +658,7 @@ public class MessageProperties implements Serializable {
 	 * @param amqpAcknowledgment the {@link AmqpAcknowledgment} to use in the application.
 	 * @since 4.0
 	 */
-	public void setAmqpAcknowledgment(AmqpAcknowledgment amqpAcknowledgment) {
+	public void setAmqpAcknowledgment(@Nullable AmqpAcknowledgment amqpAcknowledgment) {
 		this.amqpAcknowledgment = amqpAcknowledgment;
 	}
 

--- a/spring-amqp/src/test/kotlin/org/springframework/amqp/core/KotlinMessagePropertiesTests.kt
+++ b/spring-amqp/src/test/kotlin/org/springframework/amqp/core/KotlinMessagePropertiesTests.kt
@@ -21,25 +21,30 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
 import java.lang.reflect.Type
 import java.util.Date
 
 /**
  * @author Ngoc Nhan
+ *
+ * @since 4.0.5
  */
 class KotlinMessagePropertiesTests {
 
 	@Test
 	fun testSetterForNullabilityFields () {
 		val currentDate = Date()
+		val amqpAcknowledgment = mock(AmqpAcknowledgment::class.java)
+		val inferredArgumentType = mock(Type::class.java)
 		val messageProperties = MessageProperties()
-			messageProperties.amqpAcknowledgment = AmqpAcknowledgmentImpl()
+			messageProperties.amqpAcknowledgment = amqpAcknowledgment
 			messageProperties.appId = "appId"
 			messageProperties.clusterId = "clusterId"
 			messageProperties.consumerQueue = "consumerQueue"
 			messageProperties.consumerTag = "consumerTag"
 			messageProperties.expiration = "expiration"
-			messageProperties.inferredArgumentType = TypeImpl()
+			messageProperties.inferredArgumentType = inferredArgumentType
 			messageProperties.messageCount = 1
 			messageProperties.messageId = "messageId"
 			messageProperties.receivedDelayLong = 1
@@ -52,13 +57,13 @@ class KotlinMessagePropertiesTests {
 			messageProperties.type = "type"
 			messageProperties.userId = "userId"
 
-		assertThat(messageProperties.amqpAcknowledgment).isEqualTo(AmqpAcknowledgmentImpl())
+		assertThat(messageProperties.amqpAcknowledgment).isEqualTo(amqpAcknowledgment)
 		assertThat(messageProperties.appId).isEqualTo("appId")
 		assertThat(messageProperties.clusterId).isEqualTo("clusterId")
 		assertThat(messageProperties.consumerQueue).isEqualTo("consumerQueue")
 		assertThat(messageProperties.consumerTag).isEqualTo("consumerTag")
 		assertThat(messageProperties.expiration).isEqualTo("expiration")
-		assertThat(messageProperties.inferredArgumentType).isEqualTo(TypeImpl())
+		assertThat(messageProperties.inferredArgumentType).isEqualTo(inferredArgumentType)
 		assertThat(messageProperties.messageCount).isEqualTo(1)
 		assertThat(messageProperties.messageId).isEqualTo("messageId")
 		assertThat(messageProperties.receivedDelayLong).isEqualTo(1)
@@ -70,32 +75,6 @@ class KotlinMessagePropertiesTests {
 		assertThat(messageProperties.timestamp).isEqualTo(currentDate)
 		assertThat(messageProperties.type).isEqualTo("type")
 		assertThat(messageProperties.userId).isEqualTo("userId")
-	}
-
-	class AmqpAcknowledgmentImpl: AmqpAcknowledgment {
-
-		override fun acknowledge(status: AmqpAcknowledgment.Status) {
-			TODO("Not yet implemented")
-		}
-
-		override fun equals(other: Any?): Boolean {
-			if (this === other) return true
-			if (other !is AmqpAcknowledgmentImpl) return false
-
-			return true
-		}
-
-	}
-
-	class TypeImpl: Type {
-
-		override fun equals(other: Any?): Boolean {
-			if (this === other) return true
-			if (other !is TypeImpl) return false
-
-			return true
-		}
-
 	}
 
 }

--- a/spring-amqp/src/test/kotlin/org/springframework/amqp/core/KotlinMessagePropertiesTests.kt
+++ b/spring-amqp/src/test/kotlin/org/springframework/amqp/core/KotlinMessagePropertiesTests.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.core
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Type
+import java.util.Date
+
+/**
+ * @author Ngoc Nhan
+ */
+class KotlinMessagePropertiesTests {
+
+	@Test
+	fun testSetterForNullabilityFields () {
+		val currentDate = Date()
+		val messageProperties = MessageProperties()
+			messageProperties.amqpAcknowledgment = AmqpAcknowledgmentImpl()
+			messageProperties.appId = "appId"
+			messageProperties.clusterId = "clusterId"
+			messageProperties.consumerQueue = "consumerQueue"
+			messageProperties.consumerTag = "consumerTag"
+			messageProperties.expiration = "expiration"
+			messageProperties.inferredArgumentType = TypeImpl()
+			messageProperties.messageCount = 1
+			messageProperties.messageId = "messageId"
+			messageProperties.receivedDelayLong = 1
+			messageProperties.receivedDeliveryMode = MessageDeliveryMode.PERSISTENT
+			messageProperties.receivedExchange = "receivedExchange"
+			messageProperties.receivedRoutingKey = "receivedRoutingKey"
+			messageProperties.receivedUserId = "receivedUserId"
+			messageProperties.redelivered = true
+			messageProperties.timestamp = currentDate
+			messageProperties.type = "type"
+			messageProperties.userId = "userId"
+
+		assertThat(messageProperties.amqpAcknowledgment).isEqualTo(AmqpAcknowledgmentImpl())
+		assertThat(messageProperties.appId).isEqualTo("appId")
+		assertThat(messageProperties.clusterId).isEqualTo("clusterId")
+		assertThat(messageProperties.consumerQueue).isEqualTo("consumerQueue")
+		assertThat(messageProperties.consumerTag).isEqualTo("consumerTag")
+		assertThat(messageProperties.expiration).isEqualTo("expiration")
+		assertThat(messageProperties.inferredArgumentType).isEqualTo(TypeImpl())
+		assertThat(messageProperties.messageCount).isEqualTo(1)
+		assertThat(messageProperties.messageId).isEqualTo("messageId")
+		assertThat(messageProperties.receivedDelayLong).isEqualTo(1)
+		assertThat(messageProperties.receivedDeliveryMode).isEqualTo(MessageDeliveryMode.PERSISTENT)
+		assertThat(messageProperties.receivedExchange).isEqualTo("receivedExchange")
+		assertThat(messageProperties.receivedRoutingKey).isEqualTo("receivedRoutingKey")
+		assertThat(messageProperties.receivedUserId).isEqualTo("receivedUserId")
+		assertThat(messageProperties.redelivered).isNotNull().isTrue()
+		assertThat(messageProperties.timestamp).isEqualTo(currentDate)
+		assertThat(messageProperties.type).isEqualTo("type")
+		assertThat(messageProperties.userId).isEqualTo("userId")
+	}
+
+	class AmqpAcknowledgmentImpl: AmqpAcknowledgment {
+
+		override fun acknowledge(status: AmqpAcknowledgment.Status) {
+			TODO("Not yet implemented")
+		}
+
+		override fun equals(other: Any?): Boolean {
+			if (this === other) return true
+			if (other !is AmqpAcknowledgmentImpl) return false
+
+			return true
+		}
+
+	}
+
+	class TypeImpl: Type {
+
+		override fun equals(other: Any?): Boolean {
+			if (this === other) return true
+			if (other !is TypeImpl) return false
+
+			return true
+		}
+
+	}
+
+}


### PR DESCRIPTION
For Kotlin, nullable and non-nullable types are different types. Since the setter method in the Java class is not annotated with `@Nullable`, Kotlin treats the property as a val (read-only). This commit fixes that issue.

Closes gh-3487

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.md).
-->
