### PR TITLE
Fix error-spin in AMQP 1.0 listener container

### DIFF
--- a/spring-amqp-client/src/main/java/org/springframework/amqp/client/config/AmqpMessageListenerContainerFactory.java
+++ b/spring-amqp-client/src/main/java/org/springframework/amqp/client/config/AmqpMessageListenerContainerFactory.java
@@ -27,6 +27,8 @@ import org.springframework.amqp.client.AmqpConnectionFactory;
 import org.springframework.amqp.client.listener.AmqpMessageListenerContainer;
 import org.springframework.amqp.utils.JavaUtils;
 import org.springframework.util.ErrorHandler;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.FixedBackOff;
 
 /**
  * The configuration factory to produce {@link AmqpMessageListenerContainer} instance
@@ -57,6 +59,8 @@ public class AmqpMessageListenerContainerFactory {
 	private @Nullable Duration receiveTimeout;
 
 	private @Nullable Duration gracefulShutdownPeriod;
+
+	private @Nullable BackOff recoveryBackOff;
 
 	private Advice @Nullable [] adviceChain;
 
@@ -141,6 +145,27 @@ public class AmqpMessageListenerContainerFactory {
 	}
 
 	/**
+	 * The default recovery interval for container instances created by this factory.
+	 * @param recoveryInterval the interval between consumer recovery attempts.
+	 * @since 4.1.1
+	 * @see AmqpMessageListenerContainer#setRecoveryInterval(Duration)
+	 */
+	public void setRecoveryInterval(Duration recoveryInterval) {
+		setRecoveryBackOff(new FixedBackOff(recoveryInterval.toMillis(), FixedBackOff.UNLIMITED_ATTEMPTS));
+	}
+
+	/**
+	 * The default {@link BackOff} for a failed consumer recovery
+	 * in container instances created by this factory.
+	 * @param recoveryBackOff the {@link BackOff} to use for the consumer recovery.
+	 * @since 4.1.1
+	 * @see AmqpMessageListenerContainer#setRecoveryBackOff(BackOff)
+	 */
+	public void setRecoveryBackOff(BackOff recoveryBackOff) {
+		this.recoveryBackOff = recoveryBackOff;
+	}
+
+	/**
 	 * Set The default advice chain for container instances created by this factory.
 	 * Can be overridden by {@link AmqpListenerEndpoint#getAdviceChain()}.
 	 * @param advices the advice chain.
@@ -168,6 +193,7 @@ public class AmqpMessageListenerContainerFactory {
 		listenerContainer.setQueueNames(listenerEndpoint.getAddresses());
 		JavaUtils.INSTANCE
 				.acceptIfNotNull(this.errorHandler, listenerContainer::setErrorHandler)
+				.acceptIfNotNull(this.recoveryBackOff, listenerContainer::setRecoveryBackOff)
 				.acceptIfNotNull(listenerEndpoint.getId(), listenerContainer::setBeanName)
 				.acceptOrElseIfNotNull(
 						listenerEndpoint.getConcurrency(), this.concurrency,

--- a/spring-amqp-client/src/main/java/org/springframework/amqp/client/listener/AmqpMessageListenerContainer.java
+++ b/spring-amqp-client/src/main/java/org/springframework/amqp/client/listener/AmqpMessageListenerContainer.java
@@ -60,6 +60,9 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.BackOffExecution;
+import org.springframework.util.backoff.FixedBackOff;
 
 /**
  * The {@link MessageListenerContainer} implementation for AMQP 1.0 protocol.
@@ -79,6 +82,10 @@ import org.springframework.util.StringUtils;
 public class AmqpMessageListenerContainer implements MessageListenerContainer, BeanNameAware {
 
 	private static final LogAccessor LOG = new LogAccessor(AmqpMessageListenerContainer.class);
+
+	private static final Duration DEFAULT_RECOVERY_INTERVAL = Duration.ofSeconds(5);
+
+	private static final long RECOVERY_SLEEP_SLICE = 100;
 
 	private final Lock lock = new ReentrantLock();
 
@@ -107,6 +114,9 @@ public class AmqpMessageListenerContainer implements MessageListenerContainer, B
 	private Duration receiveTimeout = Duration.ofSeconds(1);
 
 	private Duration gracefulShutdownPeriod = Duration.ofSeconds(30);
+
+	private BackOff recoveryBackOff =
+			new FixedBackOff(DEFAULT_RECOVERY_INTERVAL.toMillis(), FixedBackOff.UNLIMITED_ATTEMPTS);
 
 	private Executor taskExecutor = new SimpleAsyncTaskExecutor();
 
@@ -239,6 +249,32 @@ public class AmqpMessageListenerContainer implements MessageListenerContainer, B
 		this.receiveTimeout = receiveTimeout;
 	}
 
+	/**
+	 * Set an interval between recovery attempts of a failed consumer.
+	 * Default 5 seconds.
+	 * @param recoveryInterval the interval between recovery attempts.
+	 * @since 4.1.1
+	 * @see #setRecoveryBackOff(BackOff)
+	 */
+	public void setRecoveryInterval(Duration recoveryInterval) {
+		setRecoveryBackOff(new FixedBackOff(recoveryInterval.toMillis(), FixedBackOff.UNLIMITED_ATTEMPTS));
+	}
+
+	/**
+	 * Specify the {@link BackOff} for a failed consumer recovery.
+	 * The receiver link is not restored by the ProtonJ client itself, even when the connection
+	 * is re-established, so the consumer re-opens its receiver according to this {@link BackOff}.
+	 * The consumer is stopped when the {@link BackOff} returns {@link BackOffExecution#STOP},
+	 * and then the {@link #isRunning()} returns {@code false}
+	 * as soon as no consumers are left in this container.
+	 * The default is {@link FixedBackOff} with a 5-second interval and unlimited attempts.
+	 * @param recoveryBackOff the {@link BackOff} to use for the consumer recovery.
+	 * @since 4.1.1
+	 */
+	public void setRecoveryBackOff(BackOff recoveryBackOff) {
+		this.recoveryBackOff = recoveryBackOff;
+	}
+
 	@Override
 	public void afterPropertiesSet() {
 		Assert.state(this.queues != null, "At least one queue has to be provided for consuming.");
@@ -272,37 +308,57 @@ public class AmqpMessageListenerContainer implements MessageListenerContainer, B
 		this.lock.lock();
 		try {
 			if (this.queueToConsumers.isEmpty()) {
-				ReceiverOptions receiverOptions =
-						new ReceiverOptions()
-								// Since 'AmqpConsumer' implements pause/resume logic,
-								// the auto-replenishment for the credit window is disabled.
-								.creditWindow(0)
-								.autoAccept(this.autoAccept);
-
 				for (String queue : this.queues) {
 					for (int i = 0; i < this.consumersPerQueue; i++) {
-						try {
-							Future<Receiver> openFuture =
-									this.connectionFactory.getConnection()
-											.openReceiver(queue, receiverOptions)
-											.openFuture();
-							ClientReceiver receiver =
-									(ClientReceiver) ProtonUtils.toSupplier(openFuture, receiverOptions.openTimeout())
-											.get()
-											.addCredit(this.initialCredits);
-							AmqpConsumer consumer = new AmqpConsumer(receiver);
-							this.queueToConsumers.add(queue, consumer);
-							this.taskExecutor.execute(consumer);
-						}
-						catch (ClientException ex) {
-							throw ProtonUtils.toAmqpException(ex);
-						}
+						AmqpConsumer consumer = new AmqpConsumer(queue, openReceiver(queue));
+						this.queueToConsumers.add(queue, consumer);
+						this.taskExecutor.execute(consumer);
 					}
 				}
 			}
 		}
 		finally {
 			this.lock.unlock();
+		}
+	}
+
+	/**
+	 * Open a new receiver link for the provided queue with the initial credits granted.
+	 * @param queue the queue to consume from.
+	 * @return a newly opened receiver.
+	 */
+	private ClientReceiver openReceiver(String queue) {
+		ReceiverOptions receiverOptions =
+				new ReceiverOptions()
+						// Since 'AmqpConsumer' implements pause/resume logic,
+						// the auto-replenishment for the credit window is disabled.
+						.creditWindow(0)
+						.autoAccept(this.autoAccept);
+
+		Receiver receiver;
+		try {
+			receiver = this.connectionFactory.getConnection().openReceiver(queue, receiverOptions);
+		}
+		catch (ClientException ex) {
+			throw ProtonUtils.toAmqpException(ex);
+		}
+
+		try {
+			Future<Receiver> openFuture = receiver.openFuture();
+			return (ClientReceiver) ProtonUtils.toSupplier(openFuture, receiverOptions.openTimeout())
+					.get()
+					.addCredit(this.initialCredits);
+		}
+		catch (Exception ex) {
+			// The link has been created locally but has not reached a usable state:
+			// close it, so a failed recovery attempt does not leak a link into the session.
+			try {
+				receiver.close();
+			}
+			catch (Exception closeEx) {
+				LOG.debug(closeEx, () -> "Failed to close a not opened receiver for: " + queue);
+			}
+			throw ProtonUtils.toAmqpException(ex);
 		}
 	}
 
