### PR TITLE
GH-3605: Use doSetPublisherConnectionFactory in ThreadChannelConnectionFactory ctor

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactory.java
@@ -87,7 +87,7 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory
 	private ThreadChannelConnectionFactory(ConnectionFactory rabbitConnectionFactory, boolean isPublisher) {
 		super(rabbitConnectionFactory);
 		if (!isPublisher) {
-			setPublisherConnectionFactory(new ThreadChannelConnectionFactory(rabbitConnectionFactory, true));
+			doSetPublisherConnectionFactory(new ThreadChannelConnectionFactory(rabbitConnectionFactory, true));
 		}
 		else {
 			this.defaultPublisherFactory = false;

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryPublisherTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryPublisherTests.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Kumar Gaurav
  *
- * @since 4.0
+ * @since 4.0.6
  */
 class ThreadChannelConnectionFactoryPublisherTests {
 

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryPublisherTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryPublisherTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import com.rabbitmq.client.ConnectionFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ThreadChannelConnectionFactory} publisher connection factory
+ * configuration. These require no broker.
+ *
+ * @author Kumar Gaurav
+ *
+ * @since 4.0
+ */
+class ThreadChannelConnectionFactoryPublisherTests {
+
+	@Test
+	void simplePublisherConfirmsPropagateToDefaultPublisherFactory() {
+		ThreadChannelConnectionFactory tccf = new ThreadChannelConnectionFactory(new ConnectionFactory());
+
+		tccf.setSimplePublisherConfirms(true);
+
+		assertThat(tccf.isSimplePublisherConfirms()).isTrue();
+		org.springframework.amqp.rabbit.connection.ConnectionFactory publisher =
+				tccf.getPublisherConnectionFactory();
+		assertThat(publisher).isNotNull();
+		assertThat(((ThreadChannelConnectionFactory) publisher).isSimplePublisherConfirms())
+				.as("simplePublisherConfirms must reach the default publisher sub-factory")
+				.isTrue();
+	}
+
+}


### PR DESCRIPTION
**Problem**

The private `ThreadChannelConnectionFactory` constructor calls the overridable `setPublisherConnectionFactory()`, whose override sets `defaultPublisherFactory = false`. That happens during construction, so the flag is `false` on every instance and the guard in `setSimplePublisherConfirms()` never fires — the setting never reaches the default publisher sub-factory.

**Impact**

Wider than confirms not being selected. `RabbitTemplate.invoke()` reassigns `connectionFactory` to the publisher sub-factory (RabbitTemplate:2316-2317) and then gates `setPhysicalCloseRequired` on `isSimplePublisherConfirms()` of that reassigned factory:

```java
if (this.usePublisherConnection && connectionFactory.getPublisherConnectionFactory() != null) {
    connectionFactory = connectionFactory.getPublisherConnectionFactory();
}
...
if (!connectionFactory.isPublisherConfirms() && !connectionFactory.isSimplePublisherConfirms()) {
    RabbitUtils.setPhysicalCloseRequired(channel, true);
}
```

With the flag stuck `false` there, every `invoke()` marks the thread's cached channel for physical close — so the thread-channel caching this factory exists to provide silently stops working. Thanks to @renechoi for pointing that out.

Separately, `waitForConfirms()` fails with `IllegalStateException: Confirms not selected`, since `ConnectionWrapper.createChannel` never calls `channel.confirmSelect()`.

**Solution**

Call `doSetPublisherConnectionFactory()`, which `AbstractConnectionFactory` declares `protected final` precisely so constructors do not dispatch to an override. `PooledChannelConnectionFactory` (line 96) and `CachingConnectionFactory` (lines 271, 283) already do this; this aligns the third implementation with them. One line.

**Tests**

Added `ThreadChannelConnectionFactoryPublisherTests` — broker-free, since the assertion is pure constructor wiring and needs no RabbitMQ.

It fails on current `main` with `AssertionFailedError` ("Expecting value to be true but was false") and passes with this change. Reverting only the production line while keeping the test reproduces the failure as an assertion rather than a compile error, so the test genuinely exercises the fix.

Locally on JDK 25: the renamed test passes and `checkstyleTest` is clean; 111 connection-factory tests pass with 0 failures (36 `@RabbitAvailable` tests skipped — no broker in my environment).

**Risk**

Low. `doSetPublisherConnectionFactory` is the non-virtual form of the same call, and `AbstractConnectionFactory.setPublisherConnectionFactory` delegates to it. Behaviour changes only where the flag was previously stuck at `false`.

Fixes GH-3605
