### PR TITLE
 Improve null validation for AbstractRouting(Amqp)ConnectionFactory

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactory.java
@@ -67,7 +67,7 @@ public abstract class AbstractRoutingConnectionFactory implements ConnectionFact
 	 */
 	public void setTargetConnectionFactories(Map<Object, ConnectionFactory> targetConnectionFactories) {
 		Assert.notNull(targetConnectionFactories, "'targetConnectionFactories' must not be null.");
-		Assert.noNullElements(targetConnectionFactories.values().toArray(),
+		Assert.noNullElements(targetConnectionFactories.values(),
 				"'targetConnectionFactories' cannot have null values.");
 		this.targetConnectionFactories.putAll(targetConnectionFactories);
 		targetConnectionFactories.values().forEach(this::checkConfirmsAndReturns);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/AbstractRoutingConnectionFactoryTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.connection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * @author Ngoc Nhan
+ *
+ * @since 4.2
+ */
+public class AbstractRoutingConnectionFactoryTests {
+
+	@Test
+	public void setTargetConnectionFactoriesShouldRejectNullValues() {
+
+		Map<Object, ConnectionFactory> factories = new HashMap<>(1);
+		factories.put(Boolean.FALSE, null);
+		AbstractRoutingConnectionFactory factory = new AbstractRoutingConnectionFactory() {
+
+			@Override
+			protected @Nullable Object determineCurrentLookupKey() {
+				return null;
+			}
+
+		};
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> factory.setTargetConnectionFactories(null))
+				.withMessage("'targetConnectionFactories' must not be null.");
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> factory.setTargetConnectionFactories(factories))
+				.withMessage("'targetConnectionFactories' cannot have null values.");
+	}
+
+}

--- a/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/AbstractRoutingAmqpConnectionFactory.java
+++ b/spring-rabbitmq-client/src/main/java/org/springframework/amqp/rabbitmq/client/AbstractRoutingAmqpConnectionFactory.java
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  * thread-bound context.
  *
  * @author Robin Collard
+ * @author Ngoc Nhan
  *
  * @since 4.2
  */
@@ -53,7 +54,7 @@ public abstract class AbstractRoutingAmqpConnectionFactory
 	 */
 	public void setTargetConnectionFactories(Map<Object, AmqpConnectionFactory> targetConnectionFactories) {
 		Assert.notNull(targetConnectionFactories, "'targetConnectionFactories' must not be null.");
-		Assert.noNullElements(targetConnectionFactories.values().toArray(),
+		Assert.noNullElements(targetConnectionFactories.values(),
 				"'targetConnectionFactories' cannot have null values.");
 		this.targetConnectionFactories.putAll(targetConnectionFactories);
 	}

--- a/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/AbstractRoutingAmqpConnectionFactoryTests.java
+++ b/spring-rabbitmq-client/src/test/java/org/springframework/amqp/rabbitmq/client/AbstractRoutingAmqpConnectionFactoryTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbitmq.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * @author Ngoc Nhan
+ *
+ * @since 4.2
+ */
+public class AbstractRoutingAmqpConnectionFactoryTests {
+
+	@Test
+	public void setTargetConnectionFactoriesShouldRejectNullValues() {
+
+		Map<Object, AmqpConnectionFactory> factories = new HashMap<>(1);
+		factories.put(Boolean.FALSE, null);
+		AbstractRoutingAmqpConnectionFactory factory = new AbstractRoutingAmqpConnectionFactory() {
+
+			@Override
+			protected @Nullable Object determineCurrentLookupKey() {
+				return null;
+			}
+
+		};
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> factory.setTargetConnectionFactories(null))
+				.withMessage("'targetConnectionFactories' must not be null.");
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> factory.setTargetConnectionFactories(factories))
+				.withMessage("'targetConnectionFactories' cannot have null values.");
+	}
+
+}


### PR DESCRIPTION
Use the Collection returned by `Map#values()` directly when validating `targetConnectionFactories`, avoiding an unnecessary array allocation.

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.md).
-->
