### PR TITLE
Honor `autoStartup` after `RabbitListenerEndpointRegistry` restart

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
@@ -249,6 +249,7 @@ public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLife
 
 	@Override
 	public void stop() {
+		this.contextRefreshed = false;
 		for (MessageListenerContainer listenerContainer : getListenerContainers()) {
 			listenerContainer.stop();
 		}
@@ -256,6 +257,7 @@ public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLife
 
 	@Override
 	public void stop(Runnable callback) {
+		this.contextRefreshed = false;
 		Collection<MessageListenerContainer> containers = getListenerContainers();
 		if (!containers.isEmpty()) {
 			AggregatingCallback aggregatingCallback = new AggregatingCallback(containers.size(), callback);

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistry.java
@@ -306,15 +306,10 @@ public class RabbitListenerEndpointRegistry implements DisposableBean, SmartLife
 		}
 	}
 
-	private static final class AggregatingCallback implements Runnable {
+	private record AggregatingCallback(AtomicInteger count, Runnable finishCallback) implements Runnable {
 
-		private final AtomicInteger count;
-
-		private final Runnable finishCallback;
-
-		AggregatingCallback(int count, Runnable finishCallback) {
-			this.count = new AtomicInteger(count);
-			this.finishCallback = finishCallback;
+		private AggregatingCallback(int count, Runnable finishCallback) {
+			this(new AtomicInteger(count), finishCallback);
 		}
 
 		@Override

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistryTests.java
@@ -29,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -47,19 +46,19 @@ public class RabbitListenerEndpointRegistryTests {
 	@Test
 	public void createWithNullEndpoint() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> registry.registerListenerContainer(null, containerFactory));
+				.isThrownBy(() -> registry.registerListenerContainer(null, containerFactory));
 	}
 
 	@Test
 	public void createWithNullEndpointId() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> registry.registerListenerContainer(new SimpleRabbitListenerEndpoint(), containerFactory));
+				.isThrownBy(() -> registry.registerListenerContainer(new SimpleRabbitListenerEndpoint(), containerFactory));
 	}
 
 	@Test
 	public void createWithNullContainerFactory() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> registry.registerListenerContainer(createEndpoint("foo", "myDestination"), null));
+				.isThrownBy(() -> registry.registerListenerContainer(createEndpoint("foo", "myDestination"), null));
 	}
 
 	@Test
@@ -67,7 +66,7 @@ public class RabbitListenerEndpointRegistryTests {
 		registry.registerListenerContainer(createEndpoint("test", "queue"), containerFactory);
 
 		assertThatIllegalStateException()
-			.isThrownBy(() -> registry.registerListenerContainer(createEndpoint("test", "queue"), containerFactory));
+				.isThrownBy(() -> registry.registerListenerContainer(createEndpoint("test", "queue"), containerFactory));
 	}
 
 	@Test

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/listener/RabbitListenerEndpointRegistryTests.java
@@ -18,16 +18,25 @@ package org.springframework.amqp.rabbit.listener;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.amqp.core.MessageListenerContainer;
 import org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerEndpoint;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.support.GenericApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  *
  * @author Stephane Nicoll
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class RabbitListenerEndpointRegistryTests {
 
@@ -59,6 +68,42 @@ public class RabbitListenerEndpointRegistryTests {
 
 		assertThatIllegalStateException()
 			.isThrownBy(() -> registry.registerListenerContainer(createEndpoint("test", "queue"), containerFactory));
+	}
+
+	@Test
+	public void stopThenStartHonorsAutoStartupFalse() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.refresh();
+		registry.setApplicationContext(context);
+		MessageListenerContainer container = registerAutoStartupFalseContainer("listener");
+		registry.start();
+		verify(container, never()).start();
+		registry.onApplicationEvent(new ContextRefreshedEvent(context));
+		registry.stop();
+		registry.start();
+		verify(container, never()).start();
+	}
+
+	@Test
+	public void startAfterRefreshWithoutStopStartsContainerRegardlessOfAutoStartup() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.refresh();
+		registry.setApplicationContext(context);
+		MessageListenerContainer container = registerAutoStartupFalseContainer("listener");
+		registry.onApplicationEvent(new ContextRefreshedEvent(context));
+		registry.start();
+		verify(container).start();
+	}
+
+	private MessageListenerContainer registerAutoStartupFalseContainer(String id) {
+		RabbitListenerEndpoint endpoint = mock();
+		given(endpoint.getId()).willReturn(id);
+		RabbitListenerContainerFactory<MessageListenerContainer> factory = mock();
+		MessageListenerContainer container = mock();
+		given(container.isAutoStartup()).willReturn(false);
+		given(factory.createListenerContainer(endpoint)).willReturn(container);
+		registry.registerListenerContainer(endpoint, factory);
+		return container;
 	}
 
 	private SimpleRabbitListenerEndpoint createEndpoint(String id, String queueName) {


### PR DESCRIPTION
## Summary

`RabbitListenerEndpointRegistry.contextRefreshed` is set on `ContextRefreshedEvent` and never cleared. After that, every registry `start()` - including one triggered by `ConfigurableApplicationContext.restart()` (Spring Framework 7.0.3+ test context pause/resume) - unconditionally starts all listener containers, ignoring `autoStartup=false`.

This mirrors the same problem fixed in Spring for Apache Kafka's `KafkaListenerEndpointRegistry`: https://github.com/spring-projects/spring-kafka/pull/4568

This change resets `contextRefreshed` when the registry stops (`stop()` and `stop(Runnable)`), so a subsequent `start()`/`restart()` re-applies each container's `autoStartup` setting again. A `start()` right after the initial refresh (no intervening `stop()`) still starts containers unconditionally, as before.

## Test plan

- [x] `./gradlew :spring-rabbit:test --tests "org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistryTests"`