### PR TITLE
GH-2480: Avoid ThreadLocal

### DIFF
--- a/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCondition.java
+++ b/spring-rabbit-junit/src/main/java/org/springframework/amqp/rabbit/junit/RabbitAvailableCondition.java
@@ -17,7 +17,9 @@
 package org.springframework.amqp.rabbit.junit;
 
 import java.lang.reflect.AnnotatedElement;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.rabbitmq.client.ConnectionFactory;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -50,7 +52,7 @@ public class RabbitAvailableCondition
 	private static final ConditionEvaluationResult ENABLED = ConditionEvaluationResult.enabled(
 			"@RabbitAvailable is not present");
 
-	private static final ThreadLocal<BrokerRunningSupport> BROKER_RUNNING_HOLDER = new ThreadLocal<>();
+	private static final Map<Thread, BrokerRunningSupport> BROKER_RUNNING_HOLDER = new ConcurrentHashMap<>();
 
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
@@ -73,7 +75,7 @@ public class RabbitAvailableCondition
 				}
 				brokerRunning.setPurgeAfterEach(rabbit.purgeAfterEach());
 				brokerRunning.test();
-				BROKER_RUNNING_HOLDER.set(brokerRunning);
+				BROKER_RUNNING_HOLDER.put(Thread.currentThread(), brokerRunning);
 				Store store = getStore(context);
 				store.put(BROKER_RUNNING_BEAN, brokerRunning);
 				store.put("queuesToDelete", queues);
