### PR TITLE
GH-3604: Apply default container factory name before configurers

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -98,7 +98,7 @@ import org.springframework.validation.Validator;
  * @author Artem Bilan
  * @author Ngoc Nhan
  * @author Martin Ferret
- * @author Burak KALAYCI
+ * @author Burak Kalayci
  *
  * @since 1.4
  *

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessor.java
@@ -98,6 +98,7 @@ import org.springframework.validation.Validator;
  * @author Artem Bilan
  * @author Ngoc Nhan
  * @author Martin Ferret
+ * @author Burak KALAYCI
  *
  * @since 1.4
  *
@@ -198,6 +199,7 @@ public class RabbitListenerAnnotationBeanPostProcessor
 	public void afterSingletonsInstantiated() {
 		super.afterSingletonsInstantiated();
 		this.registrar.setBeanFactory(getBeanFactory());
+		this.registrar.setContainerFactoryBeanName(this.defaultContainerFactoryBeanName);
 
 		if (getBeanFactory() instanceof ListableBeanFactory lbf) {
 			Map<String, RabbitListenerConfigurer> instances =
@@ -216,8 +218,6 @@ public class RabbitListenerAnnotationBeanPostProcessor
 			}
 			this.registrar.setEndpointRegistry(this.endpointRegistry);
 		}
-
-		this.registrar.setContainerFactoryBeanName(this.defaultContainerFactoryBeanName);
 
 		// Set the custom handler method factory once resolved by the configurer
 		MessageHandlerMethodFactory handlerMethodFactory = this.registrar.getMessageHandlerMethodFactory();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
@@ -45,9 +45,12 @@ import org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory
 import org.springframework.amqp.rabbit.listener.AbstractRabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.listener.MethodRabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpoint;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistrar;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -64,6 +67,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Juergen Hoeller
  * @author Alex Panchenko
  * @author Martin Ferret
+ * @author Burak KALAYCI
  */
 public class RabbitListenerAnnotationBeanPostProcessorTests {
 
@@ -369,6 +373,24 @@ public class RabbitListenerAnnotationBeanPostProcessorTests {
 			assertThat(endpoint.getBatchSize()).isEqualTo(7);
 			assertThat(endpoint.getBatchReceiveTimeout()).isEqualTo(2500L);
 		}
+	}
+
+	@Test
+	public void configurerOverridesDefaultContainerFactoryBeanName() {
+		RabbitListenerAnnotationBeanPostProcessor postProcessor = new RabbitListenerAnnotationBeanPostProcessor();
+		StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+		beanFactory.addBean("configurer", (RabbitListenerConfigurer) registrar ->
+				registrar.setContainerFactoryBeanName("customFactory"));
+		postProcessor.setBeanFactory(beanFactory);
+		postProcessor.setEndpointRegistry(new RabbitListenerEndpointRegistry());
+
+		postProcessor.afterSingletonsInstantiated();
+
+		RabbitListenerEndpointRegistrar registrar =
+				TestUtils.getPropertyValue(postProcessor, "registrar");
+		assertThat(registrar).isNotNull();
+		String containerFactoryBeanName = TestUtils.getPropertyValue(registrar, "containerFactoryBeanName");
+		assertThat(containerFactoryBeanName).isEqualTo("customFactory");
 	}
 
 	static class BeanForConcurrencyTesting {

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitListenerAnnotationBeanPostProcessorTests.java
@@ -45,7 +45,6 @@ import org.springframework.amqp.rabbit.config.RabbitListenerContainerTestFactory
 import org.springframework.amqp.rabbit.listener.AbstractRabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.listener.MethodRabbitListenerEndpoint;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpoint;
-import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistrar;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.utils.test.TestUtils;
@@ -67,7 +66,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Juergen Hoeller
  * @author Alex Panchenko
  * @author Martin Ferret
- * @author Burak KALAYCI
+ * @author Burak Kalayci
  */
 public class RabbitListenerAnnotationBeanPostProcessorTests {
 
@@ -386,11 +385,8 @@ public class RabbitListenerAnnotationBeanPostProcessorTests {
 
 		postProcessor.afterSingletonsInstantiated();
 
-		RabbitListenerEndpointRegistrar registrar =
-				TestUtils.getPropertyValue(postProcessor, "registrar");
-		assertThat(registrar).isNotNull();
-		String containerFactoryBeanName = TestUtils.getPropertyValue(registrar, "containerFactoryBeanName");
-		assertThat(containerFactoryBeanName).isEqualTo("customFactory");
+		assertThat((String) TestUtils.getPropertyValue(postProcessor, "registrar.containerFactoryBeanName"))
+				.isEqualTo("customFactory");
 	}
 
 	static class BeanForConcurrencyTesting {


### PR DESCRIPTION
Fixes #3604

`afterSingletonsInstantiated` copied the default container factory bean name onto the registrar after `RabbitListenerConfigurer` ran, so a name set from a configurer was overwritten.

Apply the default name first. Configurers can still override it. The bean name stays required; null is not supported.

## Test plan

- `./gradlew :spring-rabbit:test --tests "org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessorTests"`
- `./gradlew :spring-rabbit:test --tests "org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistrarTests"`