### PR TITLE
GH-3540: Deprecate `RestTemplateNodeLocator`

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -261,7 +261,7 @@ public final class ConnectionFactoryUtils {
 			return new WebFluxNodeLocator();
 		}
 		else {
-			return new RestTemplateNodeLocator();
+			return new RestClientNodeLocator();
 		}
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RestClientNodeLocator.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RestClientNodeLocator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.support.BasicAuthenticationInterceptor;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriUtils;
+
+/**
+ * A {@link NodeLocator} using the {@link RestClient}.
+ *
+ * @author Rene Choi
+ *
+ * @since 4.2
+ *
+ */
+public class RestClientNodeLocator implements NodeLocator<RestClient> {
+
+	@Override
+	public RestClient createClient(String userName, String password) {
+		return RestClient.builder()
+				.requestInterceptor(new BasicAuthenticationInterceptor(userName, password))
+				.build();
+	}
+
+	@Override
+	public @Nullable Map<String, Object> restCall(RestClient client, String baseUri, String vhost, String queue) {
+
+		URI uri = URI.create(baseUri)
+				.resolve("/api/queues/"
+						+ UriUtils.encodePathSegment(vhost, StandardCharsets.UTF_8) + "/"
+						+ UriUtils.encodePathSegment(queue, StandardCharsets.UTF_8));
+
+		return client.get()
+				.uri(uri)
+				.accept(MediaType.APPLICATION_JSON)
+				.retrieve()
+				.body(new ParameterizedTypeReference<>() {
+
+				});
+	}
+
+}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RestTemplateNodeLocator.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RestTemplateNodeLocator.java
@@ -45,7 +45,11 @@ import org.springframework.web.util.UriUtils;
  *
  * @since 3.0
  *
+ * @deprecated since 4.2 in favor of {@link RestClientNodeLocator} since the
+ * {@link RestTemplate} is deprecated in Spring Framework 7.1.
  */
