### PR TITLE
GH-3518: RepublishMessageRecoverer: no stack trace by default

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
@@ -38,8 +38,9 @@ import org.springframework.util.Assert;
 
 /**
  * {@link MessageRecoverer} implementation that republishes recovered messages
- * to a specified exchange with the exception stack trace stored in the
- * message header x-exception.
+ * to a specified exchange with the exception message and stack trace
+ * (if opted-in via {@link #includeStackTrace(boolean)}) stored in the
+ * message headers: {@value X_EXCEPTION_MESSAGE} and {@code X_EXCEPTION_STACKTRACE}.
  * <p>
  * If no routing key is provided, the original routing key for the message,
  * prefixed with {@link #setErrorRoutingKeyPrefix(String)} (default "error.")

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
@@ -82,7 +82,7 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 
 	private int frameMaxHeadroom = DEFAULT_FRAME_MAX_HEADROOM;
 
-	private volatile Integer maxStackTraceLength = -1;
+	private volatile Integer maxStackTraceLength = 0;
 
 	private MessageDeliveryMode deliveryMode = MessageDeliveryMode.PERSISTENT;
 
@@ -130,9 +130,6 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 		this.errorTemplate = errorTemplate;
 		this.errorExchangeNameExpression = errorExchange != null ? errorExchange : new ValueExpression<>(null);
 		this.errorRoutingKeyExpression = errorRoutingKey != null ? errorRoutingKey : new ValueExpression<>(null);
-		if (!(this.errorTemplate instanceof RabbitTemplate)) {
-			this.maxStackTraceLength = Integer.MAX_VALUE;
-		}
 	}
 
 	/**
@@ -157,6 +154,18 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 	 */
 	public RepublishMessageRecoverer frameMaxHeadroom(int headroom) {
 		this.frameMaxHeadroom = headroom;
+		return this;
+	}
+
+	/**
+	 * Set {@code true} to add header with error stack trace.
+	 * @param includeStackTrace {@code true} to add header with error stack trace.
+	 * @return this.
+	 * @since 4.0.5
+	 */
+	public RepublishMessageRecoverer includeStackTrace(boolean includeStackTrace) {
+		this.maxStackTraceLength =
+				includeStackTrace ? (!(this.errorTemplate instanceof RabbitTemplate) ? Integer.MAX_VALUE : -1) : 0;
 		return this;
 	}
 
@@ -200,7 +209,9 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 			if (truncatedExceptionMessage != null) {
 				exceptionMessage = truncatedExceptionMessage;
 			}