@@ -91,7 +93,7 @@ public class RabbitAvailableCondition
 
 	@Override
 	public void afterEach(ExtensionContext context) {
-		BrokerRunningSupport brokerRunning = BROKER_RUNNING_HOLDER.get();
+		BrokerRunningSupport brokerRunning = BROKER_RUNNING_HOLDER.get(Thread.currentThread());
 		if (brokerRunning != null && brokerRunning.isPurgeAfterEach()) {
 			brokerRunning.purgeTestQueues();
 		}
@@ -99,7 +101,7 @@ public class RabbitAvailableCondition
 
 	@Override
 	public void afterAll(ExtensionContext context) {
-		BROKER_RUNNING_HOLDER.remove();
+		BROKER_RUNNING_HOLDER.remove(Thread.currentThread());
 		Store store = getStore(context);
 		BrokerRunningSupport brokerRunning = store.remove(BROKER_RUNNING_BEAN, BrokerRunningSupport.class);
 		if (brokerRunning != null) {
@@ -138,7 +140,9 @@ public class RabbitAvailableCondition
 	}
 
 	public static BrokerRunningSupport getBrokerRunning() {
-		return BROKER_RUNNING_HOLDER.get();
+		BrokerRunningSupport running = BROKER_RUNNING_HOLDER.get(Thread.currentThread());
+		Assert.state(running != null, "Could not find brokerRunning instance on current thread");
+		return running;
 	}
 
 }

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractExchangeParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/AbstractExchangeParser.java
@@ -17,6 +17,7 @@
 package org.springframework.amqp.rabbit.config;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Element;
@@ -40,7 +41,7 @@ import org.springframework.util.xml.DomUtils;
  */
 public abstract class AbstractExchangeParser extends AbstractSingleBeanDefinitionParser {
 
-	private static final ThreadLocal<@Nullable Element> CURRENT_ELEMENT = new ThreadLocal<>();
+	private static final Map<Thread, Element> CURRENT_ELEMENT = new ConcurrentHashMap<>();
 
 	private static final String ARGUMENTS_ELEMENT = "exchange-arguments";
 
@@ -69,13 +70,8 @@ public abstract class AbstractExchangeParser extends AbstractSingleBeanDefinitio
 
 	@Override
 	protected boolean shouldParseNameAsAliases() {
-		Element element = CURRENT_ELEMENT.get();
-		try {
-			return element == null || !element.hasAttribute(ID_ATTRIBUTE);
-		}
-		finally {
-			CURRENT_ELEMENT.remove();
-		}
+		Element element = CURRENT_ELEMENT.remove(Thread.currentThread());
+		return element == null || !element.hasAttribute(ID_ATTRIBUTE);
 	}
 
 	@Override
@@ -93,7 +89,7 @@ public abstract class AbstractExchangeParser extends AbstractSingleBeanDefinitio
 		parseArguments(element, ARGUMENTS_ELEMENT, parserContext, builder, null);
 
 		NamespaceUtils.parseDeclarationControls(element, builder);
-		CURRENT_ELEMENT.set(element);
+		CURRENT_ELEMENT.put(Thread.currentThread(), element);
 	}
 
 	protected void parseBindings(Element element, ParserContext parserContext, BeanDefinitionBuilder builder,

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/QueueParser.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/config/QueueParser.java
@@ -17,8 +17,8 @@
 package org.springframework.amqp.rabbit.config;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Element;
 
 import org.springframework.amqp.core.AnonymousQueue;
@@ -39,7 +39,7 @@ import org.springframework.util.xml.DomUtils;
  */
 public class QueueParser extends AbstractSingleBeanDefinitionParser {
 
-	private static final ThreadLocal<@Nullable Element> CURRENT_ELEMENT = new ThreadLocal<>();
+	private static final Map<Thread, Element> CURRENT_ELEMENT = new ConcurrentHashMap<>();
 
 	/**  Element OR attribute. */
 	private static final String ARGUMENTS = "queue-arguments";
@@ -61,13 +61,8 @@ public class QueueParser extends AbstractSingleBeanDefinitionParser {
 
 	@Override
 	protected boolean shouldParseNameAsAliases() {
-		Element element = CURRENT_ELEMENT.get();
-		try {
-			return element == null || !element.hasAttribute(ID_ATTRIBUTE);
-		}
-		finally {
-			CURRENT_ELEMENT.remove();
-		}
+		Element element = CURRENT_ELEMENT.remove(Thread.currentThread());
+		return element == null || !element.hasAttribute(ID_ATTRIBUTE);
 	}
 
 	@Override
@@ -117,7 +112,7 @@ public class QueueParser extends AbstractSingleBeanDefinitionParser {
 		parseArguments(element, parserContext, builder);
 
 		NamespaceUtils.parseDeclarationControls(element, builder);
-		CURRENT_ELEMENT.set(element);
+		CURRENT_ELEMENT.put(Thread.currentThread(), element);
 	}
 
 	private void parseArguments(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConnectionFactoryUtils.java
@@ -17,6 +17,8 @@
 package org.springframework.amqp.rabbit.connection;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 import com.rabbitmq.client.Channel;
@@ -48,7 +50,7 @@ public final class ConnectionFactoryUtils {
 			ClassUtils.isPresent("org.springframework.web.reactive.function.client.WebClient",
 					ConnectionFactoryUtils.class.getClassLoader());
 
-	private static final ThreadLocal<@Nullable AfterCompletionFailedException> COMPLETION_EXCEPTIONS = new ThreadLocal<>();
+	private static final Map<Thread, AfterCompletionFailedException> COMPLETION_EXCEPTIONS = new ConcurrentHashMap<>();
 
 	private static boolean captureAfterCompletionExceptions;
 
@@ -197,15 +199,15 @@ public final class ConnectionFactoryUtils {
 
 	private static void completionFailed(AfterCompletionFailedException ex) {
 		if (captureAfterCompletionExceptions) {
-			COMPLETION_EXCEPTIONS.set(ex);
+			COMPLETION_EXCEPTIONS.put(Thread.currentThread(), ex);
 		}
 	}
 
 	/**
 	 * Call this method to enable capturing {@link AfterCompletionFailedException}s
-	 * when using transaction synchronization. Exceptions are stored in a {@link ThreadLocal}
-	 * which must be cleared by calling {@link #checkAfterCompletion()} after the transaction
-	 * has completed.
+	 * when using transaction synchronization. Exceptions are stored in a map keyed by
+	 * thread which must be cleared by calling {@link #checkAfterCompletion()} after the
+	 * transaction has completed.
 	 * @param enable true to enable capture.
 	 */
 	public static void enableAfterCompletionFailureCapture(boolean enable) {
@@ -219,9 +221,8 @@ public final class ConnectionFactoryUtils {
 	 * @since 2.3.10
 	 */
 	public static void checkAfterCompletion() {
-		AfterCompletionFailedException ex = COMPLETION_EXCEPTIONS.get();
+		AfterCompletionFailedException ex = COMPLETION_EXCEPTIONS.remove(Thread.currentThread());
 		if (ex != null) {
-			COMPLETION_EXCEPTIONS.remove();
 			throw ex;
 		}
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConsumerChannelRegistry.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ConsumerChannelRegistry.java
@@ -16,6 +16,9 @@
 
 package org.springframework.amqp.rabbit.connection;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import com.rabbitmq.client.Channel;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -37,7 +40,7 @@ public final class ConsumerChannelRegistry {
 
 	private static final Log logger = LogFactory.getLog(ConsumerChannelRegistry.class); // NOSONAR - lower case
 
-	private static final ThreadLocal<@Nullable ChannelHolder> CONSUMER_CHANNEL = new ThreadLocal<>();
+	private static final Map<Thread, ChannelHolder> CONSUMER_CHANNEL = new ConcurrentHashMap<>();
 
 	private ConsumerChannelRegistry() {
 	}
@@ -58,7 +61,7 @@ public final class ConsumerChannelRegistry {
 			logger.debug("Registering consumer channel" + channel + " from factory " +
 					connectionFactory);
 		}
-		CONSUMER_CHANNEL.set(new ChannelHolder(channel, connectionFactory));
+		CONSUMER_CHANNEL.put(Thread.currentThread(), new ChannelHolder(channel, connectionFactory));
 	}
 
 	/**
@@ -66,10 +69,11 @@ public final class ConsumerChannelRegistry {
 	 * the channel when the consumer exits.
 	 */
 	public static void unRegisterConsumerChannel() {
+		Thread currentThread = Thread.currentThread();
 		if (logger.isDebugEnabled()) {
-			logger.debug("Unregistering consumer channel" + CONSUMER_CHANNEL.get());
+			logger.debug("Unregistering consumer channel" + CONSUMER_CHANNEL.get(currentThread));
 		}
-		CONSUMER_CHANNEL.remove();
+		CONSUMER_CHANNEL.remove(currentThread);
 	}
 
 	/**
@@ -79,7 +83,7 @@ public final class ConsumerChannelRegistry {
 	 * @return The channel.
 	 */
 	public static @Nullable Channel getConsumerChannel() {
-		ChannelHolder channelHolder = CONSUMER_CHANNEL.get();
+		ChannelHolder channelHolder = CONSUMER_CHANNEL.get(Thread.currentThread());
 		return channelHolder != null
 				? channelHolder.channel()
 				: null;
@@ -93,7 +97,7 @@ public final class ConsumerChannelRegistry {
 	 * @return The channel.
 	 */
 	public static @Nullable Channel getConsumerChannel(ConnectionFactory connectionFactory) {
-		ChannelHolder channelHolder = CONSUMER_CHANNEL.get();
+		ChannelHolder channelHolder = CONSUMER_CHANNEL.get(Thread.currentThread());
 		Channel channel = null;
 		if (channelHolder != null && channelHolder.connectionFactory().equals(connectionFactory)) {
 			channel = channelHolder.channel();

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/RabbitUtils.java
@@ -18,6 +18,8 @@ package org.springframework.amqp.rabbit.connection;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AlreadyClosedException;
@@ -82,7 +84,7 @@ public abstract class RabbitUtils {
 
 	private static final Log LOGGER = LogFactory.getLog(RabbitUtils.class);
 
-	private static final ThreadLocal<@Nullable Boolean> physicalCloseRequired = new ThreadLocal<>(); // NOSONAR - lower case
+	private static final Map<Thread, Boolean> physicalCloseRequired = new ConcurrentHashMap<>(); // NOSONAR - lower case
 
 	/**
 	 * Close the given RabbitMQ Connection and ignore any thrown exception. This is useful for typical
@@ -211,30 +213,30 @@ public abstract class RabbitUtils {
 	}
 
 	/**
-	 * Sets a ThreadLocal indicating the channel MUST be physically closed.
+	 * Sets a flag indicating the channel MUST be physically closed.
 	 * @param channel the channel.
 	 * @param b true if the channel must be closed (if it's a proxy).
 	 */
 	public static void setPhysicalCloseRequired(Channel channel, boolean b) {
 		if (channel instanceof ChannelProxy) {
-			physicalCloseRequired.set(b);
+			physicalCloseRequired.put(Thread.currentThread(), b);
 		}
 	}
 
 	/**
-	 * Gets and removes a ThreadLocal indicating the channel MUST be physically closed.
+	 * Gets a flag indicating the channel MUST be physically closed.
 	 * @return true if the channel must be physically closed
 	 */
 	public static boolean isPhysicalCloseRequired() {
-		Boolean mustClose = physicalCloseRequired.get();
-		return mustClose != null && mustClose;
+		Boolean mustClose = physicalCloseRequired.get(Thread.currentThread());
+		return Boolean.TRUE.equals(mustClose);
 	}
 
 	/**
 	 * Clear the physicalCloseRequired flag.
 	 */
 	public static void clearPhysicalCloseRequired() {
-		physicalCloseRequired.remove();
+		physicalCloseRequired.remove(Thread.currentThread());
 	}
 
 	/**

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/SimpleResourceHolder.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/SimpleResourceHolder.java
@@ -21,12 +21,12 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.core.NamedThreadLocal;
 import org.springframework.util.Assert;
 
 /**
@@ -57,11 +57,9 @@ public final class SimpleResourceHolder {
 
 	private static final Log LOGGER = LogFactory.getLog(SimpleResourceHolder.class);
 
-	private static final ThreadLocal<@Nullable Map<Object, Object>> RESOURCES =
-			new NamedThreadLocal<>("Simple resources");
+	private static final Map<Thread, Map<Object, Object>> RESOURCES = new ConcurrentHashMap<>();
 
-	private static final ThreadLocal<@Nullable Map<Object, Deque<@Nullable Object>>> STACK =
-			new NamedThreadLocal<>("Simple resources");
+	private static final Map<Thread, Map<Object, Deque<@Nullable Object>>> STACK = new ConcurrentHashMap<>();
 
 	/**
 	 * Return all resources that are bound to the current thread.
@@ -73,7 +71,7 @@ public final class SimpleResourceHolder {
 	 * @see #has
 	 */
 	public static Map<Object, Object> getResources() {
-		Map<Object, Object> map = RESOURCES.get();
+		Map<Object, Object> map = RESOURCES.get(Thread.currentThread());
 		return (map != null ? Collections.unmodifiableMap(map) : Collections.emptyMap());
 	}
 
@@ -108,7 +106,7 @@ public final class SimpleResourceHolder {
 	 * @return the resource object.
 	 */
 	private static @Nullable Object doGet(Object actualKey) {
-		Map<Object, Object> map = RESOURCES.get();
+		Map<Object, Object> map = RESOURCES.get(Thread.currentThread());
 		if (map == null) {
 			return null;
 		}
@@ -123,19 +121,15 @@ public final class SimpleResourceHolder {
 	 */
 	public static void bind(Object key, Object value) {
 		Assert.notNull(value, "Value must not be null");
-		Map<Object, Object> map = RESOURCES.get();
-		// set ThreadLocal Map if none found
-		if (map == null) {
-			map = new HashMap<>();
-			RESOURCES.set(map);
-		}
+		Thread currentThread = Thread.currentThread();
+		Map<Object, Object> map = RESOURCES.computeIfAbsent(currentThread, k -> new HashMap<>());
 		Object oldValue = map.put(key, value);
 		Assert.isNull(oldValue, () -> "Already value [" + oldValue + FOR_KEY + key + BOUND_TO_THREAD
-				+ Thread.currentThread().getName() + "]");
+				+ currentThread.getName() + "]");
 
 		if (LOGGER.isTraceEnabled()) {
 			LOGGER.trace(
-					"Bound value [" + value + FOR_KEY + key + "] to thread [" + Thread.currentThread().getName() + "]");
+					"Bound value [" + value + FOR_KEY + key + "] to thread [" + currentThread.getName() + "]");
 		}
 	}
 
@@ -151,13 +145,11 @@ public final class SimpleResourceHolder {
 			bind(key, value);
 		}
 		else {
-			Map<Object, Deque<@Nullable Object>> stack = STACK.get();
-			if (stack == null) {
-				stack = new HashMap<>();
-				STACK.set(stack);
-			}
-			stack.computeIfAbsent(key, k -> new LinkedList<>());
-			stack.get(key).push(currentValue);
+			Thread currentThread = Thread.currentThread();
+			Map<Object, Deque<@Nullable Object>> stack =
+					STACK.computeIfAbsent(currentThread, k -> new HashMap<>());
+			Deque<@Nullable Object> deque = stack.computeIfAbsent(key, k -> new LinkedList<>());
+			deque.push(currentValue);
 			unbind(key);
 			bind(key, value);
 		}
@@ -171,7 +163,8 @@ public final class SimpleResourceHolder {
 	 */
 	public static Object pop(Object key) {
 		Object popped = unbind(key);
-		Map<Object, Deque<@Nullable Object>> stack = STACK.get();
+		Thread currentThread = Thread.currentThread();
+		Map<Object, Deque<@Nullable Object>> stack = STACK.get(currentThread);
 		if (stack != null) {
 			Deque<@Nullable Object> deque = stack.get(key);
 			if (deque != null && !deque.isEmpty()) {
@@ -180,8 +173,11 @@ public final class SimpleResourceHolder {
 					bind(key, previousValue);
 				}
 				if (deque.isEmpty()) {
-					STACK.remove();
+					stack.remove(key);
 				}
+			}
+			if (stack.isEmpty()) {
+				STACK.remove(currentThread);
 			}
 		}
 		return popped;
@@ -206,19 +202,20 @@ public final class SimpleResourceHolder {
 	 * @return the previously bound value, or <code>null</code> if none bound
 	 */
 	public static @Nullable Object unbindIfPossible(Object key) {
-		Map<Object, Object> map = RESOURCES.get();
+		Thread currentThread = Thread.currentThread();
+		Map<Object, Object> map = RESOURCES.get(currentThread);
 		if (map == null) {
 			return null;
 		}
 		Object value = map.remove(key);
-		// Remove entire ThreadLocal if empty...
+		// Remove entire thread entry if empty...
 		if (map.isEmpty()) {
-			RESOURCES.remove();
+			RESOURCES.remove(currentThread);
 		}
 
 		if (value != null && LOGGER.isTraceEnabled()) {
 			LOGGER.trace("Removed value [" + value + FOR_KEY + key + "] from thread ["
-					+ Thread.currentThread().getName() + "]");
+					+ currentThread.getName() + "]");
 		}
 		return value;
 	}
@@ -227,8 +224,9 @@ public final class SimpleResourceHolder {
 	 * Clear resources for the current thread.
 	 */
 	public static void clear() {
-		RESOURCES.remove();
-		STACK.remove();
+		Thread currentThread = Thread.currentThread();
+		RESOURCES.remove(currentThread);
+		STACK.remove(currentThread);
 	}
 
 	private SimpleResourceHolder() {

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactory.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactory.java
@@ -284,9 +284,9 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory
 		/*
 		 * Intentionally not static.
 		 */
-		private final ThreadLocal<@Nullable Channel> channels = new ThreadLocal<>();
+		private final Map<Thread, Channel> channels = new ConcurrentHashMap<>();
 
-		private final ThreadLocal<@Nullable Channel> txChannels = new ThreadLocal<>();
+		private final Map<Thread, Channel> txChannels = new ConcurrentHashMap<>();
 
 		ConnectionWrapper(com.rabbitmq.client.Connection delegate, int closeTimeout) {
 			super(delegate, closeTimeout);
@@ -295,7 +295,9 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory
 		@SuppressWarnings("resource")
 		@Override
 		public Channel createChannel(boolean transactional) {
-			Channel channel = transactional ? this.txChannels.get() : this.channels.get();
+			Thread currentThread = Thread.currentThread();
+			Map<Thread, Channel> channelMap = transactional ? this.txChannels : this.channels;
+			Channel channel = channelMap.get(currentThread);
 			if (channel == null || !channel.isOpen()) {
 				channel = createProxy(super.createChannel(transactional), transactional);
 				if (transactional) {
@@ -305,7 +307,7 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory
 					catch (IOException e) {
 						throw RabbitExceptionTranslator.convertRabbitAccessException(e);
 					}
-					this.txChannels.set(channel);
+					this.txChannels.put(currentThread, channel);
 				}
 				else {
 					if (ThreadChannelConnectionFactory.this.simplePublisherConfirms) {
@@ -316,7 +318,7 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory
 							throw RabbitExceptionTranslator.convertRabbitAccessException(e);
 						}
 					}
-					this.channels.set(channel);
+					this.channels.put(currentThread, channel);
 				}
 				getChannelListener().onCreate(channel, transactional);
 			}
@@ -358,18 +360,15 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory
 		}
 
 		private void handleClose(Channel channel, boolean transactional) {
-			if ((transactional && this.txChannels.get() == null) || (!transactional && this.channels.get() == null)) {
+			Thread currentThread = Thread.currentThread();
+			Map<Thread, Channel> channelMap = transactional ? this.txChannels : this.channels;
+			if (channelMap.get(currentThread) == null) {
 				physicalClose(channel);
 			}
 			else {
 				if (RabbitUtils.isPhysicalCloseRequired()) {
 					physicalClose(channel);
-					if (transactional) {
-						this.txChannels.remove();
-					}
-					else {
-						this.channels.remove();
-					}
+					channelMap.remove(currentThread);
 				}
 			}
 		}
@@ -384,10 +383,9 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory
 			doClose(this.txChannels);
 		}
 
-		private void doClose(ThreadLocal<@Nullable Channel> channelsTL) {
-			Channel channel = channelsTL.get();
+		private void doClose(Map<Thread, Channel> channelMap) {
+			Channel channel = channelMap.remove(Thread.currentThread());
 			if (channel != null) {
-				channelsTL.remove();
 				physicalClose(channel);
 			}
 		}
@@ -412,9 +410,8 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory
 		}
 
 		Context prepareSwitchContext() {
-			Context context = new Context(this.channels.get(), this.txChannels.get());
-			this.channels.remove();
-			this.txChannels.remove();
+			Thread currentThread = Thread.currentThread();
+			Context context = new Context(this.channels.remove(currentThread), this.txChannels.remove(currentThread));
 			return context;
 		}
 
@@ -429,13 +426,14 @@ public class ThreadChannelConnectionFactory extends AbstractConnectionFactory
 			}
 		}
 
-		private void doSwitch(Channel channel, ThreadLocal<@Nullable Channel> channelTL) {
-			Channel toClose = channelTL.get();
+		private void doSwitch(Channel channel, Map<Thread, Channel> channelMap) {
+			Thread currentThread = Thread.currentThread();
+			Channel toClose = channelMap.get(currentThread);
 			if (toClose != null) {
 				RabbitUtils.setPhysicalCloseRequired(channel, true);
 				physicalClose(toClose);
 			}
-			channelTL.set(channel);
+			channelMap.put(currentThread, channel);
 		}
 
 	}

--- a/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
+++ b/spring-rabbit/src/main/java/org/springframework/amqp/rabbit/core/RabbitTemplate.java
@@ -188,9 +188,9 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
 	/*
-	 * Not static as normal since we want this TL to be scoped within the template instance.
+	 * Not static as normal since we want this map to be scoped within the template instance.
 	 */
-	private final ThreadLocal<@Nullable Channel> dedicatedChannels = new ThreadLocal<>();
+	private final Map<Thread, Channel> dedicatedChannels = new ConcurrentHashMap<>();
 
 	private final AtomicInteger activeTemplateCallbacks = new AtomicInteger();
 
@@ -2218,9 +2218,9 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 		Assert.notNull(action, "Callback object must not be null");
 		Channel channel = null;
 		boolean invokeScope = false;
-		// No need to check the thread local if we know that no invokes are in process
+		// No need to check the thread-bound map if we know that no invokes are in process
 		if (this.activeTemplateCallbacks.get() > 0) {
-			channel = this.dedicatedChannels.get();
+			channel = this.dedicatedChannels.get(Thread.currentThread());
 		}
 		RabbitResourceHolder resourceHolder = null;
 		Connection connection = null; // NOSONAR (close)
@@ -2295,7 +2295,8 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 	public <T extends @Nullable Object> T invoke(OperationsCallback<T> action,
 			com.rabbitmq.client.@Nullable ConfirmCallback acks, com.rabbitmq.client.@Nullable ConfirmCallback nacks) {
 
-		final Channel currentChannel = this.dedicatedChannels.get();
+		Thread currentThread = Thread.currentThread();
+		final Channel currentChannel = this.dedicatedChannels.get(currentThread);
 		Assert.state(currentChannel == null, () -> "Nested invoke() calls are not supported; channel '" + currentChannel
 				+ "' is already associated with this thread");
 		this.activeTemplateCallbacks.incrementAndGet();
@@ -2322,7 +2323,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 				if (!connectionFactory.isPublisherConfirms() && !connectionFactory.isSimplePublisherConfirms()) {
 					RabbitUtils.setPhysicalCloseRequired(channel, true);
 				}
-				this.dedicatedChannels.set(channel);
+				this.dedicatedChannels.put(currentThread, channel);
 			}
 			catch (RuntimeException e) {
 				RabbitUtils.closeConnection(connection);
@@ -2356,7 +2357,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 			channel.removeConfirmListener(listener);
 		}
 		this.activeTemplateCallbacks.decrementAndGet();
-		this.dedicatedChannels.remove();
+		this.dedicatedChannels.remove(Thread.currentThread());
 		if (resourceHolder != null) {
 			ConnectionFactoryUtils.releaseResources(resourceHolder);
 		}
@@ -2368,7 +2369,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 
 	@Override
 	public boolean waitForConfirms(long timeout) {
-		Channel channel = this.dedicatedChannels.get();
+		Channel channel = this.dedicatedChannels.get(Thread.currentThread());
 		Assert.state(channel != null, "This operation is only available within the scope of an invoke operation");
 		try {
 			return channel.waitForConfirms(timeout);
@@ -2384,7 +2385,7 @@ public class RabbitTemplate extends RabbitAccessor // NOSONAR type line count
 
 	@Override
 	public void waitForConfirmsOrDie(long timeout) {
-		Channel channel = this.dedicatedChannels.get();
+		Channel channel = this.dedicatedChannels.get(Thread.currentThread());
 		Assert.state(channel != null, "This operation is only available within the scope of an invoke operation");
 		try {
 			channel.waitForConfirmsOrDie(timeout);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/connection/ThreadChannelConnectionFactoryTests.java
@@ -77,7 +77,8 @@ public class ThreadChannelConnectionFactoryTests {
 		assertThat(chann2).isSameAs(chann1);
 		chann2.close();
 		conn.closeThreadChannel();
-		assertThat(TestUtils.<ThreadLocal<?>>getPropertyValue(conn, "channels").get()).isNull();
+		assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "channels").get(Thread.currentThread()))
+				.isNull();
 		chann2 = conn.createChannel(false);
 		assertThat(chann2).isNotSameAs(chann1);
 		chann2.close();
@@ -88,12 +89,16 @@ public class ThreadChannelConnectionFactoryTests {
 		chann2 = conn.createChannel(true);
 		assertThat(chann2).isSameAs(chann1);
 		chann2.close();
-		assertThat(TestUtils.<ThreadLocal<?>>getPropertyValue(conn, "channels").get()).isNotNull();
-		assertThat(TestUtils.<ThreadLocal<?>>getPropertyValue(conn, "txChannels").get()).isNotNull();
+		assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "channels").get(Thread.currentThread()))
+				.isNotNull();
+		assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "txChannels").get(Thread.currentThread()))
+				.isNotNull();
 		conn.closeThreadChannel();
-		assertThat(TestUtils.<ThreadLocal<?>>getPropertyValue(conn, "txChannels").get()).isNull();
+		assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "txChannels").get(Thread.currentThread()))
+				.isNull();
 		chann2 = conn.createChannel(true);
-		assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn, "txChannels").get().isOpen())
+		assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "txChannels").get(Thread.currentThread())
+				.isOpen())
 				.isTrue();
 		chann2.close();
 		chann2 = conn.createChannel(false);
@@ -105,9 +110,11 @@ public class ThreadChannelConnectionFactoryTests {
 		assertThat(((ChannelProxy) chann1).isConfirmSelected()).isTrue();
 		chann1.close();
 		tccf.destroy();
-		assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn, "channels").get().isOpen())
+		assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "channels").get(Thread.currentThread())
+				.isOpen())
 				.isFalse();
-		assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn, "txChannels").get().isOpen())
+		assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "txChannels").get(Thread.currentThread())
+				.isOpen())
 				.isFalse();
 	}
 
@@ -171,8 +178,10 @@ public class ThreadChannelConnectionFactoryTests {
 			tx.set(conn.createChannel(true));
 			Object ctx = tccf.prepareSwitchContext();
 			assertThat(tccf.prepareSwitchContext()).isNull();
-			assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn, "channels").get()).isNull();
-			assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn, "txChannels").get()).isNull();
+			assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "channels").get(Thread.currentThread()))
+					.isNull();
+			assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "txChannels").get(Thread.currentThread()))
+					.isNull();
 			context.add(ctx);
 		});
 		Object ctx = context.poll(10, TimeUnit.SECONDS);
