### PR TITLE
GH-3448: Close channels if confirm wait fails

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -1328,21 +1328,30 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 								}
 								catch (InterruptedException ex) {
 									Thread.currentThread().interrupt();
+									closeAfterFailedConfirmWait();
 								}
-								catch (ShutdownSignalException | TimeoutException ex) {
+								catch (Exception ex) {
 									// The channel didn't handle confirms, so close it altogether to avoid
 									// memory leaks for pending confirms
-									try {
-										physicalClose();
-									}
-									catch (@SuppressWarnings(UNUSED) Exception e) {
-									}
+									closeAfterFailedConfirmWait();
 								}
 							});
 				}
 			}
 			else {
 				doReturnToCache(proxy);
+			}
+		}
+
+		private void closeAfterFailedConfirmWait() {
+			Channel targetChannel = this.target;
+			if (targetChannel != null) {
+				this.theConnection.channelsAwaitingAcks.remove(targetChannel);
+			}
+			try {
+				physicalClose();
+			}
+			catch (@SuppressWarnings(UNUSED) Exception e) {
 			}
 		}
 

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -1312,7 +1312,8 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 					&& this.publisherConfirms
 					&& proxy instanceof PublisherCallbackChannel publisherCallbackChannel) {
 
-				this.theConnection.channelsAwaitingAcks.put(this.target, proxy);
+				Channel channelAwaitingAcks = this.target;
+				this.theConnection.channelsAwaitingAcks.put(channelAwaitingAcks, proxy);
 				AtomicBoolean ackCallbackCalledImmediately = new AtomicBoolean();
 				publisherCallbackChannel
 						.setAfterAckCallback(c -> {
@@ -1328,12 +1329,12 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 								}
 								catch (InterruptedException ex) {
 									Thread.currentThread().interrupt();
-									closeAfterFailedConfirmWait();
+									closeAfterFailedConfirmWait(channelAwaitingAcks);
 								}
 								catch (Exception ex) {
 									// The channel didn't handle confirms, so close it altogether to avoid
 									// memory leaks for pending confirms
-									closeAfterFailedConfirmWait();
+									closeAfterFailedConfirmWait(channelAwaitingAcks);
 								}
 							});
 				}
@@ -1343,13 +1344,12 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			}
 		}
 
