### PR TITLE
Leverage `Base64#getUrlEncoder#withoutPadding` for name generation

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/core/Base64UrlNamingStrategy.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/core/Base64UrlNamingStrategy.java
@@ -26,9 +26,10 @@ import org.springframework.util.Assert;
  * Generates names with the form {@code <prefix><base64url>} where 'prefix' is
  * 'spring.gen-' by default (e.g. spring.gen-eIwaZAYgQv6LvwaDCfVTNQ); the 'base64url'
  * String is generated from a UUID. The base64 alphabet is the "URL and Filename Safe
- * Alphabet"; see RFC-4648. Trailing padding characters (@code =) are removed.
+ * Alphabet"; see RFC-4648. Trailing padding characters ({@code =}) are removed.
  *
  * @author Gary Russell
+ * @author Ngoc Nhan
  *
  * @since 2.1
  */
@@ -55,19 +56,17 @@ public class Base64UrlNamingStrategy implements NamingStrategy {
 	 * @param prefix The prefix.
 	 */
 	public Base64UrlNamingStrategy(String prefix) {
-		Assert.notNull(prefix, "'prefix' cannot be null; use an empty String ");
+		Assert.notNull(prefix, "'prefix' cannot be null; use an empty String");
 		this.prefix = prefix;
 	}
 
 	@Override
 	public String generateName() {
 		UUID uuid = UUID.randomUUID();
-		ByteBuffer bb = ByteBuffer.wrap(new byte[SIXTEEN]);
-		bb.putLong(uuid.getMostSignificantBits())
-		  .putLong(uuid.getLeastSignificantBits());
-		// Convert to base64 and remove trailing =
-		return this.prefix + Base64.getUrlEncoder().encodeToString(bb.array())
-								.replaceAll("=", "");
+		ByteBuffer bb = ByteBuffer.wrap(new byte[SIXTEEN])
+				.putLong(uuid.getMostSignificantBits())
+				.putLong(uuid.getLeastSignificantBits());
+		return this.prefix + Base64.getUrlEncoder().withoutPadding().encodeToString(bb.array());
 	}
 
 }

--- a/spring-amqp/src/test/java/org/springframework/amqp/Base64UrlNamingStrategyTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/Base64UrlNamingStrategyTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import org.springframework.amqp.core.Base64UrlNamingStrategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * @author Ngoc Nhan
+ *
+ * @since 4.2
+ */
+public class Base64UrlNamingStrategyTests {
+
+	Base64UrlNamingStrategy strategy = new Base64UrlNamingStrategy();
+
+	@Test
+	void generateNameByDefault() {
+
+		String name = this.strategy.generateName();
+		assertThat(name).startsWith("spring.gen-");
+
+		String encoded = name.substring("spring.gen-".length());
+		assertThat(encoded).doesNotContain("=").hasSize(22);
+	}
+
+	@Test
+	void generateNameWithMockRandomUuid() {
+
+		UUID uuid = UUID.fromString("fcbfc9b4-d4d6-4cc0-b8b0-dfa245ffaea5");
+
+		try (MockedStatic<UUID> mockedStatic = mockStatic()) {
+
+			mockedStatic.when(UUID::randomUUID).thenReturn(uuid);
+			String name = this.strategy.generateName();
+			assertThat(name).isEqualTo("spring.gen-_L_JtNTWTMC4sN-iRf-upQ");
+
+			String encoded = name.substring("spring.gen-".length());
+			assertThat(encoded).doesNotContain("=").hasSize(22);
+
+			byte[] bytes = Base64.getUrlDecoder().decode(encoded);
+			ByteBuffer bb = ByteBuffer.wrap(bytes);
+			assertThat(new UUID(bb.getLong(), bb.getLong()).toString())
+					.isEqualTo("fcbfc9b4-d4d6-4cc0-b8b0-dfa245ffaea5");
+		}
+	}
+
+}

--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupport.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupport.java
@@ -61,6 +61,7 @@ import org.springframework.web.util.UriUtils;
  * @author Dave Syer
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Ngoc Nhan
  *
  * @since 2.2
  */
@@ -460,10 +461,10 @@ public final class BrokerRunningSupport {
 	 */
 	public String generateId() {
 		UUID uuid = UUID.randomUUID();
-		ByteBuffer bb = ByteBuffer.wrap(new byte[SIXTEEN]);
-		bb.putLong(uuid.getMostSignificantBits())
+		ByteBuffer bb = ByteBuffer.wrap(new byte[SIXTEEN])
+				.putLong(uuid.getMostSignificantBits())
 				.putLong(uuid.getLeastSignificantBits());
-		return "SpringBrokerRunning." + Base64.getUrlEncoder().encodeToString(bb.array()).replaceAll("=", "");
+		return "SpringBrokerRunning." + Base64.getUrlEncoder().withoutPadding().encodeToString(bb.array());
 	}
 
 	private boolean isDefaultQueue(String queue) {

--- a/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupportTests.java
+++ b/spring-rabbit-junit/src/test/java/org/springframework/amqp/rabbit/junit/BrokerRunningSupportTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.amqp.rabbit.junit;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * @author Ngoc Nhan
+ *
+ * @since 4.2
+ */
+public class BrokerRunningSupportTests {
+
+	BrokerRunningSupport support = BrokerRunningSupport.isNotRunning();
+
+	@Test
+	void generateIdByDefault() {
+
+		String name = this.support.generateId();
+		assertThat(name).startsWith("SpringBrokerRunning.");
+
+		String encoded = name.substring("SpringBrokerRunning.".length());
+		assertThat(encoded).doesNotContain("=").hasSize(22);
+	}
+
+	@Test
+	void generateIdWithMockRandomUuid() {
+
+		UUID uuid = UUID.fromString("fcbfc9b4-d4d6-4cc0-b8b0-dfa245ffaea5");
+
+		try (MockedStatic<UUID> mockedStatic = mockStatic()) {
+
+			mockedStatic.when(UUID::randomUUID).thenReturn(uuid);
+			String name = this.support.generateId();
+			assertThat(name).isEqualTo("SpringBrokerRunning._L_JtNTWTMC4sN-iRf-upQ");
+
+			String encoded = name.substring("SpringBrokerRunning.".length());
+			assertThat(encoded).doesNotContain("=").hasSize(22);
+
+			byte[] bytes = Base64.getUrlDecoder().decode(encoded);
+			ByteBuffer bb = ByteBuffer.wrap(bytes);
+			assertThat(new UUID(bb.getLong(), bb.getLong()).toString())
+					.isEqualTo("fcbfc9b4-d4d6-4cc0-b8b0-dfa245ffaea5");
+		}
+	}
+
+}


### PR DESCRIPTION
`Base64UrlNamingStrategy#generateName` and `BrokerRunningSupport#generateId` use `replaceAll("=", "")` to check for and remove padding characters from the encoded result. They should leverage `Base64#getUrlEncoder#withoutPadding` instead.

* Remove redundant whitespace in `Base64UrlNamingStrategy`
* Update the code tag in `Base64UrlNamingStrategy`