### PR TITLE
GH-3507: Reject deliveries individually

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -66,6 +66,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactoryUtils;
 import org.springframework.amqp.rabbit.connection.RabbitResourceHolder;
 import org.springframework.amqp.rabbit.connection.RabbitUtils;
 import org.springframework.amqp.rabbit.connection.RoutingConnectionFactory;
+import org.springframework.amqp.rabbit.listener.adapter.AbstractAdaptableMessageListener;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareBatchMessageListener;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter;
@@ -463,6 +464,28 @@ public abstract class AbstractMessageListenerContainer extends ObservableListene
 	@Override
 	public @Nullable MessageListener getMessageListener() {
 		return this.messageListener;
+	}
+
+	/**
+	 * Return true when the listener may settle a delivery itself, which happens only if it
+	 * is given the consumer {@link Channel}. The container cannot then reject a failed
+	 * delivery individually: re-settling an already settled delivery is a protocol
+	 * violation which closes the whole channel.
+	 * @return true if the listener may settle a delivery itself.
+	 * @since 4.2
+	 * @see AbstractAdaptableMessageListener#maySettleDelivery()
+	 */
+	boolean listenerMaySettleDelivery() {
+		MessageListener listener = getMessageListener();
+		if (!(listener instanceof ChannelAwareMessageListener) || !isExposeListenerChannel()) {
+			// A plain MessageListener is not given any channel; a not exposed one is not the consumer channel.
+			return false;
+		}
+		if (listener instanceof AbstractAdaptableMessageListener adaptableListener) {
+			return adaptableListener.maySettleDelivery();
+		}
+		// An arbitrary ChannelAwareMessageListener does whatever it wants with the channel.
+		return true;
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/AbstractMessageListenerContainer.java
@@ -472,7 +472,7 @@ public abstract class AbstractMessageListenerContainer extends ObservableListene
 	 * delivery individually: re-settling an already settled delivery is a protocol
 	 * violation which closes the whole channel.
 	 * @return true if the listener may settle a delivery itself.
-	 * @since 4.2
+	 * @since 4.0.6
 	 * @see AbstractAdaptableMessageListener#maySettleDelivery()
 	 */
 	boolean listenerMaySettleDelivery() {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 import com.rabbitmq.client.AMQP;
@@ -116,6 +117,8 @@ public class BlockingQueueConsumer {
 
 	@SuppressWarnings("NullAway.Init")
 	private RabbitResourceHolder resourceHolder;
+
+	private BooleanSupplier listenerMaySettleDelivery = () -> false;
 
 	private final ConcurrentMap<String, InternalConsumer> consumers = new ConcurrentHashMap<>();
 
@@ -318,6 +321,20 @@ public class BlockingQueueConsumer {
 
 	public Channel getChannel() {
 		return this.channel;
+	}
+
+	/**
+	 * Set a supplier which returns false when the listener cannot settle a delivery
+	 * itself, so this consumer is the only party which settles what it has outstanding.
+	 * It is consulted when a delivery has to be rejected.
+	 * @param listenerMaySettleDelivery the supplier; a consumer without a listener - not
+	 * driven by a container - returns false by default.
+	 * @since 4.2
+	 * @see AbstractMessageListenerContainer#listenerMaySettleDelivery()
+	 * @see #rollbackOnExceptionIfNecessary(Throwable, long)
+	 */
+	void setListenerMaySettleDelivery(BooleanSupplier listenerMaySettleDelivery) {
+		this.listenerMaySettleDelivery = listenerMaySettleDelivery;
 	}
 
 	public Collection<String> getConsumerTags() {
@@ -858,10 +875,34 @@ public class BlockingQueueConsumer {
 			}
 			if (ackRequired) {
 				if (tag < 0) {
-					OptionalLong deliveryTag = this.deliveryTags.stream().mapToLong(l -> l).max();
-					if (deliveryTag.isPresent()) {
-						this.channel.basicNack(deliveryTag.getAsLong(), true,
-								ContainerUtils.shouldRequeue(this.defaultRequeueRejected, ex, logger));
+					boolean requeue = ContainerUtils.shouldRequeue(this.defaultRequeueRejected, ex, logger);
+					if (this.deliveryTags.size() == 1 && !this.listenerMaySettleDelivery.getAsBoolean()) {
+						/*
+						 * Reject the delivery individually, rather than with a cumulative
+						 * 'basic.nack': RabbitMQ counts only individually rejected deliveries
+						 * towards 'x-delivery-count', so a quorum queue 'x-delivery-limit' would
+						 * never be reached otherwise, and the message would be redelivered forever
+						 * instead of being dead-lettered.
+						 */
+						this.channel.basicReject(this.deliveryTags.iterator().next(), requeue);
+					}
+					else {
+						/*
+						 * Either there are several outstanding deliveries, or the listener may have
+						 * settled one itself - a consumer batch acking a part of it and then
+						 * throwing (see ConsumerBatchingTests) is both. Re-settling an already
+						 * settled delivery individually is a protocol violation - the broker answers
+						 * it with 'PRECONDITION_FAILED - unknown delivery tag' and closes the whole
+						 * channel, failing everything else in progress on it. A cumulative nack
+						 * tolerates such a delivery instead - it settles whatever is still
+						 * outstanding up to the given tag - hence it is used here; a listener which
+						 * needs every delivery counted can reject them individually itself, which is
+						 * anyway the way to control its deliveries one by one.
+						 */
+						OptionalLong deliveryTag = this.deliveryTags.stream().mapToLong(l -> l).max();
+						if (deliveryTag.isPresent()) {
+							this.channel.basicNack(deliveryTag.getAsLong(), true, requeue);
+						}
 					}
 					if (this.transactional) {
 						// Need to commit the reject (=nack)

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumer.java
@@ -329,7 +329,7 @@ public class BlockingQueueConsumer {
 	 * It is consulted when a delivery has to be rejected.
 	 * @param listenerMaySettleDelivery the supplier; a consumer without a listener - not
 	 * driven by a container - returns false by default.
-	 * @since 4.2
+	 * @since 4.0.6
 	 * @see AbstractMessageListenerContainer#listenerMaySettleDelivery()
 	 * @see #rollbackOnExceptionIfNecessary(Throwable, long)
 	 */

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1344,9 +1344,12 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 						 * channel and the delivery tag. Re-settling an already settled delivery
 						 * individually is a protocol violation - the broker answers it with
 						 * 'PRECONDITION_FAILED - unknown delivery tag' and closes the whole channel,
-						 * failing everything else in progress on it. A cumulative nack tolerates such
-						 * a delivery instead - it settles whatever is still outstanding up to the
-						 * given tag - hence the previous nack is retained here as it was.
+						 * failing everything else in progress on it. A cumulative nack tolerates
+						 * such a delivery instead - it settles whatever is still outstanding up to
+						 * the given tag. Hence, the nack is left exactly as it was before, including
+						 * the individual one for an async reply: that one is settled by the listener
+						 * adapter when it completes, so a listener which threw instead has not
+						 * settled anything.
 						 */
 						getChannel().basicNack(deliveryTag, !isAsyncReplies(),
 								ContainerUtils.shouldRequeue(isDefaultRequeueRejected(), e, this.logger));

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainer.java
@@ -1328,11 +1328,43 @@ public class DirectMessageListenerContainer extends AbstractMessageListenerConta
 							this.lock.unlock();
 						}
 					}
-					getChannel().basicNack(deliveryTag, !isAsyncReplies(),
-							ContainerUtils.shouldRequeue(isDefaultRequeueRejected(), e, this.logger));
+					if (getAcknowledgeMode().isAutoAck()) {
+						/*
+						 * There is nothing to settle: the broker settled the delivery when it sent
+						 * it. Rejecting it would be a protocol violation - the broker answers with
+						 * 'PRECONDITION_FAILED - unknown delivery tag' and closes the whole channel.
+						 */
+						if (this.logger.isDebugEnabled()) {
+							this.logger.debug("Cannot reject a delivery in auto-ack mode: " + deliveryTag);
+						}
+					}
+					else if (listenerMaySettleDelivery()) {
+						/*
+						 * The listener may have settled this delivery itself - it is given the
+						 * channel and the delivery tag. Re-settling an already settled delivery
+						 * individually is a protocol violation - the broker answers it with
+						 * 'PRECONDITION_FAILED - unknown delivery tag' and closes the whole channel,
+						 * failing everything else in progress on it. A cumulative nack tolerates such
+						 * a delivery instead - it settles whatever is still outstanding up to the
+						 * given tag - hence the previous nack is retained here as it was.
+						 */
+						getChannel().basicNack(deliveryTag, !isAsyncReplies(),
+								ContainerUtils.shouldRequeue(isDefaultRequeueRejected(), e, this.logger));
+					}
+					else {
+						/*
+						 * Reject the delivery individually, rather than with a cumulative
+						 * 'basic.nack': RabbitMQ counts only individually rejected deliveries
+						 * towards 'x-delivery-count', so a quorum queue 'x-delivery-limit' would
+						 * never be reached otherwise, and the message would be redelivered forever
+						 * instead of being dead-lettered.
+						 */
+						getChannel().basicReject(deliveryTag,
+								ContainerUtils.shouldRequeue(isDefaultRequeueRejected(), e, this.logger));
+					}
 				}
 				catch (Exception e1) {
-					this.logger.error("Failed to nack message", e1);
+					this.logger.error("Failed to reject message", e1);
 				}
 			}
 			if (isChannelTransacted()) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -64,7 +64,7 @@ import org.springframework.amqp.rabbit.support.ActiveObjectCounter;
 import org.springframework.amqp.rabbit.support.ConsumerCancelledException;
 import org.springframework.amqp.rabbit.support.ListenerContainerAware;
 import org.springframework.amqp.rabbit.support.RabbitExceptionTranslator;
-import org.springframework.amqp.support.ConsumerTagStrategy;
+import org.springframework.amqp.utils.JavaUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.log.LogMessage;
 import org.springframework.jmx.export.annotation.ManagedMetric;
@@ -994,34 +994,31 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 	}
 
 	protected BlockingQueueConsumer createBlockingQueueConsumer() {
-		BlockingQueueConsumer consumer;
-		String[] queues = getQueueNames();
 		// There's no point prefetching less than the tx size, otherwise the consumer will stall because the broker
 		// didn't get an ack for delivered messages
 		int actualPrefetchCount = Math.max(getPrefetchCount(), this.batchSize);
-		consumer = new BlockingQueueConsumer(getConnectionFactory(), getMessagePropertiesConverter(),
-				this.cancellationLock, getAcknowledgeMode(), isChannelTransacted(), actualPrefetchCount,
-				isDefaultRequeueRejected(), getConsumerArguments(), isNoLocal(), isExclusive(), queues);
+		BlockingQueueConsumer consumer =
+				new BlockingQueueConsumer(getConnectionFactory(), getMessagePropertiesConverter(),
+						this.cancellationLock, getAcknowledgeMode(), isChannelTransacted(), actualPrefetchCount,
+						isDefaultRequeueRejected(), getConsumerArguments(), isNoLocal(), isExclusive(), getQueueNames());
 		consumer.setGlobalQos(isGlobalQos());
 		consumer.setMissingQueuePublisher(this::publishMissingQueueEvent);
-		if (this.declarationRetries != null) {
-			consumer.setDeclarationRetries(this.declarationRetries);
-		}
-		if (getFailedDeclarationRetryInterval() > 0) {
-			consumer.setFailedDeclarationRetryInterval(getFailedDeclarationRetryInterval());
-		}
-		if (this.retryDeclarationInterval != null) {
-			consumer.setRetryDeclarationInterval(this.retryDeclarationInterval);
-		}
-		ConsumerTagStrategy consumerTagStrategy = getConsumerTagStrategy();
-		if (consumerTagStrategy != null) {
-			consumer.setTagStrategy(consumerTagStrategy);
-		}
 		consumer.setBackOffExecution(getRecoveryBackOff().start());
 		consumer.setShutdownTimeout(getShutdownTimeout());
 		consumer.setApplicationEventPublisher(getApplicationEventPublisher());
 		consumer.setMessageAckListener(getMessageAckListener());
 		consumer.setListenerMaySettleDelivery(this::listenerMaySettleDelivery);
+
+		JavaUtils.INSTANCE
+				.acceptIfNotNull(this.declarationRetries, consumer::setDeclarationRetries)
+				.acceptIfNotNull(this.retryDeclarationInterval, consumer::setRetryDeclarationInterval)
+				.acceptIfNotNull(getConsumerTagStrategy(), consumer::setTagStrategy);
+
+		long failedDeclarationRetryInterval = getFailedDeclarationRetryInterval();
+		if (failedDeclarationRetryInterval > 0) {
+			consumer.setFailedDeclarationRetryInterval(failedDeclarationRetryInterval);
+		}
+
 		return consumer;
 	}
 
@@ -1598,21 +1595,18 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 			}
 		}
 
-		private void initialize() throws Throwable { // NOSONAR
+		private void initialize() throws Throwable {
 			try {
 				redeclareElementsIfNecessary();
 				this.consumer.start();
 				this.start.countDown();
 			}
-			catch (QueuesNotAvailableException e) {
-				if (isMissingQueuesFatal()) {
-					throw e;
-				}
-				else {
+			catch (QueuesNotAvailableException ex) {
+				if (!isMissingQueuesFatal()) {
 					this.start.countDown();
 					handleStartupFailure(this.consumer.getBackOffExecution());
-					throw e;
 				}
+				throw ex;
 			}
 			catch (FatalListenerStartupException ex) {
 				if (isPossibleAuthenticationFailureFatal()) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/SimpleMessageListenerContainer.java
@@ -1021,6 +1021,7 @@ public class SimpleMessageListenerContainer extends AbstractMessageListenerConta
 		consumer.setShutdownTimeout(getShutdownTimeout());
 		consumer.setApplicationEventPublisher(getApplicationEventPublisher());
 		consumer.setMessageAckListener(getMessageAckListener());
+		consumer.setListenerMaySettleDelivery(this::listenerMaySettleDelivery);
 		return consumer;
 	}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -344,7 +344,7 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 	 * Returns true unconditionally by default; a subclass which knows better should
 	 * override this method.
 	 * @return true if this listener may settle a delivery itself.
-	 * @since 4.2
+	 * @since 4.0.6
 	 */
 	public boolean maySettleDelivery() {
 		return true;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/AbstractAdaptableMessageListener.java
@@ -335,6 +335,22 @@ public abstract class AbstractAdaptableMessageListener implements ChannelAwareMe
 	}
 
 	/**
+	 * Return true when this listener, or the code it delegates to, may settle a delivery
+	 * itself - by calling {@code basicAck()}, {@code basicNack()} or
+	 * {@code basicReject()} on the channel it is given. The container needs to know that
+	 * because it cannot reject an already settled delivery individually: such a
+	 * re-settlement is a protocol violation which closes the whole channel.
+	 * <p>
+	 * Returns true unconditionally by default; a subclass which knows better should
+	 * override this method.
+	 * @return true if this listener may settle a delivery itself.
+	 * @since 4.2
+	 */
+	public boolean maySettleDelivery() {
+		return true;
+	}
+
+	/**
 	 * Handle the given exception that arose during listener execution.
 	 * The default implementation logs the exception at error level.
 	 * <p>

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -65,6 +65,8 @@ public class BatchMessagingMessageListenerAdapter extends MessagingMessageListen
 	/**
 	 * This adapter rejects a message it fails to convert, so a delivery of the batch may
 	 * be settled independently of the container.
+	 * @return always true.
+	 * @since 4.0.6
 	 */
 	@Override
 	public boolean maySettleDelivery() {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -62,6 +62,15 @@ public class BatchMessagingMessageListenerAdapter extends MessagingMessageListen
 		this.batchingStrategy = batchingStrategy == null ? new SimpleBatchingStrategy(0, 0, 0L) : batchingStrategy;
 	}
 
+	/**
+	 * This adapter rejects a message it fails to convert, so a delivery of the batch may
+	 * be settled independently of the container.
+	 */
+	@Override
+	public boolean maySettleDelivery() {
+		return true;
+	}
+
 	@Override
 	public void onMessageBatch(List<org.springframework.amqp.core.Message> messages, @Nullable Channel channel) {
 		Message<?> converted;

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -18,6 +18,7 @@ package org.springframework.amqp.rabbit.listener.adapter;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 
 import com.rabbitmq.client.Channel;
 import org.jspecify.annotations.Nullable;
@@ -143,6 +144,24 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	public boolean isAsyncReplies() {
 		Assert.notNull(this.handlerAdapter, "The 'handlerAdapter' is required");
 		return this.handlerAdapter.isAsyncReplies();
+	}
+
+	/**
+	 * Only a listener method with a {@link Channel} parameter can settle a delivery
+	 * itself. In addition, an async reply is acknowledged when it completes, a
+	 * {@link RabbitListenerErrorHandler} is given the channel as well, and the message is
+	 * acknowledged for an error handler which returns nothing in the manual ack mode.
+	 * A handler method which cannot be determined upfront - a {@code @RabbitHandler} one -
+	 * is assumed to settle.
+	 */
+	@Override
+	public boolean maySettleDelivery() {
+		if (this.errorHandler != null || isManualAck() || isAsyncReplies()) {
+			return true;
+		}
+		Method method = this.messagingMessageConverter.getMethod();
+		return method == null
+				|| Arrays.stream(method.getParameterTypes()).anyMatch(Channel.class::isAssignableFrom);
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapter.java
@@ -153,6 +153,9 @@ public class MessagingMessageListenerAdapter extends AbstractAdaptableMessageLis
 	 * acknowledged for an error handler which returns nothing in the manual ack mode.
 	 * A handler method which cannot be determined upfront - a {@code @RabbitHandler} one -
 	 * is assumed to settle.
+	 * @return true when {@link #errorHandler} is provided, or {@link #isManualAck()}, or {@link #isAsyncReplies()},
+	 * or target POJO method expects a {@link Channel} as one of its arguments.
+	 * @since 4.0.6
 	 */
 	@Override
 	public boolean maySettleDelivery() {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/BlockingQueueConsumerTests.java
@@ -63,6 +63,7 @@ import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -258,7 +259,35 @@ public class BlockingQueueConsumerTests {
 		deliveryTags.add(1L);
 		dfa.setPropertyValue("deliveryTags", deliveryTags);
 		blockingQueueConsumer.rollbackOnExceptionIfNecessary(ex);
-		verify(channel).basicNack(1L, true, expectedRequeue);
+		verify(channel).basicReject(1L, expectedRequeue);
+	}
+
+	@Test
+	void listenerWhichMaySettleDeliveryKeepsTheCumulativeNack() throws Exception {
+		Channel channel = mock(Channel.class);
+		BlockingQueueConsumer consumer = new BlockingQueueConsumer(mock(ConnectionFactory.class),
+				new DefaultMessagePropertiesConverter(), new ActiveObjectCounter<>(),
+				AcknowledgeMode.AUTO, false, 1, "testQ");
+		DirectFieldAccessor dfa = new DirectFieldAccessor(consumer);
+		dfa.setPropertyValue("channel", channel);
+		Set<Long> deliveryTags = new HashSet<>();
+		deliveryTags.add(1L);
+		dfa.setPropertyValue("deliveryTags", deliveryTags);
+
+		// The listener is given the channel and may have settled the delivery itself:
+		// an individual reject of an already settled delivery would close the whole channel.
+		consumer.setListenerMaySettleDelivery(() -> true);
+		consumer.rollbackOnExceptionIfNecessary(new RuntimeException());
+		verify(channel).basicNack(1L, true, true);
+		verify(channel, never()).basicReject(1L, true);
+
+		// The tags are cleared by the rollback; add the next outstanding delivery.
+		deliveryTags.add(2L);
+		// The listener cannot settle a delivery: reject it individually for the 'x-delivery-count'.
+		consumer.setListenerMaySettleDelivery(() -> false);
+		consumer.rollbackOnExceptionIfNecessary(new RuntimeException());
+		verify(channel).basicReject(2L, true);
+		verify(channel, never()).basicNack(2L, true, true);
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DeliveryLimitRedeliveryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DeliveryLimitRedeliveryTests.java
@@ -29,8 +29,7 @@ import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.junit.RabbitAvailable;
-import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
+import org.springframework.amqp.rabbit.junit.AbstractTestContainerTests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,8 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @see <a href="https://github.com/spring-projects/spring-amqp/issues/3507">GH-3507</a>
  */
-@RabbitAvailable
-public class DeliveryLimitRedeliveryTests {
+class DeliveryLimitRedeliveryTests extends AbstractTestContainerTests {
 
 	private static final int DELIVERY_LIMIT = 3;
 
@@ -58,14 +56,13 @@ public class DeliveryLimitRedeliveryTests {
 
 	private static final String DLQ = QUEUE + ".dlq";
 
-	private final CachingConnectionFactory connectionFactory =
-			new CachingConnectionFactory(RabbitAvailableCondition.getBrokerRunning().getConnectionFactory());
+	private final CachingConnectionFactory connectionFactory = new CachingConnectionFactory("localhost", amqpPort());
 
 	private final RabbitAdmin admin = new RabbitAdmin(this.connectionFactory);
 
 	@BeforeEach
 	void declareQueues() {
-		// A quorum queue cannot be auto-delete or exclusive, hence the explicit clean up.
+		// A quorum queue cannot be auto-delete or exclusive, hence the explicit clean-up.
 		this.admin.deleteQueue(QUEUE);
 		this.admin.deleteQueue(DLQ);
 		this.admin.declareQueue(QueueBuilder.durable(QUEUE)

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DeliveryLimitRedeliveryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DeliveryLimitRedeliveryTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.listener;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verify that a failing listener causes the broker to bump {@code x-delivery-count}, so a
+ * quorum queue {@code x-delivery-limit} is eventually reached and the message is
+ * dead-lettered instead of being redelivered forever.
+ * <p>
+ * RabbitMQ only counts deliveries rejected individually; it does not count those settled
+ * by a {@code basic.nack} with {@code multiple=true}, which is what both containers used
+ * to issue for a listener that is not returning an async reply.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.0.6
+ *
+ * @see <a href="https://github.com/spring-projects/spring-amqp/issues/3507">GH-3507</a>
+ */
+@RabbitAvailable
+public class DeliveryLimitRedeliveryTests {
+
+	private static final int DELIVERY_LIMIT = 3;
+
+	private static final String QUEUE = "test.delivery.limit";
+
+	private static final String DLQ = QUEUE + ".dlq";
+
+	private final CachingConnectionFactory connectionFactory =
+			new CachingConnectionFactory(RabbitAvailableCondition.getBrokerRunning().getConnectionFactory());
+
+	private final RabbitAdmin admin = new RabbitAdmin(this.connectionFactory);
+
+	@BeforeEach
+	void declareQueues() {
+		// A quorum queue cannot be auto-delete or exclusive, hence the explicit clean up.
+		this.admin.deleteQueue(QUEUE);
+		this.admin.deleteQueue(DLQ);
+		this.admin.declareQueue(QueueBuilder.durable(QUEUE)
+				.quorum()
+				.deliveryLimit(DELIVERY_LIMIT)
+				.deadLetterExchange("")
+				.deadLetterRoutingKey(DLQ)
+				.build());
+		this.admin.declareQueue(QueueBuilder.durable(DLQ).build());
+	}
+
+	@AfterEach
+	void deleteQueues() {
+		this.admin.deleteQueue(QUEUE);
+		this.admin.deleteQueue(DLQ);
+		this.connectionFactory.destroy();
+	}
+
+	@Test
+	void simpleContainerRejectionIsCountedTowardsDeliveryLimit() throws InterruptedException {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(this.connectionFactory);
+		container.setReceiveTimeout(10);
+		verifyDeliveryLimitIsReached(container);
+	}
+
+	@Test
+	void directContainerRejectionIsCountedTowardsDeliveryLimit() throws InterruptedException {
+		verifyDeliveryLimitIsReached(new DirectMessageListenerContainer(this.connectionFactory));
+	}
+
+	private void verifyDeliveryLimitIsReached(AbstractMessageListenerContainer container) throws InterruptedException {
+		AtomicInteger deliveries = new AtomicInteger();
+		// The broker dead-letters once 'x-delivery-count' exceeds the limit, hence one more delivery.
+		int expectedDeliveries = DELIVERY_LIMIT + 1;
+		CountDownLatch latch = new CountDownLatch(expectedDeliveries);
+		container.setQueueNames(QUEUE);
+		container.setMessageListener(message -> {
+			deliveries.incrementAndGet();
+			latch.countDown();
+			throw new RuntimeException("intentional: force a requeue");
+		});
+		container.afterPropertiesSet();
+		container.start();
+
+		RabbitTemplate template = new RabbitTemplate(this.connectionFactory);
+		try {
+			template.convertAndSend(QUEUE, "foo");
+
+			assertThat(latch.await(30, TimeUnit.SECONDS))
+					.withFailMessage("the message was not redelivered up to the delivery limit")
+					.isTrue();
+
+			Message deadLettered = template.receive(DLQ, 30_000);
+			assertThat(deadLettered)
+					.withFailMessage("the message was redelivered indefinitely instead of being dead-lettered")
+					.isNotNull();
+			assertThat(deadLettered.getBody()).asString().isEqualTo("foo");
+		}
+		finally {
+			container.stop();
+		}
+
+		// The delivery is requeued (and counted) after each failure, until the limit is exceeded.
+		assertThat(deliveries).hasValue(expectedDeliveries);
+	}
+
+}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/DirectMessageListenerContainerMockTests.java
@@ -50,6 +50,7 @@ import org.springframework.amqp.rabbit.connection.AutoRecoverConnectionNotCurren
 import org.springframework.amqp.rabbit.connection.ChannelProxy;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.backoff.FixedBackOff;
@@ -67,6 +68,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -168,7 +170,7 @@ public class DirectMessageListenerContainerMockTests {
 		willAnswer(i -> {
 			latch4.countDown();
 			return null;
-		}).given(channel).basicNack(19L, true, true);
+		}).given(channel).basicReject(19L, true);
 
 		DirectMessageListenerContainer container = new DirectMessageListenerContainer(connectionFactory);
 		container.setQueueNames("test");
@@ -204,9 +206,9 @@ public class DirectMessageListenerContainerMockTests {
 		consumer.get().handleDelivery("consumerTag", envelope(18), props, body);
 		consumer.get().handleDelivery("consumerTag", envelope(19), props, body);
 		assertThat(latch4.await(30, TimeUnit.SECONDS)).isTrue();
-		// pending acks before nack
+		// pending acks before the reject
 		verify(channel).basicAck(18L, true);
-		verify(channel).basicNack(19L, true, true);
+		verify(channel).basicReject(19L, true);
 		consumer.get().handleDelivery("consumerTag", envelope(20), props, body);
 		final CountDownLatch latch5 = new CountDownLatch(1);
 		willAnswer(i -> {
@@ -218,6 +220,58 @@ public class DirectMessageListenerContainerMockTests {
 		assertThat(latch5.await(30, TimeUnit.SECONDS)).isTrue();
 		// pending acks on stop
 		verify(channel).basicAck(20L, true);
+	}
+
+	@Test
+	void listenerWhichMaySettleDeliveryKeepsTheCumulativeNack() throws Exception {
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
+		ChannelProxy channel = mock();
+		AutorecoveringChannel rabbitChannel = mock();
+		given(channel.getTargetChannel()).willReturn(rabbitChannel);
+
+		given(connectionFactory.createConnection()).willReturn(connection);
+		given(connection.createChannel(anyBoolean())).willReturn(channel);
+		given(channel.isOpen()).willReturn(true);
+		given(channel.queueDeclarePassive(Mockito.anyString()))
+				.willAnswer(invocation -> mock(AMQP.Queue.DeclareOk.class));
+		AtomicReference<Consumer> consumer = new AtomicReference<>();
+		CountDownLatch consumeLatch = new CountDownLatch(1);
+		willAnswer(i -> {
+			consumer.set(i.getArgument(6));
+			consumer.get().handleConsumeOk("consumerTag");
+			consumeLatch.countDown();
+			return "consumerTag";
+		}).given(channel)
+				.basicConsume(anyString(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(),
+						anyMap(), any(Consumer.class));
+		CountDownLatch nackLatch = new CountDownLatch(1);
+		willAnswer(i -> {
+			nackLatch.countDown();
+			return null;
+		}).given(channel).basicNack(1L, true, true);
+		willAnswer(i -> {
+			consumer.get().handleCancelOk("consumerTag");
+			return null;
+		}).given(channel).basicCancel("consumerTag");
+
+		DirectMessageListenerContainer container = new DirectMessageListenerContainer(connectionFactory);
+		container.setQueueNames("test");
+		// A ChannelAwareMessageListener is given the channel, so it may settle the delivery itself.
+		container.setMessageListener((ChannelAwareMessageListener) (message, channelForListener) -> {
+			throw new RuntimeException("test");
+		});
+		container.afterPropertiesSet();
+		container.start();
+
+		assertThat(consumeLatch.await(30, TimeUnit.SECONDS)).isTrue();
+		consumer.get().handleDelivery("consumerTag", envelope(1), new BasicProperties(), new byte[1]);
+		assertThat(nackLatch.await(30, TimeUnit.SECONDS)).isTrue();
+
+		// An individual reject of a delivery settled by the listener would close the whole channel.
+		verify(channel, never()).basicReject(anyLong(), anyBoolean());
+		verify(channel).basicNack(1L, true, true);
+		container.stop();
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/ExternalTxManagerTests.java
@@ -327,12 +327,9 @@ public abstract class ExternalTxManagerTests {
 		assertThat(rejectLatch.await(10, TimeUnit.SECONDS)).isTrue();
 
 		assertThat(rollbackLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		if (propagation != TransactionDefinition.PROPAGATION_NEVER) {
-			verify(channel).basicReject(anyLong(), eq(expectRequeue));
-		}
-		else {
-			verify(channel).basicNack(anyLong(), eq(Boolean.TRUE), eq(expectRequeue));
-		}
+		// The single outstanding delivery is rejected individually, so that RabbitMQ counts it
+		// towards 'x-delivery-count'.
+		verify(channel).basicReject(anyLong(), eq(expectRequeue));
 		container.stop();
 	}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
@@ -49,6 +49,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
@@ -190,6 +191,23 @@ public abstract class LocallyTransactedTests {
 		assertThat(commitLatch.get().await(10, TimeUnit.SECONDS)).isTrue();
 		verify(onlyChannel, times(2)).basicAck(anyLong(), anyBoolean());
 		verify(onlyChannel, times(4)).txCommit();
+
+		// A ChannelAwareMessageListener is given the channel, hence it may have settled the
+		// delivery itself: the cumulative nack, which tolerates that, is kept for it.
+		container.setMessageListener((ChannelAwareMessageListener) (m, channel) -> {
+			throw new RuntimeException();
+		});
+		commitLatch.set(new CountDownLatch(1));
+		rollbackLatch.set(new CountDownLatch(1));
+		consumer.get().handleDelivery("qux", new Envelope(1, false, "foo", "bar"), new BasicProperties(),
+				new byte[] { 0 });
+		assertThat(rollbackLatch.get().await(10, TimeUnit.SECONDS)).isTrue();
+		// The cumulative nack is committed like any other reject, so wait for that too:
+		// otherwise the assertions below can race ahead of the container thread.
+		assertThat(commitLatch.get().await(10, TimeUnit.SECONDS)).isTrue();
+		verify(onlyChannel).basicNack(anyLong(), eq(true), anyBoolean());
+		// No more individual rejects than the two from the plain MessageListener above.
+		verify(onlyChannel, times(2)).basicReject(anyLong(), anyBoolean());
 
 		container.stop();
 	}

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/LocallyTransactedTests.java
@@ -162,7 +162,9 @@ public abstract class LocallyTransactedTests {
 				new byte[] { 0 });
 		assertThat(commitLatch.get().await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(rollbackLatch.get().await(10, TimeUnit.SECONDS)).isTrue();
-		verify(onlyChannel).basicNack(anyLong(), anyBoolean(), anyBoolean());
+		// The single outstanding delivery is rejected individually, so that RabbitMQ counts it
+		// towards 'x-delivery-count'.
+		verify(onlyChannel).basicReject(anyLong(), anyBoolean());
 		verify(onlyChannel, times(1)).txRollback();
 
 		// ImmediateAck tests
@@ -176,7 +178,7 @@ public abstract class LocallyTransactedTests {
 				new byte[] { 0 });
 		assertThat(rollbackLatch.get().await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(commitLatch.get().await(10, TimeUnit.SECONDS)).isTrue();
-		verify(onlyChannel, times(2)).basicNack(anyLong(), anyBoolean(), anyBoolean());
+		verify(onlyChannel, times(2)).basicReject(anyLong(), anyBoolean());
 		verify(onlyChannel, times(2)).txRollback();
 
 		container.setMessageListener(m -> {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -381,6 +382,33 @@ public class MessagingMessageListenerAdapterTests {
 		verify(channel).basicPublish(any(), any(), anyBoolean(), any(), any());
 	}
 
+	@Test
+	void maySettleDeliveryOnlyWhenTheListenerHasTheChannel() {
+		// The listener method cannot settle a delivery without a 'Channel' argument.
+		assertThat(getSimpleInstance("fail", String.class).maySettleDelivery()).isFalse();
+		assertThat(getSimpleInstance("withChannel", String.class, Channel.class).maySettleDelivery()).isTrue();
+
+		// The error handler is given the channel as well.
+		assertThat(getSimpleInstance("fail", mock(RabbitListenerErrorHandler.class), false, String.class)
+				.maySettleDelivery())
+				.isTrue();
+
+		// In the manual ack mode the message is acknowledged for an error handler returning nothing.
+		MessagingMessageListenerAdapter manualAckAdapter = getSimpleInstance("fail", String.class);
+		manualAckAdapter.containerAckMode(AcknowledgeMode.MANUAL);
+		assertThat(manualAckAdapter.maySettleDelivery()).isTrue();
+
+		// An async reply is acknowledged when it completes.
+		assertThat(getSimpleInstance("asyncFail", String.class).maySettleDelivery()).isTrue();
+
+		// A '@RabbitHandler' method is not known upfront.
+		assertThat(getMultiInstance("fail", "wrongParam", false, String.class, Integer.class).maySettleDelivery())
+				.isTrue();
+
+		// A batch adapter rejects a message it fails to convert.
+		assertThat(getBatchInstance("withFooBatch").maySettleDelivery()).isTrue();
+	}
+
 	protected MessagingMessageListenerAdapter getSimpleInstance(String methodName, Class<?>... parameterTypes) {
 		return getSimpleInstance(methodName, null, false, parameterTypes);
 	}
@@ -462,6 +490,16 @@ public class MessagingMessageListenerAdapterTests {
 		@SuppressWarnings("unused")
 		public void fail(String input) {
 			throw new IllegalArgumentException("Expected test exception");
+		}
+
+		@SuppressWarnings("unused")
+		public void withChannel(String input, Channel channel) {
+			this.payload = input;
+		}
+
+		@SuppressWarnings("unused")
+		public CompletableFuture<Void> asyncFail(String input) {
+			return CompletableFuture.failedFuture(new IllegalArgumentException("Expected test exception"));
 		}
 
 		@SuppressWarnings("unused")

--- a/src/reference/antora/modules/ROOT/pages/amqp/resilience-recovering-from-errors-and-broker-failures.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/resilience-recovering-from-errors-and-broker-failures.adoc
@@ -202,6 +202,25 @@ See xref:amqp/connections.adoc#cf-pub-conf-ret[Publisher Confirms and Returns] f
 
 Starting with version 2.1, an `ImmediateRequeueMessageRecoverer` is  added to throw an `ImmediateRequeueAmqpException`, which notifies a listener container to requeue the current failed message.
 
+[[broker-delivery-limit]]
+== Broker Delivery Limits
+
+Instead of limiting re-deliveries on the client, a quorum queue can be declared with an `x-delivery-limit` argument - see `QueueBuilder.deliveryLimit()`.
+The broker dead-letters a message once its `x-delivery-count` exceeds that limit.
+However, the broker counts only a delivery which is settled individually - with a `basic.reject`, or a `basic.nack` for a single delivery tag; a cumulative `basic.nack` (the one with a `multiple` flag) is not counted.
+
+Starting with version 4.0.6, the listener containers reject a failed delivery individually, so it is counted towards such a delivery limit and the message is eventually dead-lettered instead of being redelivered endlessly.
+The cumulative `basic.nack` is retained only when the container is not the only party which settles the delivery:
+
+* the listener is given the consumer `Channel` (the default `exposeListenerChannel = true`) and may have settled the delivery itself - a `ChannelAwareMessageListener`, a `@RabbitListener` method with a `Channel` parameter, a `RabbitListenerErrorHandler`, an async reply, or the `AcknowledgeMode.MANUAL`.
+Settling an already settled delivery is a protocol violation: the broker replies with a `PRECONDITION_FAILED - unknown delivery tag` and closes the whole channel, failing everything else in progress on it.
+* several deliveries are outstanding - with consumer batching, or a `batchSize` greater than `1` on the `SimpleMessageListenerContainer` - since such deliveries are rolled back together.
+
+In other words, a listener which is given the channel is in charge of its deliveries: if every failed delivery has to be counted towards the queue delivery limit, that listener (or its `RabbitListenerErrorHandler`) must reject the delivery individually itself, which is anyway the way to settle deliveries one by one.
+See xref:amqp/receiving-messages/async-annotation-driven/error-handling.adoc[Handling Exceptions] for an example of such a manual rejection.
+
+NOTE: With the `AcknowledgeMode.NONE` there is nothing to settle: the broker settles a delivery as soon as it sends it, hence a failed delivery is neither rejected nor counted.
+
 [[exception-classification-for-spring-retry]]
 == Exception Classification for Spring Retry
 


### PR DESCRIPTION
Fixes #3507

## The problem

RabbitMQ bumps `x-delivery-count` only for deliveries rejected **individually**; it does not for a `basic.nack` with `multiple=true`.
Both listener containers issued exactly such a bulk nack for a listener that is not returning an async reply:

* `BlockingQueueConsumer.rollbackOnExceptionIfNecessary()` nacked the highest of the outstanding tags with `multiple=true` — the `tag < 0` branch, which `SimpleMessageListenerContainer` always takes unless `isAsyncReplies()`.
* `DirectMessageListenerContainer.SimpleConsumer.rollback()` nacked with `multiple = !isAsyncReplies()`.

So a quorum queue `x-delivery-limit` was never reached and a failing message was redelivered forever instead of being dead-lettered.
This is the report in #3507, and the same symptom as #3435 for the synchronous case.

## The change

* `DirectMessageListenerContainer.SimpleConsumer.rollback()` now rejects the failed delivery individually.
  This consumer handles a single delivery at a time — a producer-created batch is one delivery whose de-batched messages all carry its tag — hence there is exactly one delivery to reject.
* `BlockingQueueConsumer.rollbackOnExceptionIfNecessary()` rejects the outstanding delivery individually when there is exactly one of them: the default configuration, which includes a de-batched producer batch, again a single delivery tag for many messages.
  Consumer batching, or a `batchSize` greater than one, accumulate several outstanding deliveries instead and keep the cumulative nack.

Accumulated deliveries keep the cumulative nack because listener code may have settled some of them itself — `ConsumerBatchingTests` acks or rejects part of a batch and then throws — and re-settling an already settled delivery individually is a protocol violation rather than a per-call error, so the broker answers it with `PRECONDITION_FAILED - unknown delivery tag` and closes the whole channel, failing everything else in progress on it.
A cumulative nack tolerates such a delivery instead — the broker settles whatever is still outstanding up to the given tag — hence it is retained for that case.
A batch listener which needs each of its deliveries counted can reject them individually itself, which is already the way to handle the batch messages one by one.

With `AcknowledgeMode.NONE` there is nothing to settle at all — the broker settles a delivery as it sends it — so `SimpleConsumer` now skips the rejection in that mode.
It used to nack unconditionally whenever `ContainerUtils.isRejectManual()`, which the cumulative nack turned into a silent no-op, while an individual reject would close the channel.
That matters in particular for `DirectReplyToMessageListenerContainer`: a `NONE` container which tracks its in-use consumers by channel.

The success path bulk `basicAck(max, multiple=true)` is left alone — `x-delivery-count` only concerns rejects.

## Verification

Against a real RabbitMQ **4.3.0** — new `DeliveryLimitRedeliveryTests`, a quorum queue with `x-delivery-limit=3` and a listener that always throws:

* `simpleContainerRejectionIsCountedTowardsDeliveryLimit()` and `directContainerRejectionIsCountedTowardsDeliveryLimit()` — the message is dead-lettered after `limit + 1` deliveries. Both fail against the previous bulk nack with *"the message was redelivered indefinitely instead of being dead-lettered"*.

`o.s.a.rabbit.listener`, `annotation`, `config` and `core` are green against a live broker, and `./gradlew build -x test` passes across modules.

This also answers the "confirm with the RabbitMQ team" question from the issue thread empirically: on 4.3.0 individual rejects do bump the count, the bulk nack does not.

## Known follow-up, not in this PR

Accumulated deliveries (consumer batching, `batchSize > 1`) still use the cumulative nack, so `x-delivery-count` is not bumped for those individually — only the default single-delivery case is fixed here. Extending this to per-message counting in batch mode would need a way to know which deliveries a listener already settled itself without re-wrapping the channel, which is deliberately left out of this PR to keep it small and backportable.

## Backport

No `whats-new.adoc` entry (this is an internal fix, not a new capability), and confirmed to cherry-pick onto `4.1.x` and `4.0.x` without conflicts, so this is fit to backport down to `4.0.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