-		private void closeAfterFailedConfirmWait() {
-			Channel targetChannel = this.target;
-			if (targetChannel != null) {
-				this.theConnection.channelsAwaitingAcks.remove(targetChannel);
+		private void closeAfterFailedConfirmWait(@Nullable Channel channelAwaitingAcks) {
+			if (channelAwaitingAcks != null) {
+				this.theConnection.channelsAwaitingAcks.remove(channelAwaitingAcks);
 			}
 			try {
-				physicalClose();
+				physicalClose(channelAwaitingAcks);
 			}
 			catch (@SuppressWarnings(UNUSED) Exception e) {
 			}
@@ -1413,13 +1413,17 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			}
 		}
 
-		@SuppressWarnings("NullAway") // Dataflow analysis limitation
 		private void physicalClose() throws IOException, TimeoutException {
+			physicalClose(this.target);
+		}
+
+		@SuppressWarnings("NullAway") // Dataflow analysis limitation
+		private void physicalClose(@Nullable Channel channelToClose) throws IOException, TimeoutException {
 			if (logger.isDebugEnabled()) {
-				logger.debug("Closing cached Channel: " + this.target);
+				logger.debug("Closing cached Channel: " + channelToClose);
 			}
 			RabbitUtils.clearPhysicalCloseRequired();
-			if (this.target == null) {
+			if (channelToClose == null) {
 				return;
 			}
 			boolean async = false;
@@ -1428,22 +1432,24 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 						(ConfirmType.CORRELATED.equals(CachingConnectionFactory.this.confirmType) ||
 								CachingConnectionFactory.this.publisherReturns)) {
 					async = true;
-					asyncClose();
+					asyncClose(channelToClose);
 				}
 				else {
-					this.target.close();
-					if (this.target instanceof AutorecoveringChannel auto) {
+					channelToClose.close();
+					if (channelToClose instanceof AutorecoveringChannel auto) {
 						ClosingRecoveryListener.removeChannel(auto);
 					}
 				}
 			}
 			catch (AlreadyClosedException e) {
 				if (logger.isTraceEnabled()) {
-					logger.trace(this.target + " is already closed", e);
+					logger.trace(channelToClose + " is already closed", e);
 				}
 			}
 			finally {
-				this.target = null;
+				if (this.target == channelToClose) {
+					this.target = null;
+				}
 				if (!async) {
 					releasePermitIfNecessary();
 				}
@@ -1451,9 +1457,8 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		}
 
 		@SuppressWarnings("NullAway") // Dataflow analysis limitation
-		private void asyncClose() {
+		private void asyncClose(Channel channel) {
 			ExecutorService executorService = getChannelsExecutor();
-			final Channel channel = CachedChannelInvocationHandler.this.target;
 			CachingConnectionFactory.this.inFlightAsyncCloses.add(channel);
 			try {
 				executorService.execute(() -> {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -1313,6 +1313,10 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 					&& proxy instanceof PublisherCallbackChannel publisherCallbackChannel) {
 
 				Channel channelAwaitingAcks = this.target;
+				if (channelAwaitingAcks == null) {
+					doReturnToCache(proxy);
+					return;
+				}
 				this.theConnection.channelsAwaitingAcks.put(channelAwaitingAcks, proxy);
 				AtomicBoolean ackCallbackCalledImmediately = new AtomicBoolean();
 				publisherCallbackChannel
@@ -1345,11 +1349,12 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		}
 
 		private void closeAfterFailedConfirmWait(@Nullable Channel channelAwaitingAcks) {
-			if (channelAwaitingAcks != null) {
-				this.theConnection.channelsAwaitingAcks.remove(channelAwaitingAcks);
+			if (channelAwaitingAcks == null
+					|| this.theConnection.channelsAwaitingAcks.remove(channelAwaitingAcks) == null) {
+				return;
 			}
 			try {
-				physicalClose(channelAwaitingAcks);
+				physicalClose(channelAwaitingAcks, false);
 			}
 			catch (@SuppressWarnings(UNUSED) Exception e) {
 			}
@@ -1414,11 +1419,13 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 		}
 
 		private void physicalClose() throws IOException, TimeoutException {
-			physicalClose(this.target);
+			physicalClose(this.target, true);
 		}
 
 		@SuppressWarnings("NullAway") // Dataflow analysis limitation
-		private void physicalClose(@Nullable Channel channelToClose) throws IOException, TimeoutException {
+		private void physicalClose(@Nullable Channel channelToClose, boolean waitForPendingConfirms)
+				throws IOException, TimeoutException {
+
 			if (logger.isDebugEnabled()) {
 				logger.debug("Closing cached Channel: " + channelToClose);
 			}
@@ -1428,7 +1435,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 			}
 			boolean async = false;
 			try {
-				if (CachingConnectionFactory.this.active &&
+				if (waitForPendingConfirms && CachingConnectionFactory.this.active &&
 						(ConfirmType.CORRELATED.equals(CachingConnectionFactory.this.confirmType) ||
 								CachingConnectionFactory.this.publisherReturns)) {
 					async = true;
@@ -1476,25 +1483,29 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 					catch (@SuppressWarnings(UNUSED) Exception e2) {
 					}
 					finally {
-						try {
-							channel.close();
-						}
-						catch (@SuppressWarnings(UNUSED) IOException | AlreadyClosedException | TimeoutException e3) {
-						}
-						catch (ShutdownSignalException e6) {
-							if (!RabbitUtils.isNormalShutdown(e6)) {
-								logger.debug("Unexpected exception on deferred close", e6);
-							}
-						}
-						finally {
-							CachingConnectionFactory.this.inFlightAsyncCloses.release(channel);
-							releasePermitIfNecessary();
-						}
+						completeDeferredClose(channel);
 					}
 				});
 			}
 			catch (@SuppressWarnings(UNUSED) RuntimeException e) {
+				completeDeferredClose(channel);
+			}
+		}
+
+		private void completeDeferredClose(Channel channel) {
+			try {
+				channel.close();
+			}
+			catch (@SuppressWarnings(UNUSED) IOException | AlreadyClosedException | TimeoutException e3) {
+			}
+			catch (ShutdownSignalException e6) {
+				if (!RabbitUtils.isNormalShutdown(e6)) {
+					logger.debug("Unexpected exception on deferred close", e6);
+				}
+			}
+			finally {
 				CachingConnectionFactory.this.inFlightAsyncCloses.release(channel);
+				releasePermitIfNecessary();
 			}
 		}
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -83,6 +83,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -718,6 +719,47 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		open.set(true);
 		rabbitTemplate.convertAndSend("foo", "bar");
 		verify(mockChannel, times(2)).basicPublish(any(), any(), anyBoolean(), any(), any());
+	}
+
+	@Test
+	public void testPublisherConfirmsUnexpectedWaitFailureClosesChannelWhenCheckoutTimeoutZero() throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock();
+		com.rabbitmq.client.Connection mockConnection = mock();
+		Channel mockChannel = mock();
+		Channel mockChannel2 = mock();
+
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.createChannel()).willReturn(mockChannel, mockChannel2);
+		given(mockConnection.isOpen()).willReturn(true);
+		given(mockChannel.isOpen()).willReturn(true);
+		given(mockChannel2.isOpen()).willReturn(true);
+		given(mockChannel.getNextPublishSeqNo()).willReturn(1L);
+		given(mockChannel2.getNextPublishSeqNo()).willReturn(1L);
+
+		CountDownLatch closeLatch = new CountDownLatch(1);
+		willThrow(new IllegalStateException("channel closed during broker crash"))
+				.given(mockChannel).waitForConfirms(anyLong());
+		willAnswer(invoc -> {
+			closeLatch.countDown();
+			return null;
+		}).given(mockChannel).close();
+
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ExecutorService exec = Executors.newCachedThreadPool();
+		ccf.setExecutor(exec);
+		ccf.setChannelCacheSize(1);
+		ccf.setPublisherConfirmType(ConfirmType.CORRELATED);
+
+		RabbitTemplate rabbitTemplate = new RabbitTemplate(ccf);
+		rabbitTemplate.convertAndSend("foo", "bar");
+
+		assertThat(closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		verify(mockChannel, timeout(5000)).close();
+
+		rabbitTemplate.convertAndSend("foo", "bar");
+		verify(mockChannel2, timeout(5000)).basicPublish(any(), any(), anyBoolean(), any(), any());
+
+		exec.shutdownNow();
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -758,6 +758,7 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 		assertThat(closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		verify(mockChannel, timeout(5000)).close();
+		verify(mockChannel, never()).waitForConfirmsOrDie(anyLong());
 		verify(mockChannel2, never()).close();
 
 		rabbitTemplate.convertAndSend("foo", "bar");
@@ -765,6 +766,121 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		verify(mockChannel2, never()).close();
 
 		exec.shutdownNow();
+	}
+
+	@Test
+	public void testPublisherConfirmsFailedWaitDoesNotCloseWhenAckAlreadyReturnedChannel() throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock();
+		com.rabbitmq.client.Connection mockConnection = mock();
+		Channel mockChannel = mock();
+
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.createChannel()).willReturn(mockChannel);
+		given(mockConnection.isOpen()).willReturn(true);
+		given(mockChannel.isOpen()).willReturn(true);
+		given(mockChannel.getNextPublishSeqNo()).willReturn(1L);
+
+		AtomicReference<ConfirmListener> confirmListener = new AtomicReference<>();
+		willAnswer(invoc -> {
+			confirmListener.set(invoc.getArgument(0));
+			return null;
+		}).given(mockChannel).addConfirmListener(any());
+
+		CountDownLatch waitStarted = new CountDownLatch(1);
+		CountDownLatch failWait = new CountDownLatch(1);
+		willAnswer(invoc -> {
+			waitStarted.countDown();
+			assertThat(failWait.await(10, TimeUnit.SECONDS)).isTrue();
+			throw new IllegalStateException("wait failed after ack already processed");
+		}).given(mockChannel).waitForConfirms(anyLong());
+
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ExecutorService exec = Executors.newCachedThreadPool();
+		ccf.setExecutor(exec);
+		ccf.setChannelCacheSize(1);
+		ccf.setPublisherConfirmType(ConfirmType.CORRELATED);
+
+		RabbitTemplate rabbitTemplate = new RabbitTemplate(ccf);
+		rabbitTemplate.convertAndSend("foo", "bar");
+
+		assertThat(waitStarted.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(confirmListener.get()).isNotNull();
+		confirmListener.get().handleAck(1L, false);
+
+		int n = 0;
+		Map<?, ?> awaiting = TestUtils.getPropertyValue(ccf, "connection.channelsAwaitingAcks");
+		while (awaiting != null && !awaiting.isEmpty() && n++ < 100) {
+			Thread.sleep(50);
+		}
+		assertThat(awaiting).isEmpty();
+
+		failWait.countDown();
+		Thread.sleep(200);
+		verify(mockChannel, never()).close();
+
+		rabbitTemplate.convertAndSend("foo", "bar");
+		verify(mockConnection, times(1)).createChannel();
+
+		exec.shutdownNow();
+	}
+
+	@Test
+	public void testPublisherConfirmsInterruptedWaitClosesWhenExecutorRejectsAsyncClose() throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock();
+		com.rabbitmq.client.Connection mockConnection = mock();
+		Channel mockChannel = mock();
+		Channel mockChannel2 = mock();
+
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.createChannel()).willReturn(mockChannel, mockChannel2);
+		given(mockConnection.isOpen()).willReturn(true);
+		given(mockChannel.isOpen()).willReturn(true);
+		given(mockChannel2.isOpen()).willReturn(true);
+		given(mockChannel.getNextPublishSeqNo()).willReturn(1L);
+		given(mockChannel2.getNextPublishSeqNo()).willReturn(1L);
+
+		CountDownLatch closeLatch = new CountDownLatch(1);
+		willAnswer(invoc -> {
+			closeLatch.countDown();
+			return null;
+		}).given(mockChannel).close();
+
+		ExecutorService delegate = Executors.newCachedThreadPool();
+		AtomicBoolean rejectFurther = new AtomicBoolean();
+		ExecutorService exec = mock(ExecutorService.class);
+		willAnswer(invoc -> {
+			if (rejectFurther.get()) {
+				throw new RejectedExecutionException("shutdown");
+			}
+			delegate.execute(invoc.getArgument(0));
+			return null;
+		}).given(exec).execute(any());
+
+		willAnswer(invoc -> {
+			rejectFurther.set(true);
+			throw new InterruptedException("channels executor shutdown");
+		}).given(mockChannel).waitForConfirms(anyLong());
+
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ccf.setExecutor(exec);
+		ccf.setChannelCacheSize(1);
+		ccf.setChannelCheckoutTimeout(1000);
+		ccf.setPublisherConfirmType(ConfirmType.CORRELATED);
+
+		RabbitTemplate rabbitTemplate = new RabbitTemplate(ccf);
+		rabbitTemplate.convertAndSend("foo", "bar");
+
+		assertThat(closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		verify(mockChannel, timeout(5000)).close();
+		verify(mockChannel, never()).waitForConfirmsOrDie(anyLong());
+
+		Connection con = ccf.createConnection();
+		Channel channel2 = con.createChannel(false);
+		assertThat(channel2).isNotNull();
+		channel2.close();
+		verify(mockChannel2, never()).close();
+
+		delegate.shutdownNow();
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -731,14 +731,17 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
 		given(mockConnection.createChannel()).willReturn(mockChannel, mockChannel2);
 		given(mockConnection.isOpen()).willReturn(true);
-		given(mockChannel.isOpen()).willReturn(true);
+		AtomicBoolean open = new AtomicBoolean(true);
+		willAnswer(invoc -> open.get()).given(mockChannel).isOpen();
 		given(mockChannel2.isOpen()).willReturn(true);
 		given(mockChannel.getNextPublishSeqNo()).willReturn(1L);
 		given(mockChannel2.getNextPublishSeqNo()).willReturn(1L);
 
 		CountDownLatch closeLatch = new CountDownLatch(1);
-		willThrow(new IllegalStateException("channel closed during broker crash"))
-				.given(mockChannel).waitForConfirms(anyLong());
+		willAnswer(invoc -> {
+			open.set(false);
+			throw new IllegalStateException("channel closed during broker crash");
+		}).given(mockChannel).waitForConfirms(anyLong());
 		willAnswer(invoc -> {
 			closeLatch.countDown();
 			return null;
@@ -755,9 +758,11 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 
 		assertThat(closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		verify(mockChannel, timeout(5000)).close();
+		verify(mockChannel2, never()).close();
 
 		rabbitTemplate.convertAndSend("foo", "bar");
 		verify(mockChannel2, timeout(5000)).basicPublish(any(), any(), anyBoolean(), any(), any());
+		verify(mockChannel2, never()).close();
 
 		exec.shutdownNow();
 	}


### PR DESCRIPTION
Fixes #3448

When publisher confirms are correlated and `checkoutTimeout` is 0 (the default), `returnToCache()` parks overflow channels until `waitForConfirms()` completes. After an abrupt broker crash that wait can fail with exceptions other than `ShutdownSignalException` or `TimeoutException`. Those channels were left in `channelsAwaitingAcks` and never physically closed, so `ChannelN` instances accumulated and publishing stayed blocked after reconnect.

This closes the channel for any failed confirm wait (including interrupt) and drops it from `channelsAwaitingAcks`, matching the existing timeout/shutdown path.

## Test plan
- [x] `./gradlew :spring-rabbit:test --tests org.springframework.amqp.rabbit.connection.CachingConnectionFactoryTests --tests org.springframework.amqp.rabbit.core.RabbitTemplatePublisherCallbacksIntegration1Tests.testPublisherConfirmNotReceived`
- [x] `:spring-rabbit:checkstyleMain` and `:spring-rabbit:checkstyleTest`
- [x] New unit test: unexpected `waitForConfirms()` failure with `checkoutTimeout=0` physically closes the channel and a later publish proceeds