### PR TITLE
Use `supportedContentType` when `assumeSupportedContentType` is disabled

### DIFF
--- a/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJacksonMessageConverter.java
+++ b/spring-amqp/src/main/java/org/springframework/amqp/support/converter/AbstractJacksonMessageConverter.java
@@ -43,6 +43,7 @@ import org.springframework.util.MimeTypeUtils;
  * Abstract Jackson 3 message converter.
  *
  * @author Artem Bilan
+ * @author Ngoc Nhan
  *
  * @since 4.0
  */
@@ -275,9 +276,8 @@ public abstract class AbstractJacksonMessageConverter extends AbstractMessageCon
 		Object content = null;
 		MessageProperties properties = message.getMessageProperties();
 		String contentType = properties.getContentType();
-		if (this.assumeSupportedContentType &&
-				(contentType.equals(MessageProperties.DEFAULT_CONTENT_TYPE)
-						|| this.supportedContentType.isCompatibleWith(MimeType.valueOf(contentType)))) {
+		if (this.assumeSupportedContentType && contentType.equals(MessageProperties.DEFAULT_CONTENT_TYPE)
+				|| this.supportedContentType.isCompatibleWith(MimeType.valueOf(contentType))) {
 
 			String encoding = determineEncoding(properties, contentType);
 			content = doFromMessage(message, conversionHint, properties, encoding);

--- a/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonJsonMessageConverterTests.java
+++ b/spring-amqp/src/test/java/org/springframework/amqp/support/converter/JacksonJsonMessageConverterTests.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.JacksonException;
@@ -50,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Andreas Asplund
  * @author Artem Bilan
+ * @author Ngoc Nhan
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -464,6 +466,26 @@ public class JacksonJsonMessageConverterTests {
 		assertThat(converter.fromMessage(message2)).isEqualTo(trade);
 	}
 
+	@Test
+	public void convertMessageWhenContentTypeIsSupported() {
+
+		byte[] bytes = "{\"message\" : \"Hello, World\"}".getBytes();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("application/json");
+		Message message = new Message(bytes, messageProperties);
+
+		DefaultClassMapper classMapper = new DefaultClassMapper();
+		classMapper.setDefaultType(TestData.class);
+		JacksonJsonMessageConverter converter = new JacksonJsonMessageConverter();
+		converter.setAssumeSupportedContentType(false);
+		converter.setClassMapper(classMapper);
+
+		Object foo = converter.fromMessage(message);
+		assertThat(foo).isExactlyInstanceOf(TestData.class)
+				.extracting("message", InstanceOfAssertFactories.STRING)
+				.isEqualTo("Hello, World");
+	}
+
 	public List<Foo> fooLister() {
 		return null;
 	}
@@ -478,6 +500,10 @@ public class JacksonJsonMessageConverterTests {
 
 	public List<Fiz> fizLister() {
 		return null;
+	}
+
+	record TestData(String message) {
+
 	}
 
 	public static class Foo {


### PR DESCRIPTION
When `assumeSupportedContentType` is disabled, `contentType` should still be checked against `supportedContentType`. This commit fixes the check to use `supportedContentType` instead of skipping the check entirely.

Reference: https://docs.spring.io/spring-amqp/reference/amqp/message-converters.html#JacksonJsonMessageConverter-from-message

<!--
Thanks for contributing to Spring AMQP.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-amqp/blob/main/CONTRIBUTING.md).
-->