@@ -441,6 +497,29 @@ public class AmqpMessageListenerContainer implements MessageListenerContainer, B
 		}
 	}
 
+	/**
+	 * Remove a consumer which has stopped without a chance to recover,
+	 * so the {@link #isRunning()} does not report this container as running
+	 * when all its consumers are gone.
+	 * @param queue the queue the consumer was consuming from.
+	 * @param consumer the consumer to remove.
+	 */
+	private void removeConsumer(String queue, AmqpConsumer consumer) {
+		this.lock.lock();
+		try {
+			List<AmqpConsumer> consumers = this.queueToConsumers.get(queue);
+			if (consumers != null) {
+				consumers.remove(consumer);
+				if (consumers.isEmpty()) {
+					this.queueToConsumers.remove(queue);
+				}
+			}
+		}
+		finally {
+			this.lock.unlock();
+		}
+	}
+
 	private class AmqpConsumer implements SchedulingAwareRunnable, AutoCloseable {
 
 		@SuppressWarnings("NullAway")
@@ -466,24 +545,42 @@ public class AmqpMessageListenerContainer implements MessageListenerContainer, B
 			ReflectionUtils.makeAccessible(WRITE_FLOW_METHOD);
 		}
 
-		private final ClientReceiver receiver;
+		private final String queue;
 
 		private final Lock receiverLock = new ReentrantLock();
 
-		private final ProtonReceiver protonReceiver;
+		@SuppressWarnings("NullAway.Init")
+		private volatile ClientReceiver receiver;
 
-		private final ProtonLinkCreditState creditState;
+		@SuppressWarnings("NullAway.Init")
+		private volatile ProtonReceiver protonReceiver;
 
-		private final ProtonSessionIncomingWindow sessionWindow;
+		@SuppressWarnings("NullAway.Init")
+		private volatile ProtonLinkCreditState creditState;
+
+		@SuppressWarnings("NullAway.Init")
+		private volatile ProtonSessionIncomingWindow sessionWindow;
+
+		private @Nullable BackOffExecution backOffExecution;
 
 		private volatile boolean paused;
 
 		private volatile boolean running = true;
 