@@ -207,8 +216,10 @@ public class ThreadChannelConnectionFactoryTests {
 			tx.set(conn.createChannel(true));
 			Object ctx = tccf.prepareSwitchContext();
 			assertThat(tccf.prepareSwitchContext()).isNull();
-			assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn, "channels").get()).isNull();
-			assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn, "txChannels").get()).isNull();
+			assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "channels").get(Thread.currentThread()))
+					.isNull();
+			assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn, "txChannels").get(Thread.currentThread()))
+					.isNull();
 			conn.createChannel(false);
 			context.add(ctx);
 			context.add(tccf.prepareSwitchContext());
@@ -253,10 +264,14 @@ public class ThreadChannelConnectionFactoryTests {
 			tx2.set(conn2.createChannel(true));
 			Object ctx = tccf.prepareSwitchContext();
 			assertThat(tccf.prepareSwitchContext()).isNull();
-			assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn1, "channels").get()).isNull();
-			assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn1, "txChannels").get()).isNull();
-			assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn2, "channels").get()).isNull();
-			assertThat(TestUtils.<ThreadLocal<Channel>>getPropertyValue(conn2, "txChannels").get()).isNull();
+			assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn1, "channels").get(Thread.currentThread()))
+					.isNull();
+			assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn1, "txChannels").get(Thread.currentThread()))
+					.isNull();
+			assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn2, "channels").get(Thread.currentThread()))
+					.isNull();
+			assertThat(TestUtils.<Map<Thread, Channel>>getPropertyValue(conn2, "txChannels").get(Thread.currentThread()))
+					.isNull();
 			context.add(ctx);
 		});
 		Object ctx = context.poll(10, TimeUnit.SECONDS);

