### PR TITLE
Fix `includeStackTrace` when frame_max is unknown

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
@@ -84,7 +84,7 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 
 	private int frameMaxHeadroom = DEFAULT_FRAME_MAX_HEADROOM;
 
-	private volatile boolean includeStackTrace;
+	private boolean includeStackTrace;
 
 	private volatile Integer maxStackTraceLength = 0;
 
@@ -163,6 +163,8 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 
 	/**
 	 * Set {@code true} to add header with error stack trace.
+	 * When the truncation limit cannot be resolved from the negotiated {@code frame_max},
+	 * the stack trace is published untruncated.
 	 * @param includeStackTrace {@code true} to add header with error stack trace.
 	 * @return this.
 	 * @since 4.0.5

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecoverer.java
@@ -50,6 +50,7 @@ import org.springframework.util.Assert;
  * @author James Carr
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Rene Choi
  *
  * @since 1.3
  */
@@ -82,6 +83,8 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 	private String errorRoutingKeyPrefix = "error.";
 
 	private int frameMaxHeadroom = DEFAULT_FRAME_MAX_HEADROOM;
+
+	private volatile boolean includeStackTrace;
 
 	private volatile Integer maxStackTraceLength = 0;
 
@@ -165,6 +168,7 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 	 * @since 4.0.5
 	 */
 	public RepublishMessageRecoverer includeStackTrace(boolean includeStackTrace) {
+		this.includeStackTrace = includeStackTrace;
 		this.maxStackTraceLength =
 				includeStackTrace ? (!(this.errorTemplate instanceof RabbitTemplate) ? Integer.MAX_VALUE : -1) : 0;
 		return this;
@@ -210,7 +214,7 @@ public class RepublishMessageRecoverer implements MessageRecoverer {
 			if (truncatedExceptionMessage != null) {
 				exceptionMessage = truncatedExceptionMessage;
 			}
-			if (this.maxStackTraceLength > 0) {
+			if (this.includeStackTrace) {
 				headers.put(X_EXCEPTION_STACKTRACE, stackTraceAsString);
 			}
 			headers.put(X_EXCEPTION_MESSAGE, exceptionMessage);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererTests.java
@@ -30,15 +30,21 @@ import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author James Carr
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Rene Choi
  *
  * @since 1.3
  */
@@ -96,6 +102,26 @@ public class RepublishMessageRecovererTests {
 	void shouldIncludeTheStacktraceInTheHeaderOfThePublishedMessage() {
 		recoverer =
 				new RepublishMessageRecoverer(amqpTemplate)
+						.includeStackTrace(true);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		cause.printStackTrace(new PrintStream(baos));
+		final String expectedHeaderValue = baos.toString();
+
+		recoverer.recover(message, cause);
+
+		assertThat(message.getMessageProperties().getHeaders().get("x-exception-stacktrace")).isEqualTo(expectedHeaderValue);
+	}
+
+	@Test
+	void shouldIncludeTheStacktraceWhenTheFrameMaxCannotBeDetermined() {
+		RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		Connection connection = mock(Connection.class);
+		given(rabbitTemplate.getConnectionFactory()).willReturn(connectionFactory);
+		given(connectionFactory.createConnection()).willReturn(connection);
+		// connection.getDelegate() is null, so RabbitUtils.getMaxFrame() returns -1
+		recoverer =
+				new RepublishMessageRecoverer(rabbitTemplate)
 						.includeStackTrace(true);
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		cause.printStackTrace(new PrintStream(baos));

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/retry/RepublishMessageRecovererTests.java
@@ -114,9 +114,9 @@ public class RepublishMessageRecovererTests {
 
 	@Test
 	void shouldIncludeTheStacktraceWhenTheFrameMaxCannotBeDetermined() {
-		RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-		Connection connection = mock(Connection.class);
+		RabbitTemplate rabbitTemplate = mock();
+		ConnectionFactory connectionFactory = mock();
+		Connection connection = mock();
 		given(rabbitTemplate.getConnectionFactory()).willReturn(connectionFactory);
 		given(connectionFactory.createConnection()).willReturn(connection);
 		// connection.getDelegate() is null, so RabbitUtils.getMaxFrame() returns -1
@@ -129,7 +129,8 @@ public class RepublishMessageRecovererTests {
 
 		recoverer.recover(message, cause);
 
-		assertThat(message.getMessageProperties().getHeaders().get("x-exception-stacktrace")).isEqualTo(expectedHeaderValue);
+		assertThat(message.getMessageProperties().getHeaders())
+				.containsEntry(RepublishMessageRecoverer.X_EXCEPTION_STACKTRACE, expectedHeaderValue);
 	}
 
 	@Test


### PR DESCRIPTION
`includeStackTrace(true)` stores `-1` in `maxStackTraceLength` ("resolve the limit from frame_max") when the error template is a `RabbitTemplate`. `RabbitUtils.getMaxFrame()` returns `-1` when it cannot determine the negotiated frame_max, and `processStackTrace()` only overwrites the field when the resolved value is positive. The field therefore stays `-1`, and `recover()` gates the header on `maxStackTraceLength > 0`, so the `x-exception-stacktrace` header that was opted in for is dropped silently.

One field cannot be both the on/off switch and the truncation limit. This gates the header on a dedicated flag; the resolved-limit path is unchanged.

New test `shouldIncludeTheStacktraceWhenTheFrameMaxCannotBeDetermined` fails on `main`, passes here. `:spring-rabbit:test`: 1215 tests, 0 failures.
