### PR TITLE
Remove duplicated "the"

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-1-3-since-1-2.adoc
+++ b/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-1-3-since-1-2.adoc
@@ -39,7 +39,7 @@ See xref:amqp/broker-configuration.adoc[Configuring the Broker].
 == Direct Exchange Binding
 
 Previously, omitting the `key` attribute from a `binding` element of a `direct-exchange` configuration caused the queue or exchange to be bound with an empty string as the routing key.
-Now it is bound with the the name of the provided `Queue` or `Exchange`.
+Now it is bound with the name of the provided `Queue` or `Exchange`.
 If you wish to bind with an empty string routing key, you need to specify `key=""`.
 
 [[amqptemplate-changes]]

--- a/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-1-6-since-1-5.adoc
+++ b/src/reference/antora/modules/ROOT/pages/appendix/previous-whats-new/changes-in-1-6-since-1-5.adoc
@@ -124,7 +124,7 @@ See xref:amqp/message-converters.adoc#message-properties-converters[Message Prop
 === Inbound Delivery Mode
 
 The `deliveryMode` property is no longer mapped to the `MessageProperties.deliveryMode`.
-This change avoids unintended propagation if the the same `MessageProperties` object is used to send an outbound message.
+This change avoids unintended propagation if the same `MessageProperties` object is used to send an outbound message.
 Instead, the inbound `deliveryMode` header is mapped to `MessageProperties.receivedDeliveryMode`.
 
 See xref:amqp/message-converters.adoc#message-properties-converters[Message Properties Converters] for more information.
@@ -137,7 +137,7 @@ See xref:amqp/receiving-messages/async-annotation-driven/enable-signature.adoc[A
 === Inbound User ID
 
 The `user_id` property is no longer mapped to the `MessageProperties.userId`.
-This change avoids unintended propagation if the the same `MessageProperties` object is used to send an outbound message.
+This change avoids unintended propagation if the same `MessageProperties` object is used to send an outbound message.
 Instead, the inbound `userId` header is mapped to `MessageProperties.receivedUserId`.
 
 See xref:amqp/message-converters.adoc#message-properties-converters[Message Properties Converters] for more information.


### PR DESCRIPTION
This PR fixes typos of "the the" to "the".