### PR TITLE
GH-3532: Add connection name support

### DIFF
--- a/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/SingleAmqpConnectionFactory.java
+++ b/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/SingleAmqpConnectionFactory.java
@@ -60,6 +60,17 @@ public class SingleAmqpConnectionFactory implements AmqpConnectionFactory, Dispo
 		return this;
 	}
 
+	/**
+	 * Set the name used to identify the connection.
+	 * @param connectionName the connection name
+	 * @return this connection factory
+	 * @since 4.0.1
+	 */
+	public SingleAmqpConnectionFactory setConnectionName(String connectionName) {
+		this.connectionBuilder.name(connectionName);
+		return this;
+	}
+
 	public SingleAmqpConnectionFactory setPort(int port) {
 		this.connectionBuilder.port(port);
 		return this;

--- a/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/SingleAmqpConnectionFactory.java
+++ b/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/SingleAmqpConnectionFactory.java
@@ -40,7 +40,7 @@ import org.springframework.beans.factory.DisposableBean;
  * The {@link AmqpConnectionFactory} implementation to hold a single, shared {@link Connection} instance.
  *
  * @author Artem Bilan
- *
+ * @author Movindu Jayathilake
  * @since 4.0
  */
 public class SingleAmqpConnectionFactory implements AmqpConnectionFactory, DisposableBean {
@@ -64,7 +64,7 @@ public class SingleAmqpConnectionFactory implements AmqpConnectionFactory, Dispo
 	 * Set the name used to identify the connection.
 	 * @param connectionName the connection name
 	 * @return this connection factory
-	 * @since 4.0.1
+	 * @since 4.0.5
 	 */
 	public SingleAmqpConnectionFactory setConnectionName(String connectionName) {
 		this.connectionBuilder.name(connectionName);

--- a/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/SingleAmqpConnectionFactoryTests.java
+++ b/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/SingleAmqpConnectionFactoryTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbitmq.client;
+
+import com.rabbitmq.client.amqp.ConnectionBuilder;
+import com.rabbitmq.client.amqp.Environment;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link SingleAmqpConnectionFactory}.
+ *
+ * @author Movindu Jayathilake
+ *
+ * @since 4.0.1
+ */
+class SingleAmqpConnectionFactoryTests {
+
+	@Test
+	void setConnectionNameDelegatesToConnectionBuilder() {
+		Environment environment = mock(Environment.class);
+		ConnectionBuilder connectionBuilder = mock(ConnectionBuilder.class);
+
+		given(environment.connectionBuilder()).willReturn(connectionBuilder);
+
+		SingleAmqpConnectionFactory connectionFactory =
+				new SingleAmqpConnectionFactory(environment);
+
+		SingleAmqpConnectionFactory result =
+				connectionFactory.setConnectionName("billing-service");
+
+		verify(connectionBuilder).name("billing-service");
+		assertThat(result).isSameAs(connectionFactory);
+	}
+
+}

--- a/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/SingleAmqpConnectionFactoryTests.java
+++ b/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/SingleAmqpConnectionFactoryTests.java
@@ -30,14 +30,14 @@ import static org.mockito.Mockito.verify;
  *
  * @author Movindu Jayathilake
  *
- * @since 4.0.1
+ * @since 4.0.5
  */
 class SingleAmqpConnectionFactoryTests {
 
 	@Test
 	void setConnectionNameDelegatesToConnectionBuilder() {
-		Environment environment = mock(Environment.class);
-		ConnectionBuilder connectionBuilder = mock(ConnectionBuilder.class);
+		Environment environment = mock();
+		ConnectionBuilder connectionBuilder = mock();
 
 		given(environment.connectionBuilder()).willReturn(connectionBuilder);
 


### PR DESCRIPTION
Adds support for configuring a connection name on
SingleAmqpConnectionFactory.

The new fluent setConnectionName(String) method delegates to the
underlying RabbitMQ AMQP ConnectionBuilder.

Also adds focused unit coverage verifying that:

- the connection name is delegated to ConnectionBuilder.name(...)
- the setter returns the same SingleAmqpConnectionFactory instance

Fixes #3532

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.md).
-->
