### PR TITLE
Propagate channel listeners to the default publisher connection factory

### DIFF
--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/AbstractConnectionFactory.java
@@ -438,6 +438,9 @@ public abstract class AbstractConnectionFactory implements ConnectionFactory, Di
 
 	public void setChannelListeners(List<? extends ChannelListener> listeners) {
 		this.channelListener.setDelegates(listeners);
+		if (this.publisherConnectionFactory != null) {
+			this.publisherConnectionFactory.setChannelListeners(listeners);
+		}
 	}
 
 	/**

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/CachingConnectionFactoryTests.java
@@ -2133,6 +2133,21 @@ public class CachingConnectionFactoryTests extends AbstractConnectionFactoryTest
 		assertThat(ccf.isPublisherConfirms()).isFalse();
 	}
 
+	@Test
+	void channelListenersPropagateToDefaultPublisherFactory() {
+		CachingConnectionFactory ccf = new CachingConnectionFactory("someHost", 1234);
+		AtomicInteger created = new AtomicInteger();
+		ccf.setChannelListeners(List.of((channel, transactional) -> created.incrementAndGet()));
+
+		AbstractConnectionFactory publisher = (AbstractConnectionFactory) ccf.getPublisherConnectionFactory();
+		assertThat(publisher).isNotNull();
+		publisher.getChannelListener().onCreate(mock(Channel.class), false);
+
+		assertThat(created.get())
+				.as("channel listeners must reach the default publisher sub-factory")
+				.isEqualTo(1);
+	}
+
 	private static Semaphore firstSemaphoreFromCheckoutPermits(CachingConnectionFactory ccf) {
 		return TestUtils.<Map<?, Semaphore>>getPropertyValue(ccf, "checkoutPermits")
 				.values()


### PR DESCRIPTION
`AbstractConnectionFactory.setChannelListeners(List)` only sets the delegates on this factory, while `addChannelListener(ChannelListener)` below also forwards to the publisher sub-factory. The connection listener side forwards on all four of `set`, `add`, `remove` and `clear`.

So a channel listener registered with `setChannelListeners()` never sees channels created on the publisher connection (`usePublisherConnection = true`), while the same listener added with `addChannelListener()` does.

This applies the forwarding `addChannelListener()` already uses, plus a test in `CachingConnectionFactoryTests`. With the one-line change reverted that test fails with `expected: 1 but was: 0`; the other 50 in the class pass.

`:spring-rabbit:test`, `checkstyleMain`, `checkstyleTest` and `javadoc` pass locally on JDK 25.
