### PR TITLE
GH-3625: Wait for confirms on the captured channel

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactory.java
@@ -1329,7 +1329,7 @@ public class CachingConnectionFactory extends AbstractConnectionFactory
 					getChannelsExecutor()
 							.execute(() -> {
 								try {
-									publisherCallbackChannel.waitForConfirms(getCloseTimeout());
+									channelAwaitingAcks.waitForConfirms(getCloseTimeout());
 								}
 								catch (InterruptedException ex) {
 									Thread.currentThread().interrupt();

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -2138,6 +2139,139 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 				.values()
 				.iterator()
 				.next();
+	}
+
+	// GH-3625
+	@Test
+	public void testPublisherConfirmsDelayedWaitDoesNotCreateReplacementChannel() throws Exception {
+		com.rabbitmq.client.ConnectionFactory mockConnectionFactory = mock(com.rabbitmq.client.ConnectionFactory.class);
+		com.rabbitmq.client.Connection mockConnection = mock(com.rabbitmq.client.Connection.class);
+		Channel physicalChannelA = mock(Channel.class);
+		Channel physicalChannelB = mock(Channel.class);
+		Channel physicalChannelC = mock(Channel.class);
+		given(mockConnectionFactory.newConnection(any(ExecutorService.class), anyString())).willReturn(mockConnection);
+		given(mockConnection.isOpen()).willReturn(true);
+		given(mockConnection.createChannel()).willReturn(physicalChannelA, physicalChannelB, physicalChannelC);
+		given(physicalChannelA.isOpen()).willReturn(true);
+		given(physicalChannelB.isOpen()).willReturn(true);
+		given(physicalChannelC.isOpen()).willReturn(true);
+
+		CountDownLatch originalChannelClosed = new CountDownLatch(1);
+		CountDownLatch confirmWaitCompleted = new CountDownLatch(1);
+		willAnswer(invocation -> {
+			originalChannelClosed.countDown();
+			return null;
+		}).given(physicalChannelA).close();
+		willAnswer(invocation -> {
+			confirmWaitCompleted.countDown();
+			return true;
+		}).given(physicalChannelA).waitForConfirms(anyLong());
+		willAnswer(invocation -> {
+			confirmWaitCompleted.countDown();
+			return true;
+		}).given(physicalChannelC).waitForConfirms(anyLong());
+
+		WaitTaskGateExecutor executor = new WaitTaskGateExecutor();
+		CachingConnectionFactory ccf = new CachingConnectionFactory(mockConnectionFactory);
+		ccf.setExecutor(executor);
+		ccf.setChannelCacheSize(1);
+		ccf.setPublisherConfirmType(ConfirmType.CORRELATED);
+		try {
+			Connection connection = ccf.createConnection();
+			Channel channelA = connection.createChannel(false);
+			PublisherCallbackChannelImpl publisherChannelA =
+					(PublisherCallbackChannelImpl) ((ChannelProxy) channelA).getTargetChannel();
+			PublisherCallbackChannel.Listener listener = mock(PublisherCallbackChannel.Listener.class);
+			given(listener.getUUID()).willReturn("delayed-confirm-wait");
+			publisherChannelA.addListener(listener);
+			publisherChannelA.addPendingConfirm(listener, 1L, new PendingConfirm(null, System.currentTimeMillis()));
+			channelA.basicPublish("", "delayed-confirm-wait", null, new byte[0]);
+
+			Channel channelB = connection.createChannel(false);
+			channelA.close();
+			assertThat(executor.awaitWaitTaskReady()).isTrue();
+
+			channelB.close();
+			publisherChannelA.handleAck(1L, false);
+			assertThat(originalChannelClosed.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(((ChannelProxy) channelA).getTargetChannel()).isNull();
+
+			executor.releaseWaitTask();
+			assertThat(confirmWaitCompleted.await(10, TimeUnit.SECONDS)).isTrue();
+
+			verify(mockConnection, times(2)).createChannel();
+			assertThat(connection.createChannel(false)).isSameAs(channelB);
+		}
+		finally {
+			executor.releaseWaitTask();
+			ccf.destroy();
+			executor.shutdownNow();
+			assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+		}
+	}
+
+	private static final class WaitTaskGateExecutor extends AbstractExecutorService {
+
+		private final AtomicBoolean firstTask = new AtomicBoolean(true);
+
+		private final CountDownLatch waitTaskReady = new CountDownLatch(1);
+
+		private final CountDownLatch releaseWaitTask = new CountDownLatch(1);
+
+		private final ExecutorService delegate = Executors.newFixedThreadPool(2);
+
+		@Override
+		public void execute(Runnable command) {
+			this.delegate.execute(() -> {
+				if (this.firstTask.compareAndSet(true, false)) {
+					this.waitTaskReady.countDown();
+					try {
+						if (!this.releaseWaitTask.await(10, TimeUnit.SECONDS)) {
+							throw new IllegalStateException("Timed out waiting to release confirm wait task");
+						}
+					}
+					catch (InterruptedException ex) {
+						Thread.currentThread().interrupt();
+						return;
+					}
+				}
+				command.run();
+			});
+		}
+
+		boolean awaitWaitTaskReady() throws InterruptedException {
+			return this.waitTaskReady.await(10, TimeUnit.SECONDS);
+		}
+
+		void releaseWaitTask() {
+			this.releaseWaitTask.countDown();
+		}
+
+		@Override
+		public void shutdown() {
+			this.delegate.shutdown();
+		}
+
+		@Override
+		public List<Runnable> shutdownNow() {
+			return this.delegate.shutdownNow();
+		}
+
+		@Override
+		public boolean isShutdown() {
+			return this.delegate.isShutdown();
+		}
+
+		@Override
+		public boolean isTerminated() {
+			return this.delegate.isTerminated();
+		}
+
+		@Override
+		public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+			return this.delegate.awaitTermination(timeout, unit);
+		}
+
 	}
 
 }


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-amqp/issues/3625

When a cached publisher channel is closed with confirms still pending, `returnToCache()` registers an after-ack callback and submits an async task that waits for the confirms. GH-3448 changed that method to capture the physical channel as `channelAwaitingAcks` so the failure path closes the right channel — but the success path still calls `waitForConfirms()` through the proxy. If the ack callback has already run by then (cache full → `physicalClose()` → `target = null`), the proxy's `invoke()` sees a null target and creates a replacement channel just to wait on it. That channel has no pending confirms, so the wait returns immediately, and nothing returns it to the cache or closes it.

This calls `waitForConfirms()` on the captured `channelAwaitingAcks` instead, so the async task only ever touches the channel it was created for. If that channel has already been physically closed, the call fails and takes the existing `closeAfterFailedConfirmWait()` path.

The regression test is @xuzhiguang's reproduction from the issue, ported as-is to `CachingConnectionFactoryTests` (they are co-author on the commit): mocked client objects, a gated executor that holds the confirm-wait task until the ack has evicted the channel, and an assertion that `createChannel()` is invoked twice (A and B), not three times. It fails on `main` with `Wanted 2 times, but was 3 times` and passes with the change.