+		AmqpConsumer(String queue, ClientReceiver receiver) {
+			this.queue = queue;
+			assignReceiver(receiver);
+		}
+
+		/**
+		 * Adopt the provided receiver together with its internal ProtonJ state,
+		 * which is used for the {@code pause()}/{@code resume()} and credit top-up logic.
+		 * @param receiverToUse the receiver to consume from.
+		 */
 		@SuppressWarnings("NullAway")
-		AmqpConsumer(ClientReceiver receiver) {
-			this.receiver = receiver;
-			this.protonReceiver = (ProtonReceiver) ReflectionUtils.invokeMethod(PROTON_RECEIVER_METHOD, receiver);
+		private void assignReceiver(ClientReceiver receiverToUse) {
+			this.receiver = receiverToUse;
+			this.protonReceiver = (ProtonReceiver) ReflectionUtils.invokeMethod(PROTON_RECEIVER_METHOD, receiverToUse);
 			this.creditState =
 					(ProtonLinkCreditState) ReflectionUtils.invokeMethod(CREDIT_STATE_METHOD, this.protonReceiver);
 			this.sessionWindow =
@@ -491,7 +588,14 @@ public class AmqpMessageListenerContainer implements MessageListenerContainer, B
 		}
 
 		int queuedDeliveries() {
-			return (int) this.receiver.queuedDeliveries();
+			try {
+				return (int) this.receiver.queuedDeliveries();
+			}
+			catch (Exception ex) {
+				// A closed or broken receiver has nothing pending to wait for on stop.
+				LOG.debug(ex, () -> "Failed to obtain queued deliveries for: " + this.queue);
+				return 0;
+			}
 		}
 
 		@Override
@@ -499,33 +603,141 @@ public class AmqpMessageListenerContainer implements MessageListenerContainer, B
 			this.receiverLock.lock();
 			try {
 				while (this.running) {
+					Delivery delivery;
 					try {
-						Delivery delivery =
-								this.receiver.receive(AmqpMessageListenerContainer.this.receiveTimeout.toMillis(),
-										TimeUnit.MILLISECONDS);
-						if (delivery != null) {
-							doInvokeListener(delivery, this::replenishCredit);
-						}
+						delivery = this.receiver.receive(AmqpMessageListenerContainer.this.receiveTimeout.toMillis(),
+								TimeUnit.MILLISECONDS);
+						// A completed receive (even with no delivery) means the link is healthy again.
+						this.backOffExecution = null;
 					}
 					catch (Exception ex) {
-						if (this.running) {
-							AmqpException amqpException = ProtonUtils.toAmqpException(ex);
-							ErrorHandler errorHandlerToUse = AmqpMessageListenerContainer.this.errorHandler;
-							if (errorHandlerToUse != null) {
-								errorHandlerToUse.handleError(amqpException);
+						if (!this.running) {
+							LOG.debug(ex, "Consumer stopped");
+							break;
+						}
+						AmqpException amqpException = ProtonUtils.toAmqpException(ex);
+						if (!handleError(amqpException)) {
+							LOG.error(amqpException, () -> "Failed to receive from: " + this.queue);
+						}
+						// The receiver link is broken and is not restored by the ProtonJ client:
+						// re-open it with a back off instead of spinning on the same failure.
+						if (!recoverReceiver()) {
+							break;
+						}
+						continue;
+					}
+
+					if (delivery != null) {
+						try {
+							doInvokeListener(delivery, this::replenishCredit);
+						}
+						catch (Exception ex) {
+							if (this.running) {
+								AmqpException amqpException = ProtonUtils.toAmqpException(ex);
+								if (!handleError(amqpException)) {
+									throw amqpException;
+								}
 							}
 							else {
-								throw amqpException;
+								LOG.debug(ex, "Consumer stopped");
 							}
-						}
-						else {
-							LOG.debug(ex, "Consumer stopped");
 						}
 					}
 				}
 			}
 			finally {
 				this.receiverLock.unlock();
+				if (this.running) {
+					// This consumer has given up: deregister it so the container does not
+					// report itself as running while nothing is consuming anymore.
+					this.running = false;
+					closeReceiver();
+					removeConsumer(this.queue, this);
+				}
+			}
+		}
+
+		/**
+		 * Invoke the container {@link ErrorHandler}, if any.
+		 * @param ex the exception to handle.
+		 * @return true if the exception has been handled by an {@link ErrorHandler}.
+		 */
+		private boolean handleError(AmqpException ex) {
+			ErrorHandler errorHandlerToUse = AmqpMessageListenerContainer.this.errorHandler;
+			if (errorHandlerToUse != null) {
+				errorHandlerToUse.handleError(ex);
+				return true;
+			}
+			return false;
+		}
+
+		/**
+		 * Close the broken receiver and open a new one for the same queue,
+		 * according to the {@code recoveryBackOff}.
+		 * @return true if a new receiver has been opened; false if this consumer has to stop.
+		 */
+		private boolean recoverReceiver() {
+			closeReceiver();
+
+			BackOffExecution backOffExecutionToUse = this.backOffExecution;
+			if (backOffExecutionToUse == null) {
+				backOffExecutionToUse = AmqpMessageListenerContainer.this.recoveryBackOff.start();
+				this.backOffExecution = backOffExecutionToUse;
+			}
+
+			while (this.running) {
+				long interval = backOffExecutionToUse.nextBackOff();
+				if (interval == BackOffExecution.STOP) {
+					LOG.error(() -> "Cannot recover a consumer for: " + this.queue + ". Stopping it.");
+					return false;
+				}
+				if (!sleep(interval)) {
+					return false;
+				}
+				try {
+					assignReceiver(openReceiver(this.queue));
+					if (this.paused) {
+						doPause();
+					}
+					this.backOffExecution = null;
+					LOG.info(() -> "Recovered a consumer for: " + this.queue);
+					return true;
+				}
+				catch (Exception ex) {
+					LOG.debug(ex, () -> "Failed to recover a consumer for: " + this.queue);
+				}
+			}
+			return false;
+		}
+
+		/**
+		 * Sleep for the provided interval in short slices to remain responsive to a container stop.
+		 * @param interval how long to sleep, in milliseconds.
+		 * @return true if the whole interval has elapsed and this consumer is still running.
+		 */
+		private boolean sleep(long interval) {
+			long deadline = System.currentTimeMillis() + interval;
+			try {
+				while (this.running) {
+					long remaining = deadline - System.currentTimeMillis();
+					if (remaining <= 0) {
+						return true;
+					}
+					Thread.sleep(Math.min(remaining, RECOVERY_SLEEP_SLICE));
+				}
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+			}
+			return false;
+		}
+
+		private void closeReceiver() {
+			try {
+				this.receiver.close();
+			}
+			catch (Exception ex) {
+				LOG.debug(ex, () -> "Failed to close a receiver for: " + this.queue);
 			}
 		}
 
@@ -561,9 +773,13 @@ public class AmqpMessageListenerContainer implements MessageListenerContainer, B
 		void pause() {
 			if (this.running && !this.paused) {
 				this.paused = true;
-				this.creditState.updateCredit(0);
-				ReflectionUtils.invokeMethod(WRITE_FLOW_METHOD, this.sessionWindow, this.protonReceiver);
+				doPause();
 			}
+		}
+
+		private void doPause() {
+			this.creditState.updateCredit(0);
+			ReflectionUtils.invokeMethod(WRITE_FLOW_METHOD, this.sessionWindow, this.protonReceiver);
 		}
 
 		void resume() {
@@ -588,7 +804,7 @@ public class AmqpMessageListenerContainer implements MessageListenerContainer, B
 			this.running = false;
 			this.receiverLock.lock();
 			try {
-				this.receiver.close();
+				closeReceiver();
 			}
 			finally {
 				this.receiverLock.unlock();

--- a/spring-amqp-client/src/test/java/org/springframework/amqp/client/EnableAmqpTests.java
+++ b/spring-amqp-client/src/test/java/org/springframework/amqp/client/EnableAmqpTests.java
@@ -26,8 +26,6 @@ import java.util.concurrent.TimeUnit;
 import org.aopalliance.aop.Advice;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.qpid.protonj2.client.Client;
 import org.apache.qpid.protonj2.client.ConnectionOptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,6 +59,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * @author Artem Bilan
@@ -70,8 +69,6 @@ import static org.mockito.Mockito.mockingDetails;
 @SpringJUnitConfig(EnableAmqpTests.TestConfig.class)
 @DirtiesContext
 class EnableAmqpTests extends AbstractTestContainerTests {
-
-	static final Log LOG = LogFactory.getLog(EnableAmqpTests.class);
 
 	static final String TEST_QUEUE1 = "/queues/enable_amqp_queue1";
 
@@ -87,7 +84,6 @@ class EnableAmqpTests extends AbstractTestContainerTests {
 		for (String queue : QUEUE_NAMES) {
 			RABBITMQ.execInContainer("rabbitmqadmin", "queues", "declare", "--name", queue.replaceFirst("/queues/", ""));
 		}
-		RABBITMQ.execInContainer("rabbitmqctl", "set_log_level", "debug");
 	}
 
 	@Autowired
@@ -131,32 +127,26 @@ class EnableAmqpTests extends AbstractTestContainerTests {
 				.satisfies(errorHandler ->
 						assertThat(mockingDetails(errorHandler).isMock()).isTrue());
 
-		try {
-			listenerContainer.start();
+		listenerContainer.start();
 
-			this.amqpClient.to(TEST_QUEUE1)
-					.body("test_data")
-					.send();
+		this.amqpClient.to(TEST_QUEUE1)
+				.body("test_data")
+				.send();
 
-			Message message = receivedMessages.poll(10, TimeUnit.SECONDS);
-			assertThat(message)
-					.extracting(Message::getBody)
-					.isEqualTo("test_data".getBytes());
+		Message message = receivedMessages.poll(10, TimeUnit.SECONDS);
+		assertThat(message)
+				.extracting(Message::getBody)
+				.isEqualTo("test_data".getBytes());
 
-			CountDownLatch stopLatch = new CountDownLatch(1);
+		CountDownLatch stopLatch = new CountDownLatch(1);
 
-			listenerContainer.stop(stopLatch::countDown);
+		listenerContainer.stop(stopLatch::countDown);
 
-			assertThat(stopLatch.await(40, TimeUnit.SECONDS)).isTrue();
-		}
-		catch (Exception e) {
-			LOG.error("LOGS FROM RABBITMQ CONTAINER: " + RABBITMQ.getLogs());
-			throw e;
-		}
+		assertThat(stopLatch.await(40, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
-	void simpleEndpointOverridesContainerFactoryOptions() throws Throwable {
+	void simpleEndpointOverridesContainerFactoryOptions() throws InterruptedException {
 		BlockingQueue<Message> receivedMessages = new LinkedBlockingQueue<>();
 		MessageListener messageListener = receivedMessages::add;
 		String containerId = "test-endpoint";
@@ -173,46 +163,40 @@ class EnableAmqpTests extends AbstractTestContainerTests {
 		simpleAmqpListenerEndpoint.setReceiveTimeout(Duration.ofSeconds(7));
 		simpleAmqpListenerEndpoint.setGracefulShutdownPeriod(Duration.ofSeconds(17));
 
-		try {
-			this.registry.registerListenerEndpoints(new AmqpListenerEndpointRegistration(simpleAmqpListenerEndpoint));
+		this.registry.registerListenerEndpoints(new AmqpListenerEndpointRegistration(simpleAmqpListenerEndpoint));
 
-			var listenerContainer = this.beanFactory.getBean(containerId, AmqpMessageListenerContainer.class);
+		var listenerContainer = this.beanFactory.getBean(containerId, AmqpMessageListenerContainer.class);
 
-			assertThat(listenerContainer.isAutoStartup()).isTrue();
-			assertThat(listenerContainer.getListenerId()).isEqualTo(containerId);
-			assertThat(TestUtils.<Boolean>getPropertyValue(listenerContainer, "autoAccept")).isTrue();
-			assertThat(TestUtils.<Integer>getPropertyValue(listenerContainer, "consumersPerQueue")).isEqualTo(5);
-			assertThat(TestUtils.<Integer>getPropertyValue(listenerContainer, "initialCredits")).isEqualTo(11);
-			assertThat(TestUtils.<String[]>getPropertyValue(listenerContainer, "queues")).containsExactly(TEST_QUEUE2);
-			assertThat(TestUtils.<Advice[]>getPropertyValue(listenerContainer, "adviceChain")[0]).isSameAs(mockInterceptor);
-			assertThatObject(TestUtils.getPropertyValue(listenerContainer, "taskExecutor")).isSameAs(testTaskExecutor);
-			assertThat(TestUtils.<Duration>getPropertyValue(listenerContainer, "receiveTimeout"))
-					.isEqualTo(Duration.ofSeconds(7));
-			assertThat(TestUtils.<Duration>getPropertyValue(listenerContainer, "gracefulShutdownPeriod"))
-					.isEqualTo(Duration.ofSeconds(17));
-			assertThat(TestUtils.<ErrorHandler>getPropertyValue(listenerContainer, "errorHandler"))
-					.satisfies(errorHandler ->
-							assertThat(mockingDetails(errorHandler).isMock()).isTrue());
+		assertThat(listenerContainer.isAutoStartup()).isTrue();
+		assertThat(listenerContainer.getListenerId()).isEqualTo(containerId);
+		assertThat(TestUtils.<Boolean>getPropertyValue(listenerContainer, "autoAccept")).isTrue();
+		assertThat(TestUtils.<Integer>getPropertyValue(listenerContainer, "consumersPerQueue")).isEqualTo(5);
+		assertThat(TestUtils.<Integer>getPropertyValue(listenerContainer, "initialCredits")).isEqualTo(11);
+		assertThat(TestUtils.<String[]>getPropertyValue(listenerContainer, "queues")).containsExactly(TEST_QUEUE2);
+		assertThat(TestUtils.<Advice[]>getPropertyValue(listenerContainer, "adviceChain")[0]).isSameAs(mockInterceptor);
+		assertThatObject(TestUtils.getPropertyValue(listenerContainer, "taskExecutor")).isSameAs(testTaskExecutor);
+		assertThat(TestUtils.<Duration>getPropertyValue(listenerContainer, "receiveTimeout"))
+				.isEqualTo(Duration.ofSeconds(7));
+		assertThat(TestUtils.<Duration>getPropertyValue(listenerContainer, "gracefulShutdownPeriod"))
+				.isEqualTo(Duration.ofSeconds(17));
+		assertThat(TestUtils.<ErrorHandler>getPropertyValue(listenerContainer, "errorHandler"))
+				.satisfies(errorHandler ->
+						assertThat(mockingDetails(errorHandler).isMock()).isTrue());
 
-			this.amqpClient.to(TEST_QUEUE2)
-					.body("test_data2")
-					.send();
+		this.amqpClient.to(TEST_QUEUE2)
+				.body("test_data2")
+				.send();
 
-			Message message = receivedMessages.poll(10, TimeUnit.SECONDS);
-			assertThat(message)
-					.extracting(Message::getBody)
-					.isEqualTo("test_data2".getBytes());
+		Message message = receivedMessages.poll(10, TimeUnit.SECONDS);
+		assertThat(message)
+				.extracting(Message::getBody)
+				.isEqualTo("test_data2".getBytes());
 
-			CountDownLatch stopLatch = new CountDownLatch(1);
+		CountDownLatch stopLatch = new CountDownLatch(1);
 
-			listenerContainer.stop(stopLatch::countDown);
+		listenerContainer.stop(stopLatch::countDown);
 
-			assertThat(stopLatch.await(40, TimeUnit.SECONDS)).isTrue();
-		}
-		catch (Exception e) {
-			LOG.error("LOGS FROM RABBITMQ CONTAINER: " + RABBITMQ.getLogs());
-			throw e;
-		}
+		assertThat(stopLatch.await(40, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -237,7 +221,7 @@ class EnableAmqpTests extends AbstractTestContainerTests {
 		AmqpConnectionFactory amqpConnectionFactory() {
 			return new SingleAmqpConnectionFactory(Client.create())
 					.setPort(amqpPort())
-					.setConnectionOptions(new ConnectionOptions().traceFrames(true).reconnectEnabled(true));
+					.setConnectionOptions(new ConnectionOptions().reconnectEnabled(true));
 		}
 
 		@Bean
@@ -263,7 +247,9 @@ class EnableAmqpTests extends AbstractTestContainerTests {
 			containerFactory.setInitialCredits(55);
 			containerFactory.setTaskExecutor(taskExecutor);
 			containerFactory.setAdviceChain(new DebugInterceptor());
-			containerFactory.setErrorHandler(mock());
+			// A 'stubOnly' mock does not record invocations: the container error handler
+			// can be called a lot, and retaining every exception would exhaust the test heap.
+			containerFactory.setErrorHandler(mock(ErrorHandler.class, withSettings().stubOnly()));
 			return containerFactory;
 		}
 

--- a/spring-amqp-client/src/test/java/org/springframework/amqp/client/listener/AmqpListenerAnnotationTests.java
+++ b/spring-amqp-client/src/test/java/org/springframework/amqp/client/listener/AmqpListenerAnnotationTests.java
@@ -26,14 +26,11 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.aopalliance.aop.Advice;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.qpid.protonj2.client.ConnectionOptions;
 import org.apache.qpid.protonj2.client.Delivery;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.RetryingTest;
 import reactor.core.publisher.Mono;
 
 import org.springframework.amqp.client.AmqpClient;
@@ -84,8 +81,6 @@ import static org.mockito.Mockito.mockingDetails;
 @DirtiesContext
 class AmqpListenerAnnotationTests extends AbstractTestContainerTests {
 
-	static final Log LOG = LogFactory.getLog(AmqpListenerAnnotationTests.class);
-
 	static final String TEST_QUEUE1 = "/queues/listener_annotation1";
 
 	static final String TEST_QUEUE2 = "/queues/listener_annotation2";
@@ -106,7 +101,6 @@ class AmqpListenerAnnotationTests extends AbstractTestContainerTests {
 		for (String queue : QUEUE_NAMES) {
 			RABBITMQ.execInContainer("rabbitmqadmin", "queues", "declare", "--name", queue.replaceFirst("/queues/", ""));
 		}
-		RABBITMQ.execInContainer("rabbitmqctl", "set_log_level", "debug");
 	}
 
 	@Autowired
@@ -175,7 +169,7 @@ class AmqpListenerAnnotationTests extends AbstractTestContainerTests {
 	@Autowired
 	MessageConverter jsonMessageConverter;
 
-	@RetryingTest(10)
+	@Test
 	void requestReplyAndContainerFactoryOverrides() {
 		var listenerContainer = this.beanFactory.getBean("monoListener", AmqpMessageListenerContainer.class);
 
@@ -209,24 +203,18 @@ class AmqpListenerAnnotationTests extends AbstractTestContainerTests {
 
 		DataIn dataIn = new DataIn("test_data");
 
-		try {
-			this.amqpClient.to(TEST_QUEUE2)
-					.body(dataIn)
-					.replyTo(TEST_REPLY_TO)
-					.send();
+		this.amqpClient.to(TEST_QUEUE2)
+				.body(dataIn)
+				.replyTo(TEST_REPLY_TO)
+				.send();
 
-			CompletableFuture<DataOut> dataOut =
-					this.amqpClient.from(TEST_REPLY_TO)
-							.receiveAndConvert();
+		CompletableFuture<DataOut> dataOut =
+				this.amqpClient.from(TEST_REPLY_TO)
+						.receiveAndConvert();
 
-			assertThat(dataOut)
-					.succeedsWithin(Duration.ofSeconds(30))
-					.isEqualTo(new DataOut(dataIn.data + "_out"));
-		}
-		catch (Exception e) {
-			LOG.error("LOGS FROM RABBITMQ CONTAINER: " + RABBITMQ.getLogs());
-			throw e;
-		}
+		assertThat(dataOut)
+				.succeedsWithin(Duration.ofSeconds(30))
+				.isEqualTo(new DataOut(dataIn.data + "_out"));
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -242,7 +230,7 @@ class AmqpListenerAnnotationTests extends AbstractTestContainerTests {
 		AmqpConnectionFactory amqpConnectionFactory() {
 			return new SingleAmqpConnectionFactory()
 					.setPort(amqpPort())
-					.setConnectionOptions(new ConnectionOptions().traceFrames(true).reconnectEnabled(true));
+					.setConnectionOptions(new ConnectionOptions().reconnectEnabled(true));
 		}
 
 		@Bean

--- a/spring-amqp-client/src/test/java/org/springframework/amqp/client/listener/AmqpMessageListenerContainerRecoveryTests.java
+++ b/spring-amqp-client/src/test/java/org/springframework/amqp/client/listener/AmqpMessageListenerContainerRecoveryTests.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.client.listener;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.qpid.protonj2.client.ReconnectOptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.client.AmqpClient;
+import org.springframework.amqp.client.AmqpConnectionFactory;
+import org.springframework.amqp.client.SingleAmqpConnectionFactory;
+import org.springframework.amqp.client.config.EnableAmqp;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.junit.AbstractTestContainerTests;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.backoff.FixedBackOff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Tests for a broken receiver link recovery in the {@link AmqpMessageListenerContainer}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.1.1
+ */
+@SpringJUnitConfig
+@DirtiesContext
+class AmqpMessageListenerContainerRecoveryTests extends AbstractTestContainerTests {
+
+	static final String RECOVERABLE_QUEUE = "recoverable_consumer_queue";
+
+	static final String UNRECOVERABLE_QUEUE = "unrecoverable_consumer_queue";
+
+	@BeforeAll
+	static void initQueues() throws IOException, InterruptedException {
+		declareQueue(RECOVERABLE_QUEUE);
+		declareQueue(UNRECOVERABLE_QUEUE);
+	}
+
+	static void declareQueue(String queue) throws IOException, InterruptedException {
+		RABBITMQ.execInContainer("rabbitmqadmin", "queues", "declare", "--name", queue);
+	}
+
+	static void deleteQueue(String queue) throws IOException, InterruptedException {
+		RABBITMQ.execInContainer("rabbitmqadmin", "queues", "delete", "--name", queue);
+	}
+
+	@Autowired
+	TestConfig testConfig;
+
+	@Autowired
+	AmqpClient amqpClient;
+
+	@Autowired
+	@Qualifier("recoverableContainer")
+	AmqpMessageListenerContainer recoverableContainer;
+
+	@Autowired
+	@Qualifier("unrecoverableContainer")
+	AmqpMessageListenerContainer unrecoverableContainer;
+
+	@Test
+	void consumerRecoversItsReceiverWhenTheLinkIsDetached() throws IOException, InterruptedException {
+		assertThat(this.recoverableContainer.isRunning()).isTrue();
+
+		// Deleting the queue detaches the receiver link, and the ProtonJ client does not restore it.
+		deleteQueue(RECOVERABLE_QUEUE);
+
+		// The failing 'receive()' must be reported, but only a handful of times,
+		// not millions of times per second like a tight retry loop would.
+		await().atMost(Duration.ofSeconds(30)).until(() -> !this.testConfig.recoverableErrors.isEmpty());
+
+		declareQueue(RECOVERABLE_QUEUE);
+
+		// The consumer re-opens its receiver, so the messages are delivered again.
+		await().atMost(Duration.ofSeconds(60))
+				.untilAsserted(() -> {
+					this.amqpClient.to("/queues/" + RECOVERABLE_QUEUE).body("after_recovery").send();
+					Message message = this.testConfig.receivedMessages.poll(2, TimeUnit.SECONDS);
+					assertThat(message)
+							.isNotNull()
+							.extracting(Message::getBody)
+							.isEqualTo("after_recovery".getBytes());
+				});
+
+		assertThat(this.recoverableContainer.isRunning()).isTrue();
+		assertThat(this.testConfig.recoverableErrors).hasSizeLessThan(100);
+	}
+
+	@Test
+	void containerIsNotRunningWhenConsumerGivesUpRecovery() throws IOException, InterruptedException {
+		assertThat(this.unrecoverableContainer.isRunning()).isTrue();
+
+		// The queue is gone for good, so re-opening the receiver keeps failing
+		// until the 'recoveryBackOff' returns 'BackOffExecution.STOP'.
+		deleteQueue(UNRECOVERABLE_QUEUE);
+
+		// The only consumer removes itself, so the container must stop reporting itself as running.
+		await().atMost(Duration.ofSeconds(30)).until(() -> !this.unrecoverableContainer.isRunning());
+
+		assertThat(this.testConfig.unrecoverableErrors).hasSizeLessThan(100);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableAmqp
+	static class TestConfig {
+
+		final BlockingQueue<Message> receivedMessages = new LinkedBlockingQueue<>();
+
+		final Queue<Throwable> recoverableErrors = new ConcurrentLinkedQueue<>();
+
+		final Queue<Throwable> unrecoverableErrors = new ConcurrentLinkedQueue<>();
+
+		@Bean
+		AmqpConnectionFactory amqpConnectionFactory() {
+			return new SingleAmqpConnectionFactory()
+					.setPort(amqpPort())
+					.setReconnectOptions(new ReconnectOptions().reconnectEnabled(true));
+		}
+
+		@Bean
+		AmqpClient amqpClient(AmqpConnectionFactory connectionFactory) {
+			return AmqpClient.create(connectionFactory);
+		}
+
+		@Bean
+		AmqpMessageListenerContainer recoverableContainer(AmqpConnectionFactory connectionFactory) {
+			var listenerContainer = new AmqpMessageListenerContainer(connectionFactory);
+			listenerContainer.setQueueNames("/queues/" + RECOVERABLE_QUEUE);
+			listenerContainer.setReceiveTimeout(Duration.ofMillis(100));
+			listenerContainer.setRecoveryInterval(Duration.ofMillis(200));
+			listenerContainer.setErrorHandler(this.recoverableErrors::add);
+			listenerContainer.setupMessageListener(this.receivedMessages::add);
+			return listenerContainer;
+		}
+
+		@Bean
+		AmqpMessageListenerContainer unrecoverableContainer(AmqpConnectionFactory connectionFactory) {
+			var listenerContainer = new AmqpMessageListenerContainer(connectionFactory);
+			listenerContainer.setQueueNames("/queues/" + UNRECOVERABLE_QUEUE);
+			listenerContainer.setReceiveTimeout(Duration.ofMillis(100));
+			listenerContainer.setRecoveryBackOff(new FixedBackOff(200, 2));
+			listenerContainer.setErrorHandler(this.unrecoverableErrors::add);
+			listenerContainer.setupMessageListener(this.receivedMessages::add);
+			return listenerContainer;
+		}
+
+	}
+
+}

--- a/spring-amqp-client/src/test/resources/log4j2-test.xml
+++ b/spring-amqp-client/src/test/resources/log4j2-test.xml
@@ -7,7 +7,7 @@
 	</Appenders>
 	<Loggers>
 		<Logger name="org.springframework.amqp.client" level="debug"/>
-		<Logger name="org.apache.qpid.protonj2.client" level="trace"/>
+		<Logger name="org.apache.qpid.protonj2.client" level="warn"/>
 		<Root level="warn">
 			<AppenderRef ref="STDOUT" />
 		</Root>

--- a/src/reference/antora/modules/ROOT/pages/amqp10-client.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp10-client.adoc
@@ -170,6 +170,11 @@ The `AmqpMessageListenerContainer.taskExecutor` property is set to a `SimpleAsyn
 
 The message processing errors can be handled by the `ErrorHandler` configuration.
 
+When a `Receiver.receive()` operation fails, the receiver link is broken and the ProtonJ client does not restore it, even if the connection itself is re-established.
+The consumer reports such a failure to the `ErrorHandler` (or logs it as an error when no `ErrorHandler` is provided) and then re-opens its receiver link according to the `recoveryBackOff` option, which is a `FixedBackOff` with a `5 seconds` interval and unlimited attempts by default.
+The `setRecoveryInterval(Duration)` is a convenient option to change only the interval between recovery attempts.
+If the configured `BackOff` runs out of attempts, the consumer is stopped and removed from the container, so the `AmqpMessageListenerContainer.isRunning()` returns `false` when no consumers are left.
+
 The `MessageListener` can be proxied in the `AmqpMessageListenerContainer` if some AOP interceptors are provided, e.g. `TransactionInterceptor`.
 
 The `AmqpMessageListenerContainer` also provides `pause()` and `resume()` API to set AMQP link credits to `0` and replenish, respectively.


### PR DESCRIPTION
`AmqpMessageListenerContainer.AmqpConsumer.run()` caught every exception from `Receiver.receive()`, handed it to the container `ErrorHandler` and retried immediately, with no backoff and no attempt to re-open the receiver link.
ProtonJ's `reconnectEnabled(true)` restores the *connection* but not the user-facing `Receiver`, so a broken link never healed.

Measured against a real broker:

| trigger | measured behaviour before this change |
|---|---|
| queue deleted (link detached) | ~2.2M loop iterations/sec, forever, `isRunning() == true` |
| `rabbitmqctl close_all_connections` | ~1.8M iterations/sec, forever; messages published afterwards are never delivered, while `isRunning()` still returns `true` |

So a single broker blip cost one burned CPU core plus a silently dead consumer that reported itself healthy.

## Container

* A `receive()` failure is now distinguished from a listener failure - only the former means the receiver link is broken, so a poison message no longer triggers link recovery and legit throughput is unaffected.
* The receiver link is re-opened according to a new `recoveryBackOff` option, a `FixedBackOff` with a `5 seconds` interval and unlimited attempts by default. `setRecoveryInterval(Duration)` is exposed for the interval alone, consistent with the other time-based options of this container.
* When the `BackOff` returns `BackOffExecution.STOP`, the consumer stops and removes itself from the container, so `isRunning()` reports `false` once no consumers are left instead of lying.
* Recovery sleeps in 100 ms slices, so a container `stop()` stays responsive rather than blocking for a whole recovery interval.
* `queuedDeliveries()` and `close()` tolerate an already dead link, so a container stop is not derailed by it.
* A recovery attempt which creates the link locally but then fails to open it closes that link before backing off. Otherwise, with the default unlimited attempts against a queue that stays absent, every attempt would leave another half-open link behind in the ProtonJ session.
* `recoveryBackOff` / `recoveryInterval` are also exposed on `AmqpMessageListenerContainerFactory`.

Two behaviour changes worth calling out:

1. A failing `receive()` with **no** `ErrorHandler` configured is now logged at `ERROR` and recovered, instead of throwing out of `run()` and killing the consumer thread.
2. Listener exceptions keep their dispatch semantics - `ErrorHandler` if present, rethrow otherwise - but the rethrow now unwinds into the new consumer cleanup in the `finally` block, so the consumer deregisters itself from the container. Previously such a listener exception left a dead consumer thread behind a container whose `isRunning()` still returned `true`; now `isRunning()` reports `false` once no consumers are left. The dispatch itself is unchanged, but this consequence is new.

## Tests

The same spin was turning `:spring-amqp-client:test` into an intermittent `OutOfMemoryError` (~50% of commercial CI runs) rather than a test failure. `EnableAmqpTests` wired a plain Mockito mock as the container `ErrorHandler`; a non-`stubOnly` mock retains every invocation together with its `AmqpException` argument and stack trace (~1KB each), so with the spin feeding it the heap grew ~70MB/s and the 2GB test worker was gone in under 30 seconds:

```
t= 5s errorHandler invocations=299352  usedHeapMB=417
t=10s errorHandler invocations=648927  usedHeapMB=739
t=15s errorHandler invocations=994561  usedHeapMB=1189
t=20s errorHandler invocations=1337893 usedHeapMB=1507
t=25s errorHandler invocations=1669201 usedHeapMB=1792
java.lang.OutOfMemoryError: Java heap space
```

A control run with a plain lambda `ErrorHandler` kept the heap flat at 36-186MB at the same spin rate, which is what identified the mock as the amplifier.

* The container `ErrorHandler` mock is created with `withSettings().stubOnly()` - such mocks do not record invocations. The existing `mockingDetails(errorHandler).isMock()` assertions still hold.
* Dropped the `rabbitmqctl set_log_level debug` calls, which reconfigured the *shared static* broker for the whole test JVM.
* Dropped the failure-path `LOG.error("LOGS FROM RABBITMQ CONTAINER: " + RABBITMQ.getLogs())` dumps, which materialised the entire container log into a `String` exactly when the heap was already exhausted - and one of them sat inside `@RetryingTest(10)`.
* Lowered the `org.apache.qpid.protonj2.client` logger from `trace` to `warn` and removed `ConnectionOptions.traceFrames(true)`.

New `AmqpMessageListenerContainerRecoveryTests` covers both paths against a real broker: a consumer that recovers its receiver after the queue is deleted and re-declared, and a consumer that gives up under a bounded `FixedBackOff` so that `isRunning()` flips to `false`. Both assert the error handler was invoked fewer than 100 times, which is the regression guard against the spin.

## Verification

`./gradlew :spring-amqp-client:check` is green locally, including `checkstyle`, `javadoc` and the Testcontainers-based tests.

One caveat for the reviewer: during these runs `AmqpListenerAnnotationTests.requestReplyAndContainerFactoryOverrides` failed once, on all 10 retries, with `ClientSessionRemotelyClosedException: function_clause` - a broker-side Erlang crash. I could not reproduce it in three subsequent full runs, and the pre-existing tests pass with this change applied while the new test class is excluded, so it looks like unrelated broker flakiness rather than a regression. Flagging it in case it is already known.

**Auto-cherry-pick to `4.1.x`**