--- a/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
+++ b/spring-rabbit/src/test/java/org/springframework/amqp/rabbit/core/RabbitTemplateIntegrationTests.java
@@ -1585,8 +1585,8 @@ public class RabbitTemplateIntegrationTests {
 			});
 			return null;
 		});
-		ThreadLocal<?> tl = TestUtils.getPropertyValue(this.template, "dedicatedChannels");
-		assertThat(tl.get()).isNull();
+		Map<?, ?> dc = TestUtils.getPropertyValue(this.template, "dedicatedChannels");
+		assertThat(dc.get(Thread.currentThread())).isNull();
 	}
 
 	@Test

--- a/src/reference/antora/modules/ROOT/pages/amqp/connections.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/connections.adoc
@@ -73,7 +73,7 @@ Use a `CachingConnectionFactory` for consumers, or configure a separate connecti
 [[threadchannelconnectionfactory]]
 === `ThreadChannelConnectionFactory`
 
-This factory manages a single connection and two `ThreadLocal` s, one for transactional channels, the other for non-transactional channels.
+This factory manages a single connection and two thread-bound channel caches, one for transactional channels, the other for non-transactional channels.
 This factory ensures that all operations on the same thread use the same channel (as long as it remains open).
 This facilitates strict message ordering without the need for xref:amqp/template.adoc#scoped-operations[Scoped Operations].
 To avoid memory leaks, if your application uses many short-lived threads, you must call the factory's `closeThreadChannel()` to release the channel resource.


### PR DESCRIPTION
### Description

This change examines and refactors the usage of `ThreadLocal` across the codebase.

In modern execution environments (such as thread pools and virtual threads), retaining state via `ThreadLocal` can lead to unintended resource retention or lifecycle complexities. While JDK Scoped Values represent the long-term solution for thread-scoped state, they require preview features beyond the current Java 17 baseline.

Following the precedent set in Spring for Apache Kafka (GH-2729), internal `ThreadLocal` variables have been transitioned to `ConcurrentHashMap` structures keyed by `Thread`. This strategy provides explicit, deterministic thread-bound state management and facilitates clean resource reclamation while maintaining existing public API contracts and runtime behavior.

### Key Areas of Change

- **Channel Caching & Resource Management**: Migrated thread-bound channels in connection factories and templates, as well as transaction and resource synchronization holders, to concurrent thread-keyed maps with lifecycle cleanup upon unbinding.
- **Parser & Testing Contexts**: Transitioned thread-scoped state in XML bean definition parsers and JUnit extension conditions to concurrent maps.
- **Documentation & Tests**: Aligned reference documentation terminology with the thread-bound cache model and adjusted internal test assertions accordingly.

Resolves #2480.