### PR TITLE
Apply `assumeSupportedContentType` only to the default C/T

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJacksonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJacksonMessageConverter.java
@@ -275,9 +275,8 @@ public abstract class AbstractJacksonMessageConverter extends AbstractMessageCon
 		Object content = null;
 		MessageProperties properties = message.getMessageProperties();
 		String contentType = properties.getContentType();
-		if (this.assumeSupportedContentType &&
-				(contentType.equals(MessageProperties.DEFAULT_CONTENT_TYPE)
-						|| this.supportedContentType.isCompatibleWith(MimeType.valueOf(contentType)))) {
+		if ((this.assumeSupportedContentType && contentType.equals(MessageProperties.DEFAULT_CONTENT_TYPE))
+				|| this.supportedContentType.isCompatibleWith(MimeType.valueOf(contentType))) {
 
 			String encoding = determineEncoding(properties, contentType);
 			content = doFromMessage(message, conversionHint, properties, encoding);

--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJacksonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJacksonMessageConverter.java
@@ -43,6 +43,7 @@ import org.springframework.util.MimeTypeUtils;
  * Abstract Jackson 3 message converter.
  *
  * @author Artem Bilan
+ * @author kdelay
  *
  * @since 4.0
  */

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonJsonMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonJsonMessageConverterTests.java
@@ -314,6 +314,21 @@ public class JacksonJsonMessageConverterTests {
 	}
 
 	@Test
+	public void testExplicitContentTypeWhenNotAssumingSupportedContentType() {
+		byte[] bytes = "{\"name\" : \"foo\" }".getBytes();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("application/json");
+		Message message = new Message(bytes, messageProperties);
+		JacksonJsonMessageConverter jsonMessageConverter = new JacksonJsonMessageConverter();
+		DefaultClassMapper classMapper = new DefaultClassMapper();
+		classMapper.setDefaultType(Foo.class);
+		jsonMessageConverter.setClassMapper(classMapper);
+		jsonMessageConverter.setAssumeSupportedContentType(false);
+		Object foo = jsonMessageConverter.fromMessage(message);
+		assertThat(foo).isInstanceOf(Foo.class);
+	}
+
+	@Test
 	void customAbstractClass() {
 		byte[] bytes = "{\"field\" : \"foo\" }".getBytes();
 		MessageProperties messageProperties = new MessageProperties();

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonJsonMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonJsonMessageConverterTests.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Andreas Asplund
  * @author Artem Bilan
+ * @author kdelay
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -314,18 +315,18 @@ public class JacksonJsonMessageConverterTests {
 	}
 
 	@Test
-	public void testExplicitContentTypeWhenNotAssumingSupportedContentType() {
-		byte[] bytes = "{\"name\" : \"foo\" }".getBytes();
+	void explicitContentTypeConvertedWhenNotAssumingSupportedContentType() {
+		byte[] bytes = "{\"name\" : \"trade-1\" }".getBytes();
 		MessageProperties messageProperties = new MessageProperties();
 		messageProperties.setContentType("application/json");
 		Message message = new Message(bytes, messageProperties);
 		JacksonJsonMessageConverter jsonMessageConverter = new JacksonJsonMessageConverter();
 		DefaultClassMapper classMapper = new DefaultClassMapper();
-		classMapper.setDefaultType(Foo.class);
+		classMapper.setDefaultType(TestData.class);
 		jsonMessageConverter.setClassMapper(classMapper);
 		jsonMessageConverter.setAssumeSupportedContentType(false);
-		Object foo = jsonMessageConverter.fromMessage(message);
-		assertThat(foo).isInstanceOf(Foo.class);
+		Object converted = jsonMessageConverter.fromMessage(message);
+		assertThat(converted).isEqualTo(new TestData("trade-1"));
 	}
 
 	@Test
@@ -493,6 +494,10 @@ public class JacksonJsonMessageConverterTests {
 
 	public List<Fiz> fizLister() {
 		return null;
+	}
+
+	public record TestData(String name) {
+
 	}
 
 	public static class Foo {

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonXmlMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonXmlMessageConverterTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mohammad Hewedy
  * @author Gary Russell
  * @author Artem Bilan
+ * @author kdelay
  *
  * @since 2.1
  */
@@ -180,17 +181,17 @@ public class JacksonXmlMessageConverterTests {
 	}
 
 	@Test
-	public void testExplicitContentTypeWhenNotAssumingSupportedContentType() {
-		byte[] bytes = "<root><name>foo</name></root>".getBytes();
+	void explicitContentTypeConvertedWhenNotAssumingSupportedContentType() {
+		byte[] bytes = "<root><name>trade-1</name></root>".getBytes();
 		MessageProperties messageProperties = new MessageProperties();
 		messageProperties.setContentType("application/xml");
 		Message message = new Message(bytes, messageProperties);
 		DefaultClassMapper classMapper = new DefaultClassMapper();
-		classMapper.setDefaultType(Foo.class);
+		classMapper.setDefaultType(TestData.class);
 		this.converter.setClassMapper(classMapper);
 		this.converter.setAssumeSupportedContentType(false);
-		Object foo = this.converter.fromMessage(message);
-		assertThat(foo).isInstanceOf(Foo.class);
+		Object converted = this.converter.fromMessage(message);
+		assertThat(converted).isEqualTo(new TestData("trade-1"));
 	}
 
 	@Test
@@ -279,6 +280,10 @@ public class JacksonXmlMessageConverterTests {
 		Object value = ((Map<?, ?>) map.get("qux")).get("baz");
 		assertThat(value).isInstanceOf(Bar.class);
 		assertThat(((Bar) value).getFoo()).isEqualTo(new Foo("bar"));
+	}
+
+	public record TestData(String name) {
+
 	}
 
 	public static class Foo {

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonXmlMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonXmlMessageConverterTests.java
@@ -180,6 +180,20 @@ public class JacksonXmlMessageConverterTests {
 	}
 
 	@Test
+	public void testExplicitContentTypeWhenNotAssumingSupportedContentType() {
+		byte[] bytes = "<root><name>foo</name></root>".getBytes();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("application/xml");
+		Message message = new Message(bytes, messageProperties);
+		DefaultClassMapper classMapper = new DefaultClassMapper();
+		classMapper.setDefaultType(Foo.class);
+		this.converter.setClassMapper(classMapper);
+		this.converter.setAssumeSupportedContentType(false);
+		Object foo = this.converter.fromMessage(message);
+		assertThat(foo).isInstanceOf(Foo.class);
+	}
+
+	@Test
 	public void testNoJsonContentType() {
 		byte[] bytes = "<root><name>foo</name><root/>".getBytes();
 		MessageProperties messageProperties = new MessageProperties();


### PR DESCRIPTION
`AbstractJacksonMessageConverter.fromMessage()` wraps its content-type check in `assumeSupportedContentType`, so `setAssumeSupportedContentType(false)` turns the converter off for every content type, including an explicit `application/json`.

The setter Javadoc and `message-converters.adoc` scope it to an absent or default `contentType`, and `AbstractJackson2MessageConverter` still reads `(assumeSupportedContentType && isDefault) || matches`. The parentheses came in with 9e06e026 (GH-3520), whose stated goal was only `contains()` -> `MimeType.isCompatibleWith()`.

A test is added to each converter test class; with the production line reverted both fail with `but was instance of: byte[]` and the other 42 pass. `:spring-amqp:test` (176), `:spring-rabbit:test` (1229, 663 skipped), checkstyle and javadoc pass on JDK 25.
