### PR TITLE
GH-3434: `RetryListener` on stateless interceptor

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilder.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilder.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.amqp.rabbit.retry.MessageKeyGenerator;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.rabbit.retry.NewMessageIdentifier;
+import org.springframework.core.retry.RetryListener;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.util.Assert;
 
@@ -63,6 +64,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Stephane Nicoll
+ * @author Jun Cho
  *
  * @since 1.3
  *
@@ -230,12 +232,30 @@ public abstract class RetryInterceptorBuilder<B extends RetryInterceptorBuilder<
 		private final StatelessRetryOperationsInterceptorFactoryBean factoryBean =
 				new StatelessRetryOperationsInterceptorFactoryBean();
 
+		private @Nullable RetryListener retryListener;
+
 		StatelessRetryInterceptorBuilder() {
+		}
+
+		/**
+		 * Apply a {@link RetryListener} to the stateless interceptor. If multiple
+		 * listeners are needed, use a
+		 * {@link org.springframework.core.retry.support.CompositeRetryListener}.
+		 * @param retryListener the retry listener to use.
+		 * @return this.
+		 * @since 4.1.1
+		 */
+		public StatelessRetryInterceptorBuilder retryListener(RetryListener retryListener) {
+			this.retryListener = retryListener;
+			return this;
 		}
 
 		@Override
 		public StatelessRetryOperationsInterceptor build() {
 			this.applyCommonSettings(this.factoryBean);
+			if (this.retryListener != null) {
+				this.factoryBean.setRetryListener(this.retryListener);
+			}
 			return this.factoryBean.getObject();
 		}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptor.java
@@ -24,6 +24,7 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.retry.RetryException;
+import org.springframework.core.retry.RetryListener;
 import org.springframework.core.retry.RetryOperations;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
@@ -35,26 +36,38 @@ import org.springframework.core.retry.RetryTemplate;
  * @author Juergen Hoeller
  * @author Stephane Nicoll
  * @author Artem Bilan