+@Deprecated(since = "4.2", forRemoval = true)
+@SuppressWarnings("removal")
 public class RestTemplateNodeLocator implements NodeLocator<RestTemplate> {
 
 	private final AuthCache authCache = new BasicAuthCache();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/LocalizedQueueConnectionFactoryIntegrationTests.java
@@ -102,6 +102,7 @@ public class LocalizedQueueConnectionFactoryIntegrationTests extends AbstractTes
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void findLocal() {
 		ConnectionFactory defaultCf = mock(ConnectionFactory.class);
 		BrokerRunningSupport brokerRunning = RabbitAvailableCondition.getBrokerRunning();
@@ -112,9 +113,12 @@ public class LocalizedQueueConnectionFactoryIntegrationTests extends AbstractTes
 		ConnectionFactory cf = lqcf.getTargetConnectionFactory("[local]");
 		RabbitAdmin admin = new RabbitAdmin(cf);
 		assertThat(admin.getQueueProperties("local")).isNotNull();
-		lqcf.setNodeLocator(new RestTemplateNodeLocator());
+		lqcf.setNodeLocator(new RestClientNodeLocator());
 		ConnectionFactory cf2 = lqcf.getTargetConnectionFactory("[local]");
 		assertThat(cf2).isSameAs(cf);
+		lqcf.setNodeLocator(new RestTemplateNodeLocator());
+		ConnectionFactory cf3 = lqcf.getTargetConnectionFactory("[local]");
+		assertThat(cf3).isSameAs(cf);
 		lqcf.destroy();
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RestClientNodeLocatorTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/RestClientNodeLocatorTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Rene Choi
+ *
+ * @since 4.2
+ *
+ */
+public class RestClientNodeLocatorTests {
+
+	private final RestClientNodeLocator nodeLocator = new RestClientNodeLocator();
+
+	@Test
+	void queueInfoIsRetrievedFromEncodedUri() {
+		RestClient.Builder builder = RestClient.builder();
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		server.expect(MockRestRequestMatchers.requestTo("http://localhost:15672/api/queues/%2F/some%20queue"))
+				.andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
+				.andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
+				.andRespond(MockRestResponseCreators.withSuccess("{\"node\":\"rabbit@host\"}",
+						MediaType.APPLICATION_JSON));
+
+		Map<String, Object> queueInfo =
+				this.nodeLocator.restCall(builder.build(), "http://localhost:15672/api/queues/", "/", "some queue");
+
+		assertThat(queueInfo).containsEntry("node", "rabbit@host");
+		server.verify();
+	}
+
+	@Test
+	void apiPathIsResolvedAgainstTheHost() {
+		RestClient.Builder builder = RestClient.builder();
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		server.expect(MockRestRequestMatchers.requestTo("http://localhost:15672/api/queues/vhost/queue"))
+				.andRespond(MockRestResponseCreators.withSuccess("{\"node\":\"rabbit@host\"}",
+						MediaType.APPLICATION_JSON));
+
+		Map<String, Object> queueInfo =
+				this.nodeLocator.restCall(builder.build(), "http://localhost:15672/api/", "vhost", "queue");
+
+		assertThat(queueInfo).containsEntry("node", "rabbit@host");
+		server.verify();
+	}
+
+}

--- a/src/reference/antora/modules/ROOT/pages/amqp/connections.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/connections.adoc
@@ -624,7 +624,8 @@ Notice that the first three parameters are arrays of `addresses`, `adminUris`, a
 These are positional in that, when a container attempts to connect to a queue, it uses the admin API to determine which node is the lead for the queue and connects to the address in the same array position as that node.
 
 IMPORTANT: Starting with version 3.0, the RabbitMQ `http-client` is no longer used to access the Rest API.
-Instead, by default, the `WebClient` from Spring Webflux is used if `spring-webflux` is on the class path; otherwise a `RestTemplate` is used.
+Instead, by default, the `WebClient` from Spring Webflux is used if `spring-webflux` is on the class path; otherwise a `RestClient` is used.
+Before version 4.2, the non-reactive default was a `RestTemplate`, which is deprecated in Spring Framework `7.1`.
 
 To add `WebFlux` to the class path:
 
@@ -661,7 +662,8 @@ lqcf.setNodeLocator(new NodeLocator<MyClient>() {
 });
 ----
 
-The framework provides the `WebFluxNodeLocator` and `RestTemplateNodeLocator`, with the default as discussed above.
+The framework provides the `WebFluxNodeLocator` and `RestClientNodeLocator`, with the default as discussed above.
+The `RestTemplateNodeLocator` is still available, but it is deprecated since version 4.2 in favor of the `RestClientNodeLocator`.
 
 [[cf-pub-conf-ret]]
 == Publisher Confirms and Returns

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -4,3 +4,10 @@
 
 [[changes-in-4-2-since-4-1]]
 == Changes in 4.2 Since 4.1
+
+[[x42-rest-client-node-locator]]
+=== `RestClientNodeLocator`
+
+A new `RestClientNodeLocator` is now the default non-reactive `NodeLocator` implementation for the `LocalizedQueueConnectionFactory`.
+The `RestTemplateNodeLocator` is deprecated since the `RestTemplate` is deprecated in Spring Framework `7.1`.
+See xref:amqp/connections.adoc#queue-affinity[Queue Affinity and the `LocalizedQueueConnectionFactory`] for more information.


### PR DESCRIPTION
Fixes #3540

`RestTemplate` is deprecated for removal in Spring Framework `7.1` (spring-projects/spring-framework#36574) and `RestClient` is the designated replacement.

`RestTemplateNodeLocator` is not only one of the choices a user can make: it is what `ConnectionFactoryUtils.nodeLocator()` returns for the `LocalizedQueueConnectionFactory` when `spring-webflux` is not on the class path. Deprecating it on its own would leave non-reactive users without a supported `NodeLocator`, so this adds the `RestClient` variant first and makes it the new non-reactive default.

* `RestClientNodeLocator` (new) mirrors `RestTemplateNodeLocator`: basic authentication via `BasicAuthenticationInterceptor` and the same `/api/queues/{vhost}/{queue}` call. `RestClient` ships in `spring-web` just like `RestTemplate`, so the dependency profile does not change. One incidental improvement: `RestTemplateNodeLocator` wires `HttpComponentsClientHttpRequestFactory` explicitly and therefore requires the optional `httpclient5` dependency, while `RestClient` uses Apache HttpComponents when it is present and otherwise falls back to whichever client is available, down to the JDK `HttpClient`.
* `ConnectionFactoryUtils.nodeLocator()` returns `RestClientNodeLocator` when `WebClient` is absent.
* `RestTemplateNodeLocator` is annotated `@Deprecated(since = "4.2", forRemoval = true)`. A class level `@SuppressWarnings("removal")` keeps the build clean of the warnings its own use of `RestTemplate` now emits.
* Reference manual and What's New updated.

Verified locally with the JDK 25 toolchain, against RabbitMQ 4.3.4 with the management plugin (local broker plus the Testcontainers one the test class starts):

* new `RestClientNodeLocatorTests` covers the URI construction, including the `%2F` encoding of the default vhost, and the JSON deserialization, through `MockRestServiceServer`
* `LocalizedQueueConnectionFactoryIntegrationTests.findLocal()` now exercises `RestClientNodeLocator` against a live broker and keeps a leg on `RestTemplateNodeLocator` while that one is still present
* `./gradlew :spring-rabbit:test --tests "org.springframework.amqp.rabbit.connection.*"`: 135 tests, 0 failures
* `./gradlew :spring-rabbit:checkstyleMain :spring-rabbit:checkstyleTest :spring-rabbit:javadoc`: clean
