### PR TITLE
GH-1545: Add batchSize and batchReceiveTimeout to @RabbitListener

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/listener/AbstractListenerAnnotationBeanPostProcessor.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/listener/AbstractListenerAnnotationBeanPostProcessor.java
@@ -65,6 +65,7 @@ import org.springframework.util.StringUtils;
  * @param <A> the listener annotation type.
  *
  * @author Artem Bilan
+ * @author Martin Ferret
  *
  * @since 4.1
  */
@@ -253,6 +254,30 @@ public abstract class AbstractListenerAnnotationBeanPostProcessor<A extends Anno
 		}
 		else {
 			throw new IllegalStateException("The [" + attribute + "] must resolve to a Integer. "
+					+ "Resolved to [" + resolved + "] for [" + value + "]");
+		}
+	}
+
+	/**
+	 * Resolve the provided attribute value to a {@link Long}.
+	 * @param value the attribute value to resolve.
+	 * @param attribute the attribute name, for error reporting.
+	 * @return the resolved value, or {@code null} if the attribute has no length.
+	 * @since 4.2
+	 */
+	protected @Nullable Long resolveExpressionToLong(String value, String attribute) {
+		if (!StringUtils.hasLength(value)) {
+			return null;
+		}
+		Object resolved = resolveExpression(value);
+		if (resolved instanceof String str) {
+			return Long.parseLong(str);
+		}
+		else if (resolved instanceof Number number) {
+			return number.longValue();
+		}
+		else {
+			throw new IllegalStateException("The [" + attribute + "] must resolve to a Long. "
 					+ "Resolved to [" + resolved + "] for [" + value + "]");
 		}
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListener.java
@@ -95,6 +95,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
  *
  * @author Stephane Nicoll
  * @author Gary Russell
+ * @author Martin Ferret
  * @since 1.4
  * @see EnableRabbit
  * @see RabbitListenerAnnotationBeanPostProcessor
@@ -345,5 +346,32 @@ public @interface RabbitListener {
 	 * @see Boolean#parseBoolean(String)
 	 */
 	String batch() default "";
+
+	/**
+	 * Override the container factory's {@code batchSize} property. Ignored by container
+	 * factories that have no such property, such as the
+	 * {@code DirectRabbitListenerContainerFactory}. This overrides the value only; it
+	 * does not enable {@code consumerBatchEnabled}, which stays a container factory
+	 * property - refer to the reference documentation.
+	 * @return the batch size for this listener. If not set, the container factory setting
+	 * is used. SpEL {@code #{...}} and property place holders {@code ${...}} are
+	 * supported.
+	 * @since 4.2
+	 * @see #batchReceiveTimeout()
+	 */
+	String batchSize() default "";
+
+	/**
+	 * Override the container factory's {@code batchReceiveTimeout} property; the number
+	 * of milliseconds a batch gathering process should go on before a partial batch is
+	 * released. Ignored by container factories that have no such property, such as the
+	 * {@code DirectRabbitListenerContainerFactory}.
+	 * @return the batch receive timeout for this listener. If not set, the container
+	 * factory setting is used. SpEL {@code #{...}} and property place holders
+	 * {@code ${...}} are supported.
+	 * @since 4.2
+	 * @see #batchSize()
+	 */
+	String batchReceiveTimeout() default "";
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -97,6 +97,7 @@ import org.springframework.validation.Validator;
  * @author Alex Panchenko
  * @author Artem Bilan
  * @author Ngoc Nhan
+ * @author Martin Ferret
  *
  * @since 1.4
  *
@@ -327,6 +328,15 @@ public class RabbitListenerAnnotationBeanPostProcessor
 		resolveReplyContentType(endpoint, rabbitListener);
 		if (StringUtils.hasText(rabbitListener.batch())) {
 			endpoint.setBatchListener(Boolean.parseBoolean(rabbitListener.batch()));
+		}
+		Integer batchSize = resolveExpressionToInteger(rabbitListener.batchSize(), "batchSize");
+		if (batchSize != null) {
+			endpoint.setBatchSize(batchSize);
+		}
+		Long batchReceiveTimeout =
+				resolveExpressionToLong(rabbitListener.batchReceiveTimeout(), "batchReceiveTimeout");
+		if (batchReceiveTimeout != null) {
+			endpoint.setBatchReceiveTimeout(batchReceiveTimeout);
 		}
 		RabbitListenerContainerFactory<?> factory = resolveContainerFactory(rabbitListener, target, beanName);
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -193,10 +193,14 @@ public class SimpleRabbitListenerContainerFactory
 
 		super.initializeContainer(instance, endpoint);
 
-		// endpoint settings override the default factory settings
-		Integer endpointBatchSize = endpoint != null ? endpoint.getBatchSize() : null;
-		Long endpointBatchReceiveTimeout = endpoint != null ? endpoint.getBatchReceiveTimeout() : null;
-		String concurrency = endpoint != null ? endpoint.getConcurrency() : null;
+		Integer endpointBatchSize = null;
+		Long endpointBatchReceiveTimeout = null;
+		String concurrency = null;
+		if (endpoint != null) { // endpoint settings overriding default factory settings
+			endpointBatchSize = endpoint.getBatchSize();
+			endpointBatchReceiveTimeout = endpoint.getBatchReceiveTimeout();
+			concurrency = endpoint.getConcurrency();
+		}
 		JavaUtils javaUtils = JavaUtils.INSTANCE
 				.acceptOrElseIfNotNull(endpointBatchSize, this.batchSize, instance::setBatchSize)
 				.acceptIfNotNull(concurrency, instance::setConcurrency);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/SimpleRabbitListenerContainerFactory.java
@@ -35,6 +35,7 @@ import org.springframework.amqp.utils.JavaUtils;
  * @author Artem Bilan
  * @author Dustin Schultz
  * @author Jeonggi Kim
+ * @author Martin Ferret
  *
  * @since 1.4
  */
@@ -192,13 +193,13 @@ public class SimpleRabbitListenerContainerFactory
 
 		super.initializeContainer(instance, endpoint);
 
+		// endpoint settings override the default factory settings
+		Integer endpointBatchSize = endpoint != null ? endpoint.getBatchSize() : null;
+		Long endpointBatchReceiveTimeout = endpoint != null ? endpoint.getBatchReceiveTimeout() : null;
+		String concurrency = endpoint != null ? endpoint.getConcurrency() : null;
 		JavaUtils javaUtils = JavaUtils.INSTANCE
-				.acceptIfNotNull(this.batchSize, instance::setBatchSize);
-		String concurrency = null;
-		if (endpoint != null) {
-			concurrency = endpoint.getConcurrency();
-			javaUtils.acceptIfNotNull(concurrency, instance::setConcurrency);
-		}
+				.acceptOrElseIfNotNull(endpointBatchSize, this.batchSize, instance::setBatchSize)
+				.acceptIfNotNull(concurrency, instance::setConcurrency);
 		javaUtils
 				.acceptIfCondition(concurrency == null && this.concurrentConsumers != null, this.concurrentConsumers,
 						instance::setConcurrentConsumers)
@@ -210,7 +211,8 @@ public class SimpleRabbitListenerContainerFactory
 				.acceptIfNotNull(this.consecutiveActiveTrigger, instance::setConsecutiveActiveTrigger)
 				.acceptIfNotNull(this.consecutiveIdleTrigger, instance::setConsecutiveIdleTrigger)
 				.acceptIfNotNull(this.receiveTimeout, instance::setReceiveTimeout)
-				.acceptIfNotNull(this.batchReceiveTimeout, instance::setBatchReceiveTimeout)
+				.acceptOrElseIfNotNull(endpointBatchReceiveTimeout, this.batchReceiveTimeout,
+						instance::setBatchReceiveTimeout)
 				.acceptIfNotNull(this.enforceImmediateAckForManual, instance::setEnforceImmediateAckForManual)
 				.acceptIfNotNull(this.immediateScaleDown, instance::setImmediateScaleDown);
 		if (Boolean.TRUE.equals(this.consumerBatchEnabled)) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractRabbitListenerEndpoint.java
@@ -49,6 +49,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Ngoc Nhan
+ * @author Martin Ferret
  *
  * @since 1.4
  *
@@ -88,6 +89,10 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 	private @Nullable TaskExecutor taskExecutor;
 
 	private @Nullable Boolean batchListener;
+
+	private @Nullable Integer batchSize;
+
+	private @Nullable Long batchReceiveTimeout;
 
 	private @Nullable BatchingStrategy batchingStrategy;
 
@@ -324,6 +329,37 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 	}
 
 	@Override
+	public @Nullable Integer getBatchSize() {
+		return this.batchSize;
+	}
+
+	/**
+	 * Override the container factory's {@code batchSize} property for this endpoint.
+	 * @param batchSize the batch size.
+	 * @since 4.2
+	 * @see #setBatchReceiveTimeout(Long)
+	 */
+	public void setBatchSize(Integer batchSize) {
+		this.batchSize = batchSize;
+	}
+
+	@Override
+	public @Nullable Long getBatchReceiveTimeout() {
+		return this.batchReceiveTimeout;
+	}
+
+	/**
+	 * Override the container factory's {@code batchReceiveTimeout} property for this
+	 * endpoint.
+	 * @param batchReceiveTimeout the timeout in milliseconds for gathering a batch.
+	 * @since 4.2
+	 * @see #setBatchSize(Integer)
+	 */
+	public void setBatchReceiveTimeout(Long batchReceiveTimeout) {
+		this.batchReceiveTimeout = batchReceiveTimeout;
+	}
+
+	@Override
 	public @Nullable BatchingStrategy getBatchingStrategy() {
 		return this.batchingStrategy;
 	}
@@ -444,6 +480,9 @@ public abstract class AbstractRabbitListenerEndpoint implements RabbitListenerEn
 				append("' | queueNames='").append(this.queueNames).
 				append("' | exclusive='").append(this.exclusive).
 				append("' | priority='").append(this.priority).
+				append("' | batchListener='").append(this.batchListener).
+				append("' | batchSize='").append(this.batchSize).
+				append("' | batchReceiveTimeout='").append(this.batchReceiveTimeout).
 				append("' | admin='").append(this.admin).append("'");
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpoint.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpoint.java
@@ -32,6 +32,7 @@ import org.springframework.core.task.TaskExecutor;
  *
  * @author Stephane Nicoll
  * @author Gary Russell
+ * @author Martin Ferret
  * @since 1.4
  */
 public interface RabbitListenerEndpoint {
@@ -127,6 +128,28 @@ public interface RabbitListenerEndpoint {
 	 */
 	@Nullable
 	Boolean getBatchListener();
+
+	/**
+	 * Override the container factory's {@code batchSize} property for this endpoint.
+	 * @return the batch size, or {@code null} to use the container factory setting.
+	 * @since 4.2
+	 * @see #getBatchReceiveTimeout()
+	 */
+	default @Nullable Integer getBatchSize() {
+		return null;
+	}
+
+	/**
+	 * Override the container factory's {@code batchReceiveTimeout} property for this
+	 * endpoint.
+	 * @return the batch receive timeout in milliseconds, or {@code null} to use the
+	 * container factory setting.
+	 * @since 4.2
+	 * @see #getBatchSize()
+	 */
+	default @Nullable Long getBatchReceiveTimeout() {
+		return null;
+	}
 
 	/**
 	 * Set a {@link BatchingStrategy} to use when debatching messages.

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
@@ -63,6 +63,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Stephane Nicoll
  * @author Juergen Hoeller
  * @author Alex Panchenko
+ * @author Martin Ferret
  */
 public class RabbitListenerAnnotationBeanPostProcessorTests {
 
@@ -334,6 +335,42 @@ public class RabbitListenerAnnotationBeanPostProcessorTests {
 		}
 	}
 
+	@Test
+	public void batchOverridesNotSetByDefault() {
+		try (ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				getConfigClass(), SimpleMessageListenerTestBean.class)) {
+
+			RabbitListenerContainerTestFactory factory = context.getBean(RabbitListenerContainerTestFactory.class);
+			RabbitListenerEndpoint endpoint = factory.getListenerContainers().get(0).getEndpoint();
+			assertThat(endpoint.getBatchSize()).isNull();
+			assertThat(endpoint.getBatchReceiveTimeout()).isNull();
+		}
+	}
+
+	@Test
+	public void batchOverridesResolved() {
+		try (ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				getConfigClass(), BatchOverridesTestBean.class)) {
+
+			RabbitListenerContainerTestFactory factory = context.getBean(RabbitListenerContainerTestFactory.class);
+			RabbitListenerEndpoint endpoint = factory.getListenerContainers().get(0).getEndpoint();
+			assertThat(endpoint.getBatchSize()).isEqualTo(5);
+			assertThat(endpoint.getBatchReceiveTimeout()).isEqualTo(1500L);
+		}
+	}
+
+	@Test
+	public void batchOverridesResolvedFromExpressionAndPlaceholder() {
+		try (ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(
+				getConfigClass(), BatchOverridesExpressionTestBean.class)) {
+
+			RabbitListenerContainerTestFactory factory = context.getBean(RabbitListenerContainerTestFactory.class);
+			RabbitListenerEndpoint endpoint = factory.getListenerContainers().get(0).getEndpoint();
+			assertThat(endpoint.getBatchSize()).isEqualTo(7);
+			assertThat(endpoint.getBatchReceiveTimeout()).isEqualTo(2500L);
+		}
+	}
+
 	static class BeanForConcurrencyTesting {
 		public void a() {
 		}
@@ -350,6 +387,25 @@ public class RabbitListenerAnnotationBeanPostProcessorTests {
 
 		@RabbitListener(queues = "testQueue")
 		public void handleIt(String body) {
+		}
+
+	}
+
+	@Component
+	static class BatchOverridesTestBean {
+
+		@RabbitListener(queues = "testQueue", batch = "true", batchSize = "5", batchReceiveTimeout = "1500")
+		public void handleIt(List<String> body) {
+		}
+
+	}
+
+	@Component
+	static class BatchOverridesExpressionTestBean {
+
+		@RabbitListener(queues = "testQueue", batch = "true", batchSize = "${batch.size}",
+				batchReceiveTimeout = "#{'${batch.receive.timeout}'}")
+		public void handleIt(List<String> body) {
 		}
 
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.mock;
  * @author Joris Kuipers
  * @author Gary Russell
  * @author Sud Ramasamy
+ * @author Martin Ferret
  *
  */
 public class RabbitListenerContainerFactoryTests {
@@ -82,6 +83,55 @@ public class RabbitListenerContainerFactoryTests {
 		assertThat(container.getMessageListener()).isEqualTo(messageListener);
 		assertThat(container.getQueueNames()[0]).isEqualTo("myQueue");
 		assertThat(TestUtils.<BatchingStrategy>getPropertyValue(container, "batchingStrategy")).isSameAs(bs2);
+	}
+
+	@Test
+	public void endpointBatchOverridesWinOverFactory() {
+		setBasicConfig(this.factory);
+		this.factory.setBatchSize(10);
+		this.factory.setBatchReceiveTimeout(1500L);
+
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setMessageListener(this.messageListener);
+		endpoint.setQueueNames("myQueue");
+		endpoint.setBatchSize(5);
+		endpoint.setBatchReceiveTimeout(2500L);
+
+		SimpleMessageListenerContainer container = this.factory.createListenerContainer(endpoint);
+
+		assertThat(TestUtils.<Integer>getPropertyValue(container, "batchSize")).isEqualTo(5);
+		assertThat(TestUtils.<Long>getPropertyValue(container, "batchReceiveTimeout")).isEqualTo(2500L);
+	}
+
+	@Test
+	public void factoryBatchSettingsUsedWhenEndpointDoesNotOverride() {
+		setBasicConfig(this.factory);
+		this.factory.setBatchSize(10);
+		this.factory.setBatchReceiveTimeout(1500L);
+
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setMessageListener(this.messageListener);
+		endpoint.setQueueNames("myQueue");
+
+		SimpleMessageListenerContainer container = this.factory.createListenerContainer(endpoint);
+
+		assertThat(TestUtils.<Integer>getPropertyValue(container, "batchSize")).isEqualTo(10);
+		assertThat(TestUtils.<Long>getPropertyValue(container, "batchReceiveTimeout")).isEqualTo(1500L);
+	}
+
+	@Test
+	public void endpointBatchOverridesIgnoredByDirectContainerFactory() {
+		setBasicConfig(this.direct);
+
+		SimpleRabbitListenerEndpoint endpoint = new SimpleRabbitListenerEndpoint();
+		endpoint.setMessageListener(this.messageListener);
+		endpoint.setQueueNames("myQueue");
+		endpoint.setBatchSize(5);
+		endpoint.setBatchReceiveTimeout(2500L);
+
+		DirectMessageListenerContainer container = this.direct.createListenerContainer(endpoint);
+
+		assertThat(container.getQueueNames()[0]).isEqualTo("myQueue");
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/config/RabbitListenerContainerFactoryTests.java
@@ -120,6 +120,18 @@ public class RabbitListenerContainerFactoryTests {
 	}
 
 	@Test
+	public void factoryBatchSettingsAppliedWithoutEndpoint() {
+		setBasicConfig(this.factory);
+		this.factory.setBatchSize(10);
+		this.factory.setBatchReceiveTimeout(1500L);
+
+		SimpleMessageListenerContainer container = this.factory.createListenerContainer();
+
+		assertThat(TestUtils.<Integer>getPropertyValue(container, "batchSize")).isEqualTo(10);
+		assertThat(TestUtils.<Long>getPropertyValue(container, "batchReceiveTimeout")).isEqualTo(1500L);
+	}
+
+	@Test
 	public void endpointBatchOverridesIgnoredByDirectContainerFactory() {
 		setBasicConfig(this.direct);
 

--- a/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/queue-annotation.properties
+++ b/spring-rabbit/src/test/resources/org/springframework/amqp/rabbit/annotation/queue-annotation.properties
@@ -1,1 +1,3 @@
 myQueueExpression=#{@myTestQueue}
+batch.size=7
+batch.receive.timeout=2500

--- a/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/config/RabbitAmqpListenerContainerFactory.java
+++ b/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/config/RabbitAmqpListenerContainerFactory.java
@@ -42,6 +42,7 @@ import org.springframework.util.ErrorHandler;
  * {@link org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor#DEFAULT_RABBIT_LISTENER_CONTAINER_FACTORY_BEAN_NAME}.
  *
  * @author Artem Bilan
+ * @author Martin Ferret
  *
  * @since 4.0
  *
@@ -155,9 +156,21 @@ public class RabbitAmqpListenerContainerFactory
 
 	@Override
 	public RabbitAmqpListenerContainer createListenerContainer(@Nullable RabbitListenerEndpoint endpoint) {
+		Integer batchSizeToUse = this.batchSize;
+		Long batchReceiveTimeoutToUse = this.batchReceiveTimeout;
+		if (endpoint != null) { // endpoint settings overriding default factory settings
+			Integer endpointBatchSize = endpoint.getBatchSize();
+			if (endpointBatchSize != null) {
+				batchSizeToUse = endpointBatchSize;
+			}
+			Long endpointBatchReceiveTimeout = endpoint.getBatchReceiveTimeout();
+			if (endpointBatchReceiveTimeout != null) {
+				batchReceiveTimeoutToUse = endpointBatchReceiveTimeout;
+			}
+		}
 		if (endpoint instanceof MethodRabbitListenerEndpoint methodRabbitListenerEndpoint) {
 			JavaUtils.INSTANCE
-					.acceptIfCondition(this.batchSize != null && this.batchSize > 1,
+					.acceptIfCondition(batchSizeToUse != null && batchSizeToUse > 1,
 							true,
 							methodRabbitListenerEndpoint::setBatchListener);
 
@@ -173,8 +186,8 @@ public class RabbitAmqpListenerContainerFactory
 				.acceptIfNotNull(getAdviceChain(), container::setAdviceChain)
 				.acceptIfNotNull(getDefaultRequeueRejected(), container::setDefaultRequeue)
 				.acceptIfNotNull(this.afterReceivePostProcessors, container::setAfterReceivePostProcessors)
-				.acceptIfNotNull(this.batchSize, container::setBatchSize)
-				.acceptIfNotNull(this.batchReceiveTimeout, container::setBatchReceiveTimeout)
+				.acceptIfNotNull(batchSizeToUse, container::setBatchSize)
+				.acceptIfNotNull(batchReceiveTimeoutToUse, container::setBatchReceiveTimeout)
 				.acceptIfNotNull(this.taskScheduler, container::setTaskScheduler)
 				.acceptIfNotNull(this.errorHandler, container::setErrorHandler)
 				.acceptIfNotNull(this.applicationEventPublisher, container::setApplicationEventPublisher);

--- a/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/config/RabbitAmqpListenerContainerFactoryTests.java
+++ b/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/config/RabbitAmqpListenerContainerFactoryTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbitmq.client.config;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.rabbit.listener.MethodRabbitListenerEndpoint;
+import org.springframework.amqp.rabbitmq.client.AmqpConnectionFactory;
+import org.springframework.amqp.rabbitmq.client.listener.RabbitAmqpListenerContainer;
+import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Martin Ferret
+ *
+ * @since 4.2
+ */
+public class RabbitAmqpListenerContainerFactoryTests {
+
+	private final AmqpConnectionFactory connectionFactory = mock();
+
+	private final RabbitAmqpListenerContainerFactory factory =
+			new RabbitAmqpListenerContainerFactory(this.connectionFactory);
+
+	@Test
+	void endpointBatchOverridesWinOverFactory() {
+		this.factory.setBatchSize(10);
+		this.factory.setBatchReceiveTimeout(1500L);
+
+		MethodRabbitListenerEndpoint endpoint = createEndpoint();
+		endpoint.setBatchSize(5);
+		endpoint.setBatchReceiveTimeout(2500L);
+
+		RabbitAmqpListenerContainer container = this.factory.createListenerContainer(endpoint);
+
+		assertThat(TestUtils.<Integer>getPropertyValue(container, "batchSize")).isEqualTo(5);
+		assertThat(TestUtils.<Duration>getPropertyValue(container, "batchReceiveDuration"))
+				.isEqualTo(Duration.ofMillis(2500));
+	}
+
+	@Test
+	void factoryBatchSettingsUsedWhenEndpointDoesNotOverride() {
+		this.factory.setBatchSize(10);
+		this.factory.setBatchReceiveTimeout(1500L);
+
+		RabbitAmqpListenerContainer container = this.factory.createListenerContainer(createEndpoint());
+
+		assertThat(TestUtils.<Integer>getPropertyValue(container, "batchSize")).isEqualTo(10);
+		assertThat(TestUtils.<Duration>getPropertyValue(container, "batchReceiveDuration"))
+				.isEqualTo(Duration.ofMillis(1500));
+	}
+
+	@Test
+	void endpointBatchSizeTurnsOnBatchListener() {
+		MethodRabbitListenerEndpoint endpoint = createEndpoint();
+		endpoint.setBatchSize(5);
+
+		RabbitAmqpListenerContainer container = this.factory.createListenerContainer(endpoint);
+
+		assertThat(endpoint.getBatchListener()).isTrue();
+		assertThat(TestUtils.<Integer>getPropertyValue(container, "batchSize")).isEqualTo(5);
+	}
+
+	private static MethodRabbitListenerEndpoint createEndpoint() {
+		DefaultMessageHandlerMethodFactory methodFactory = new DefaultMessageHandlerMethodFactory();
+		methodFactory.setBeanFactory(new StaticListableBeanFactory());
+		methodFactory.afterPropertiesSet();
+
+		MethodRabbitListenerEndpoint endpoint = new MethodRabbitListenerEndpoint();
+		endpoint.setBean(new SampleBean());
+		endpoint.setMethod(ReflectionUtils.findMethod(SampleBean.class, "listen", List.class));
+		endpoint.setMessageHandlerMethodFactory(methodFactory);
+		endpoint.setQueueNames("myQueue");
+		return endpoint;
+	}
+
+	static class SampleBean {
+
+		void listen(List<String> messages) {
+		}
+
+	}
+
+}

--- a/src/reference/antora/modules/ROOT/pages/amqp/receiving-messages/batch.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/receiving-messages/batch.adoc
@@ -88,5 +88,28 @@ When `consumerBatchEnabled` is `true`, the listener **must** be a batch listener
 
 Starting with version 3.0, listener methods can consume `Collection<?>` or `List<?>`.
 
+[[batch-annotation-overrides]]
+== Overriding Batch Properties Per Listener
+
+Starting with version 4.2, the `batchSize` and `batchReceiveTimeout` container factory properties can be overridden for an individual listener, using the `batchSize()` and `batchReceiveTimeout()` attributes of the `@RabbitListener` annotation.
+This allows a single container factory to be shared by listeners that need different batch sizes or gathering timeouts.
+Both attributes support SpEL `+#{...}+` expressions and property place holders `+${...}+`:
+
+[source, java]
+----
+@RabbitListener(queues = "batch.1", containerFactory = "consumerBatchContainerFactory",
+        batchSize = "10", batchReceiveTimeout = "${my.batch.timeout}")
+public void consumerBatch(List<Invoice> invoices) {
+    ...
+}
+----
+
+IMPORTANT: These attributes only *override values*; neither of them enables consumer side batching.
+That remains the `consumerBatchEnabled` container factory property, and `batch = "true"` does not imply it - the annotation attribute only selects a batch listener adapter.
+Without `consumerBatchEnabled`, `batchSize` keeps its other meanings for the `SimpleMessageListenerContainer` - the number of messages processed per transaction and the ack frequency - rather than the size of the list passed to the listener, while `batchReceiveTimeout` bounds the time spent gathering that batch in both modes.
+
+Container factories that have no such properties - for example, the `DirectRabbitListenerContainerFactory` - silently ignore both attributes.
+The `RabbitAmqpListenerContainerFactory` also honors them; there, a `batchSize` greater than 1 is what turns the listener into a batch listener.
+
 NOTE: The listener in batch mode does not support replies since there might not be a correlation between messages in the batch and single reply produced.
 The xref:amqp/receiving-messages/async-returns.adoc[asynchronous return types] are still supported with batch listeners.

--- a/src/reference/antora/modules/ROOT/pages/rabbitmq-amqp-client.adoc
+++ b/src/reference/antora/modules/ROOT/pages/rabbitmq-amqp-client.adoc
@@ -222,6 +222,10 @@ The `RabbitAmqpMessageListener` can handle and settle messages in batches when `
 For this purpose the `MessageListener.onMessageBatch()` contract must be implemented.
 The `batchReceiveDuration` option is used to schedule a force release for not full batches to avoid memory and https://www.rabbitmq.com/blog/2024/09/02/amqp-flow-control[consumer credits] exhausting.
 
+Starting with version 4.2, the `batchSize` and `batchReceiveTimeout` options of the `RabbitAmqpListenerContainerFactory` can be overridden for an individual listener via the respective `@RabbitListener` annotation attributes.
+Since a `batchSize` greater than 1 is what turns the listener into a batch listener, setting only the annotation attribute is enough to consume in batches.
+See xref:amqp/receiving-messages/batch.adoc#batch-annotation-overrides[Overriding Batch Properties Per Listener] for more information.
+
 Usually, the `RabbitAmqpMessageListener` class is not used directly in the target project, and POJO method annotation configuration via `@RabbitListener` is chosen for declarative consumer configuration.
 The `RabbitAmqpListenerContainerFactory` must be registered under the `RabbitListenerAnnotationBeanPostProcessor.DEFAULT_RABBIT_LISTENER_CONTAINER_FACTORY_BEAN_NAME`, and `@RabbitListener` annotation process will register `RabbitAmqpMessageListener` instance into the `RabbitListenerEndpointRegistry`.
 The target POJO method invocation is handled by specific `RabbitAmqpMessageListenerAdapter` implementation, which extends a `MessagingMessageListenerAdapter` and reuses a lot of its functionality, including request-reply scenarios (async or not).

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -14,3 +14,9 @@ See xref:amqp/connections.adoc[] for more information.
 
 For the same reason, the `verifyHostname` property on the Logback and Log4j 2 `AmqpAppender` s is also deprecated now.
 See xref:logging.adoc[] for more information.
+
+[[x42-listener-batch-overrides]]
+=== `@RabbitListener` Batch Overrides
+
+The `@RabbitListener` annotation has new `batchSize()` and `batchReceiveTimeout()` attributes to override the respective container factory properties for a single listener.
+See xref:amqp/receiving-messages/batch.adoc[] for more information.


### PR DESCRIPTION
Fixes #1545

Adds `batchSize()` and `batchReceiveTimeout()` overrides to `@RabbitListener`, resolved onto the endpoint and applied in `SimpleRabbitListenerContainerFactory` and `RabbitAmqpListenerContainerFactory`, with the endpoint value taking precedence over the factory. Both are `String` attributes so SpEL and property placeholders are supported, consistent with `priority()` and `concurrency()`.
`batch()` already existed since 3.0, so only these two were needed.

`AbstractRabbitListenerContainerFactory` is untouched, so `DirectRabbitListenerContainerFactory` silently ignores both attributes as discussed.

These attributes override values only; they do not enable `consumerBatchEnabled`, which stays a container factory property. That is called out explicitly in the reference documentation.

The two getters are `default` methods on `RabbitListenerEndpoint`, since the endpoint is the only channel between the BPP and the factory and `batchListener` already lives there. 

Happy to move them to `AbstractRabbitListenerEndpoint` with an `instanceof` check in the factories instead, if you'd rather leave the shared interface untouched.