+ * @author Jun Cho
  *
  * @since 4.0
  */
 public final class StatelessRetryOperationsInterceptor implements MethodInterceptor {
 
-	private final RetryOperations retryOperations;
+	private final RetryTemplate retryTemplate;
 
 	private final @Nullable BiFunction<@Nullable Object[], Throwable, @Nullable Object> recoverer;
 
 	StatelessRetryOperationsInterceptor(@Nullable RetryPolicy retryPolicy,
 			@Nullable BiFunction<@Nullable Object[], Throwable, @Nullable Object> recoverer) {
-		this.retryOperations =
+		this.retryTemplate =
 				new RetryTemplate(retryPolicy != null ? retryPolicy : RetryPolicy.builder().delay(Duration.ZERO).build());
 		this.recoverer = recoverer;
+	}
+
+	/**
+	 * Set a {@link RetryListener} to be registered on the internal {@link RetryTemplate}.
+	 * If multiple listeners are needed, use a
+	 * {@link org.springframework.core.retry.support.CompositeRetryListener}.
+	 * @param retryListener the retry listener to use
+	 * @since 4.1.1
+	 */
+	public void setRetryListener(RetryListener retryListener) {
+		this.retryTemplate.setRetryListener(retryListener);
 	}
 
 	@Override
 	public @Nullable Object invoke(final MethodInvocation invocation) throws Throwable {
 		try {
-			return this.retryOperations.<@Nullable Object>execute(invocation::proceed);
+			return this.retryTemplate.<@Nullable Object>execute(invocation::proceed);
 		}
 		catch (RetryException ex) {
 			if (this.recoverer != null) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptorFactoryBean.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptorFactoryBean.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.retry.MessageBatchRecoverer;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
+import org.springframework.core.retry.RetryListener;
 import org.springframework.core.retry.RetryOperations;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.Retryable;
@@ -42,6 +43,7 @@ import org.springframework.core.retry.Retryable;
  * @author Dave Syer
  * @author Gary Russell
  * @author Stephane Nicoll
+ * @author Jun Cho
  *
  * @see RetryOperations#execute(Retryable)
  */
@@ -49,9 +51,27 @@ public class StatelessRetryOperationsInterceptorFactoryBean extends AbstractRetr
 
 	protected final Log logger = LogFactory.getLog(getClass()); // NOSONAR
 
+	private @Nullable RetryListener retryListener;
+
+	/**
+	 * Set a {@link RetryListener} for the target stateless interceptor. If multiple
+	 * listeners are needed, use a
+	 * {@link org.springframework.core.retry.support.CompositeRetryListener}.
+	 * @param retryListener the retry listener to use
+	 * @since 4.1.1
+	 */
+	public void setRetryListener(RetryListener retryListener) {
+		this.retryListener = retryListener;
+	}
+
 	@Override
 	public StatelessRetryOperationsInterceptor getObject() {
-		return new StatelessRetryOperationsInterceptor(getRetryPolicy(), this::recover);
+		StatelessRetryOperationsInterceptor interceptor =
+				new StatelessRetryOperationsInterceptor(getRetryPolicy(), this::recover);
+		if (this.retryListener != null) {
+			interceptor.setRetryListener(this.retryListener);
+		}
+		return interceptor;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilderSupportTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RetryInterceptorBuilderSupportTests.java
@@ -37,7 +37,11 @@ import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.core.retry.RetryException;
+import org.springframework.core.retry.RetryListener;
 import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryState;
+import org.springframework.core.retry.Retryable;
 import org.springframework.util.backoff.BackOff;
 import org.springframework.util.backoff.FixedBackOff;
 
@@ -50,6 +54,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Jun Cho
  *
  * @since 1.3
  *
@@ -279,6 +284,39 @@ public class RetryInterceptorBuilderSupportTests {
 				.isThrownBy(() -> delegate.onMessage("", message));
 
 		assertThat(count).hasValue(4);
+	}
+
+	@Test
+	public void testStatelessRetryListener() {
+		AtomicInteger beforeRetryCalls = new AtomicInteger();
+		AtomicInteger exhaustionCalls = new AtomicInteger();
+		StatelessRetryOperationsInterceptor interceptor = RetryInterceptorBuilder.stateless()
+				.configureRetryPolicy((retryPolicy) -> retryPolicy.delay(Duration.ZERO))
+				.retryListener(new RetryListener() {
+
+					@Override
+					public void beforeRetry(RetryPolicy retryPolicy, Retryable<?> retryable, RetryState retryState) {
+						beforeRetryCalls.incrementAndGet();
+					}
+
+					@Override
+					public void onRetryPolicyExhaustion(RetryPolicy retryPolicy, Retryable<?> retryable,
+							RetryException retryException) {
+
+						exhaustionCalls.incrementAndGet();
+					}
+
+				})
+				.build();
+
+		final AtomicInteger count = new AtomicInteger();
+		Foo delegate = createDelegate(interceptor, count);
+		Message message = MessageBuilder.withBody("".getBytes()).build();
+		delegate.onMessage("", message);
+
+		assertThat(count).hasValue(4);
+		assertThat(beforeRetryCalls).hasValue(3);
+		assertThat(exhaustionCalls).hasValue(1);
 	}
 
 	private Foo createDelegate(MethodInterceptor interceptor, final AtomicInteger count) {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptorTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/StatelessRetryOperationsInterceptorTests.java
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.config;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 import org.aopalliance.intercept.MethodInvocation;
@@ -24,7 +25,11 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.springframework.core.retry.RetryException;
+import org.springframework.core.retry.RetryListener;
 import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryState;
+import org.springframework.core.retry.Retryable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
@@ -36,9 +41,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
 /**
- * Tests fpr {@link StatelessRetryOperationsInterceptor}.
+ * Tests for {@link StatelessRetryOperationsInterceptor}.
  *
  * @author Stephane Nicoll
+ * @author Jun Cho
  */
 class StatelessRetryOperationsInterceptorTests {
 
@@ -107,6 +113,69 @@ class StatelessRetryOperationsInterceptorTests {
 		StatelessRetryOperationsInterceptor noRecovererInterceptor = new StatelessRetryOperationsInterceptor(retryPolicy, null);
 		assertThatException().isThrownBy(() -> noRecovererInterceptor.invoke(invocation))
 				.isSameAs(LastException);
+	}
+
+	@Test
+	void invokeWithRetryListenerInvokesCallbacks() throws Throwable {
+		RetryPolicy retryPolicy = RetryPolicy.builder().maxRetries(2).delay(Duration.ZERO).build();
+		Object[] arguments = new Object[] { "message" };
+		MethodInvocation invocation = mock(MethodInvocation.class);
+		given(invocation.getArguments()).willReturn(arguments);
+		given(invocation.proceed()).willThrow(new IllegalStateException("initial"))
+				.willThrow(new IllegalStateException("retry-1")).willThrow(new IllegalStateException("retry-2"));
+		given(this.recoverer.apply(eq(arguments), any())).willReturn("recovered");
+		AtomicInteger beforeRetryCalls = new AtomicInteger();
+		AtomicInteger retryFailureCalls = new AtomicInteger();
+		AtomicInteger exhaustionCalls = new AtomicInteger();
+		StatelessRetryOperationsInterceptor interceptor = createInterceptor(retryPolicy);
+		interceptor.setRetryListener(new RetryListener() {
+
+			@Override
+			public void beforeRetry(RetryPolicy policy, Retryable<?> retryable, RetryState retryState) {
+				beforeRetryCalls.incrementAndGet();
+			}
+
+			@Override
+			public void onRetryFailure(RetryPolicy policy, Retryable<?> retryable, Throwable throwable) {
+				retryFailureCalls.incrementAndGet();
+			}
+
+			@Override
+			public void onRetryPolicyExhaustion(RetryPolicy policy, Retryable<?> retryable,
+					RetryException retryException) {
+
+				exhaustionCalls.incrementAndGet();
+			}
+
+		});
+		assertThat(interceptor.invoke(invocation)).isEqualTo("recovered");
+		assertThat(beforeRetryCalls).hasValue(2);
+		assertThat(retryFailureCalls).hasValue(2);
+		assertThat(exhaustionCalls).hasValue(1);
+	}
+
+	@Test
+	void invokeWithRetryListenerAppliedViaFactoryBean() throws Throwable {
+		AtomicInteger exhaustionCalls = new AtomicInteger();
+		StatelessRetryOperationsInterceptorFactoryBean factoryBean =
+				new StatelessRetryOperationsInterceptorFactoryBean();
+		factoryBean.setRetryPolicy(RetryPolicy.builder().maxRetries(1).delay(Duration.ZERO).build());
+		factoryBean.setRetryListener(new RetryListener() {
+
+			@Override
+			public void onRetryPolicyExhaustion(RetryPolicy policy, Retryable<?> retryable,
+					RetryException retryException) {
+
+				exhaustionCalls.incrementAndGet();
+			}
+
+		});
+		MethodInvocation invocation = mock(MethodInvocation.class);
+		given(invocation.getArguments()).willReturn(new Object[] { "channel", "message" });
+		given(invocation.proceed()).willThrow(new IllegalStateException("initial"))
+				.willThrow(new IllegalStateException("retry-1"));
+		assertThat(factoryBean.getObject().invoke(invocation)).isNull();
+		assertThat(exhaustionCalls).hasValue(1);
 	}
 
 	private StatelessRetryOperationsInterceptor createInterceptor(@Nullable RetryPolicy retryPolicy) {

--- a/src/reference/antora/modules/ROOT/pages/amqp/resilience-recovering-from-errors-and-broker-failures.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/resilience-recovering-from-errors-and-broker-failures.adoc
@@ -92,6 +92,9 @@ Only a subset of retry capabilities can be configured this way.
 More advanced features would need the configuration of a `RetryPolicy`.
 See the {spring-framework-javadoc}/org/springframework/core/retry/RetryPolicy.html[`RetryPolicy` Javadoc] for more information about available policies and their configuration.
 
+Starting with version 4.1.1, a `RetryListener` can be registered with the stateless interceptor (via the `RetryInterceptorBuilder.stateless().retryListener()` option or the respective `StatelessRetryOperationsInterceptorFactoryBean` property) to react to retry events such as retry policy exhaustion.
+See the {spring-framework-javadoc}/org/springframework/core/retry/RetryListener.html[`RetryListener` Javadoc] for more information.
+
 [[batch-retry]]
 == Retry with Batch Listeners
 


### PR DESCRIPTION
Fixes #3434

The `RetryTemplate` created inside `StatelessRetryOperationsInterceptor` could only be
configured with a `RetryPolicy`, so there was no way to react to retry events, e.g. to detect
that the retry policy has been exhausted.

Expose a `setRetryListener(RetryListener)` option on `StatelessRetryOperationsInterceptor` and
`StatelessRetryOperationsInterceptorFactoryBean`, plus a `retryListener()` option on
`RetryInterceptorBuilder.stateless()`. `StreamRetryOperationsInterceptorFactoryBean` inherits
the new option.

The API takes a single listener, mirroring `RetryTemplate#setRetryListener()`; multiple
listeners can be combined with a `CompositeRetryListener`. The stateful interceptor is left
out since it manages retry state itself and doesn't use a `RetryTemplate`.