### PR TITLE
GH-3529: Fix concurrency in RabbitAmqpListenerContainer.ConsumerBatch

### DIFF
--- a/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/listener/RabbitAmqpListenerContainer.java
+++ b/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/listener/RabbitAmqpListenerContainer.java
@@ -586,7 +586,9 @@ public class RabbitAmqpListenerContainer
 
 	private class ConsumerMessageHandler implements Consumer.MessageHandler {
 
-		private volatile @Nullable ConsumerBatch consumerBatch;
+		private final Lock lock = new ReentrantLock();
+
+		private @Nullable ConsumerBatch consumerBatch;
 
 		ConsumerMessageHandler() {
 		}
@@ -594,17 +596,23 @@ public class RabbitAmqpListenerContainer
 		@Override
 		public void handle(Consumer.Context context, com.rabbitmq.client.amqp.Message message) {
 			if (RabbitAmqpListenerContainer.this.batchSize > 1) {
-				ConsumerBatch currentBatch = this.consumerBatch;
-				if (currentBatch == null || currentBatch.batchReleaseFuture == null) {
-					currentBatch =
-							new ConsumerBatch(RabbitAmqpListenerContainer.this.batchSize,
-									context.batch(RabbitAmqpListenerContainer.this.batchSize));
-					this.consumerBatch = currentBatch;
+				this.lock.lock();
+				try {
+					ConsumerBatch currentBatch = this.consumerBatch;
+					if (currentBatch == null) {
+						currentBatch =
+								new ConsumerBatch(RabbitAmqpListenerContainer.this.batchSize,
+										context.batch(RabbitAmqpListenerContainer.this.batchSize));
+						this.consumerBatch = currentBatch;
+					}
+					currentBatch.add(context, message);
+					if (currentBatch.batchContext.size() == RabbitAmqpListenerContainer.this.batchSize) {
+						currentBatch.release();
+						this.consumerBatch = null;
+					}
 				}
-				currentBatch.add(context, message);
-				if (currentBatch.batchContext.size() == RabbitAmqpListenerContainer.this.batchSize) {
-					currentBatch.release();
-					this.consumerBatch = null;
+				finally {
+					this.lock.unlock();
 				}
 			}
 			else {
@@ -618,7 +626,9 @@ public class RabbitAmqpListenerContainer
 
 			private final Consumer.BatchContext batchContext;
 
-			private volatile @Nullable ScheduledFuture<?> batchReleaseFuture;
+			private @Nullable ScheduledFuture<?> batchReleaseFuture;
+
+			private boolean released;
 
 			ConsumerBatch(int batchSize, Consumer.BatchContext batchContext) {
 				this.batchContext = batchContext;
@@ -631,22 +641,34 @@ public class RabbitAmqpListenerContainer
 				if (this.batchReleaseFuture == null) {
 					this.batchReleaseFuture =
 							Objects.requireNonNull(RabbitAmqpListenerContainer.this.taskScheduler)
-									.schedule(this::releaseInternal,
+									.schedule(this::scheduledRelease,
 											Instant.now().plus(RabbitAmqpListenerContainer.this.batchReceiveDuration));
 				}
 			}
 
 			void release() {
-				ScheduledFuture<?> currentBatchReleaseFuture = this.batchReleaseFuture;
-				if (currentBatchReleaseFuture != null) {
-					currentBatchReleaseFuture.cancel(true);
+				if (this.batchReleaseFuture != null) {
+					this.batchReleaseFuture.cancel(true);
+				}
+				releaseInternal();
+			}
+
+			private void scheduledRelease() {
+				ConsumerMessageHandler.this.lock.lock();
+				try {
+					if (ConsumerMessageHandler.this.consumerBatch == this) {
+						ConsumerMessageHandler.this.consumerBatch = null;
+					}
 					releaseInternal();
+				}
+				finally {
+					ConsumerMessageHandler.this.lock.unlock();
 				}
 			}
 
 			private void releaseInternal() {
-				if (this.batchReleaseFuture != null) {
-					this.batchReleaseFuture = null;
+				if (!this.released) {
+					this.released = true;
 					invokeBatchListener(this.batchContext, this.batch);
 				}
 			}


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-amqp/issues/3529

The `ConsumerBatch.releaseInternal()` could be called concurrently from a scheduled task and regular batch fulfillment.

* Add `ConsumerMessageHandler.lock` to guard in concurrent operations
* Add `ConsumerBatch.released` to avoid second undesired release

**Auto-cherry-pick to `4.0.x`**

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.md).
-->