-			headers.put(X_EXCEPTION_STACKTRACE, stackTraceAsString);
+			if (this.maxStackTraceLength > 0) {
+				headers.put(X_EXCEPTION_STACKTRACE, stackTraceAsString);
+			}
 			headers.put(X_EXCEPTION_MESSAGE, exceptionMessage);
 		}
 		headers.put(X_ORIGINAL_EXCHANGE, messageProperties.getReceivedExchange());

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilderSupportTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilderSupportTests.java
@@ -224,10 +224,10 @@ public class RetryInterceptorBuilderSupportTests {
 		MessageProperties messageProperties = message.getMessageProperties();
 		assertThat(messageProperties.getHeaders())
 				.containsKeys(
-						RepublishMessageRecoverer.X_EXCEPTION_STACKTRACE,
 						RepublishMessageRecoverer.X_EXCEPTION_MESSAGE,
 						RepublishMessageRecoverer.X_ORIGINAL_EXCHANGE,
 						RepublishMessageRecoverer.X_ORIGINAL_ROUTING_KEY)
+				.doesNotContainKey(RepublishMessageRecoverer.X_EXCEPTION_STACKTRACE)
 				.containsEntry("fooHeader", "barValue");
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererIntegrationTests.java
@@ -63,7 +63,9 @@ class RepublishMessageRecovererIntegrationTests {
 		this.maxHeaderSize = RabbitUtils.getMaxFrame(template.getConnectionFactory())
 				- RepublishMessageRecoverer.DEFAULT_FRAME_MAX_HEADROOM;
 		assertThat(this.maxHeaderSize).isGreaterThan(0);
-		RepublishMessageRecoverer recoverer = new RepublishMessageRecoverer(template, "", BIG_HEADER_QUEUE);
+		RepublishMessageRecoverer recoverer =
+				new RepublishMessageRecoverer(template, "", BIG_HEADER_QUEUE)
+						.includeStackTrace(true);
 		recoverer.recover(new Message("foo".getBytes(), new MessageProperties()),
 				new ListenerExecutionFailedException("Listener failed",
 						bigCause(new RuntimeException(BIG_EXCEPTION_MESSAGE1))));
@@ -91,7 +93,9 @@ class RepublishMessageRecovererIntegrationTests {
 		this.maxHeaderSize = RabbitUtils.getMaxFrame(template.getConnectionFactory())
 				- RepublishMessageRecoverer.DEFAULT_FRAME_MAX_HEADROOM;
 		assertThat(this.maxHeaderSize).isGreaterThan(0);
-		RepublishMessageRecoverer recoverer = new RepublishMessageRecoverer(template, "", BIG_HEADER_QUEUE);
+		RepublishMessageRecoverer recoverer =
+				new RepublishMessageRecoverer(template, "", BIG_HEADER_QUEUE)
+						.includeStackTrace(true);
 		ListenerExecutionFailedException cause = new ListenerExecutionFailedException("Listener failed",
 				new RuntimeException(new String(new byte[200]).replace('\u0000', 'x')));
 		recoverer.recover(new Message("foo".getBytes(), new MessageProperties()),
@@ -115,7 +119,9 @@ class RepublishMessageRecovererIntegrationTests {
 		this.maxHeaderSize = RabbitUtils.getMaxFrame(template.getConnectionFactory())
 				- RepublishMessageRecoverer.DEFAULT_FRAME_MAX_HEADROOM;
 		assertThat(this.maxHeaderSize).isGreaterThan(0);
-		RepublishMessageRecoverer recoverer = new RepublishMessageRecoverer(template, "", BIG_HEADER_QUEUE);
+		RepublishMessageRecoverer recoverer =
+				new RepublishMessageRecoverer(template, "", BIG_HEADER_QUEUE)
+						.includeStackTrace(true);
 		ListenerExecutionFailedException cause = new ListenerExecutionFailedException("Listener failed",
 				new RuntimeException(new String(new byte[this.maxHeaderSize]).replace('\u0000', 'x'),
 						new IllegalStateException("foo")));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererTests.java
@@ -94,7 +94,9 @@ public class RepublishMessageRecovererTests {
 
 	@Test
 	void shouldIncludeTheStacktraceInTheHeaderOfThePublishedMessage() {
-		recoverer = new RepublishMessageRecoverer(amqpTemplate);
+		recoverer =
+				new RepublishMessageRecoverer(amqpTemplate)
+						.includeStackTrace(true);
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		cause.printStackTrace(new PrintStream(baos));
 		final String expectedHeaderValue = baos.toString();

--- a/src/reference/antora/modules/ROOT/pages/amqp/resilience-recovering-from-errors-and-broker-failures.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/resilience-recovering-from-errors-and-broker-failures.adoc
@@ -157,7 +157,9 @@ RetryOperationsInterceptor interceptor() {
 }
 ----
 
-The `RepublishMessageRecoverer` publishes the message with additional information in message headers, such as the exception message, stack trace, original exchange, and routing key.
+The `RepublishMessageRecoverer` publishes the message with additional information in message headers, such as the exception message, original exchange, and routing key.
+The stack trace of the error is not included by default due to its size or sensitive information.
+The `includeStackTrace(true)` option should be used to include a stack trace dedicated header.
 Additional headers can be added by creating a subclass and overriding `additionalHeaders()`.
 The `deliveryMode` (or any other properties) can also be changed in the `additionalHeaders()`, as the following example shows:
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-amqp/issues/3518

The standard use-cases is to not deal with a whole stack trace.

**Auto-cherry-pick to `4.0.x`**